### PR TITLE
Externalize configuration.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -183,6 +183,9 @@ Deployment
 *TODO* Give simple instructions for deploying the server on common platforms
 like Apache and Nginx.
 
+Configuration parameters are specified in the file ga4gh/server/config.py;
+they can be overridden by setting the absolute path of a file containing
+new values in the environment variable GA4GH_CONFIGURATION. 
 
 +++++++++++++
 Running tests

--- a/ga4gh/server/__init__.py
+++ b/ga4gh/server/__init__.py
@@ -1,11 +1,14 @@
 from flask.ext.api import FlaskAPI
 from flask.ext.cors import CORS
+import os
 
 app = FlaskAPI(__name__)
-CORS(app, allow_headers='Content-Type')
 
-# TODO: Replace hard-coded value with a flag or conifg setting.
-app.config['MAX_CONTENT_LENGTH'] = 2 * 1024 * 1024  # 2MB
+app.config.from_object('ga4gh.server.config:DefaultConfig')
+if os.environ.get('GA4GH_CONFIGURATION') is not None:
+    app.config.from_envvar('GA4GH_CONFIGURATION')
+
+CORS(app, allow_headers='Content-Type')
 
 import views
 

--- a/ga4gh/server/config.py
+++ b/ga4gh/server/config.py
@@ -1,0 +1,16 @@
+"""
+Sets of configuration values for a GA4GH server.
+Any of these values may be overridden by a file on the path
+given by the environment variable GA4GH_CONFIGURATION.
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+class DefaultConfig(object):
+    """
+    Simplest default server configuration.
+    """
+    MAX_CONTENT_LENGTH = 2 * 1024 * 1024  # 2MB


### PR DESCRIPTION
Read a set of configuration values out of a file (config.py).
Checks the environment variable GA4GH_CONFIGURATION for the name of the configuration object in that file to use; default is ga4gh.server.config:Config.

Addresses issue https://github.com/ga4gh/server/issues/61.

This initial version only provides the default configuration, but in prototyping profiling I've created subclasses of Config, set new values on them, used the environment variable to select between them, and verified that the correct config was selected.