### PR TITLE
Added Travis support for Python 2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libdb-dev
+
+install:
+  - "python setup.py install"
+
+script: nosetests


### PR DESCRIPTION
This PR adds a simple travis setup for the server. We only support Python 2.7 at the moment; hopefully when Python 3 support gets sorted out we can add in some more Pyhon versions here.

@cassiedoll - we need administrator access to the GA4GH group to enable travis for the server repo; could you turn this on please?
