### PR TITLE
Update for v0.5.1

### DIFF
--- a/ga4gh/protocol.py
+++ b/ga4gh/protocol.py
@@ -110,10 +110,27 @@ class GAVariant(ProtocolElement):
         self.calls = []
 
 
+class GAVariantSetMetadata(ProtocolElement):
+
+    def __init__(self):
+        self.key = ""
+        self.value = ""
+        self.id = ""
+        self.type = ""
+        self.number = ""
+        self.description = ""
+        self.info = {}
+
+
 class GAVariantSet(ProtocolElement):
+    _embeddedTypes = {
+        "metadata": GAVariantSetMetadata
+    }
+
     def __init__(self):
         self.id = ""
         self.datasetId = ""
+        self.metadata = []
 
 
 class GASearchVariantSetsRequest(ProtocolElement):


### PR DESCRIPTION
This PR brings the Variants API up to date with the changes for v0.5.1 and passes the conformance tests in ga4gh/compliance#11. 

Changes:
- Set the `updated` and `created` times to the file creation time of the underlying dataset.
- Added `GAVariantSetMetadata` class, and populated using the wormtable column information.

The format of the metadata information (types and numbers, for example)  is not currently specified by the protocol, so I've just used the underlying wormtable values until this is fixed. Here, a number of "0" means variable and any positive integer n means a fixed number of n elements. Types are one of "int", "uint", "char" or "float".
