### PR TITLE
Fix GASearchVariantsRequest semantics

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -20,6 +20,7 @@ import ga4gh.protocol
 # Server
 ##############################################################################
 
+
 class ServerRunner(object):
     """
     Superclass of server runner; takes care of functionality common to
@@ -98,6 +99,7 @@ def server_main():
 # Client
 ##############################################################################
 
+
 class VariantSetSearchRunner(object):
     """
     Runner class for the variantsets/search method.
@@ -125,7 +127,11 @@ class VariantSearchRunner(object):
         svr.start = args.start
         svr.end = args.end
         svr.pageSize = args.pageSize
-        if args.callSetIds is not None:
+        if args.callSetIds == []:
+            svr.callSetIds = []
+        elif args.callSetIds == '*':
+            svr.callSetIds = None
+        else:
             svr.callSetIds = args.callSetIds.split(",")
         svr.variantSetIds = args.variantSetIds.split(",")
         self._request = svr
@@ -194,9 +200,12 @@ def addOptions(parser):
         "--variantName", "-n", default=None,
         help="Only return variants which have exactly this name.")
     parser.add_argument(
-        "--callSetIds", "-c", default=None,
-        help="""Only return variant calls which belong to call sets
-            with these IDs (comma seperated list).""")
+        "--callSetIds", "-c", default=[],
+        help="""Return variant calls which belong to call sets
+            with these IDs. Pass in IDs as a comma separated list (no spaces),
+            or '*' (with the single quotes!) to indicate 'all call sets'.
+            Omit this option to indicate 'no call sets'.
+            """)
     parser.add_argument(
         "--start", "-s", default=0, type=int,
         help="The start of the search range (inclusive).")

--- a/ga4gh/server.py
+++ b/ga4gh/server.py
@@ -288,7 +288,7 @@ class WormtableDataset(object):
         # First we get the set of columns for wormtable to retrieve. We don't
         # want to waste time reading in and decoding data for columns that
         # are not needed for the output when we specify callSetIds
-        if len(request.callSetIds) == 0:
+        if request.callSetIds is None:
             readCols = self._table.columns()
             # These must be in the correct order, so we cannot use the keys of
             # self._sampleCols

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -342,12 +342,7 @@ class TestVariants(TestWormtableBackend):
             # Verify we've got the correct csids.
             s1 = set(cs.callSetId for cs in variant.calls)
             self.assertEqual(len(s1), len(variant.calls))
-            # TODO remove this check once we've corrected the empty list
-            # semantics in the protocol
-            if len(callSetIds) != 0:
-                self.assertEqual(s1, set(callSetIds))
-            else:
-                self.assertEqual(s1, set(self.getCallSetIds(vsid)))
+            self.assertEqual(s1, set(callSetIds))
 
     def testSearchAllVariants(self):
         for vs in self.getVariantSets():


### PR DESCRIPTION
Updates the semantics of the GASearchVariantsRequest to follow the update in ga4gh/schemas#166 (Issue #32). Adds an option to the client to allow requesting no call sets. 
