### PR TITLE
Improve JSON serialization and equality testing.

### DIFF
--- a/ga4gh/backends.py
+++ b/ga4gh/backends.py
@@ -356,7 +356,7 @@ class Backend(object):
         any point using the nextPageToken attribute of the request object.
         """
         # TODO change this to fromJSONDict and validate
-        request = requestClass.fromJSON(requestStr)
+        request = requestClass.fromJSONString(requestStr)
         pageList = []
         nextPageToken = None
         for obj, nextPageToken in objectGenerator(request):
@@ -366,7 +366,7 @@ class Backend(object):
         response = responseClass()
         response.nextPageToken = nextPageToken
         setattr(response, pageListName, pageList)
-        return response.toJSON()
+        return response.toJSONString()
 
     def searchVariantSets(self, request):
         """

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -30,7 +30,7 @@ class HTTPClient(object):
         """
         notDone = True
         while notDone:
-            s = request.toJSON()
+            s = request.toJSONString()
             headers = {"Content-type": "application/json"}
             # make sure we correctly join with/out trailing slashes
             fullUrl = posixpath.join(self._urlPrefix, url)
@@ -46,7 +46,7 @@ class HTTPClient(object):
                 print("json response:")
                 pp = json.dumps(json.loads(s), sort_keys=True, indent=4)
                 print(pp)
-            resp = protocolClass.fromJSON(s)
+            resp = protocolClass.fromJSONString(s)
             # TODO handle HTTP errors from requests and display.
             for v in getattr(resp, listAttr):
                 yield v

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -118,8 +118,8 @@ class TestWormtableBackend(unittest.TestCase):
         request.pageSize = pageSize
         while notDone:
             # TODO validate the response there.
-            responseStr = searchMethod(request.toJSON())
-            response = ResponseClass.fromJSON(responseStr)
+            responseStr = searchMethod(request.toJSONString())
+            response = ResponseClass.fromJSONString(responseStr)
             objectList = getattr(response, listMember)
             self.assertLessEqual(len(objectList), pageSize)
             for obj in objectList:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -254,7 +254,7 @@ class EqualityTest(SchemaTest):
         for cls in self.getProtocolClasses():
             for f in factories:
                 i1 = f(cls)
-                i2 = cls.fromJSON(i1.toJSON())
+                i2 = cls.fromJSONDict(i1.toJSONDict())
                 self.verifyEqualityOperations(i1, i2)
 
     def testDifferentValues(self):
@@ -270,6 +270,12 @@ class EqualityTest(SchemaTest):
                 self.assertFalse(i1 == i2)
                 self.assertTrue(i1 != i2)
 
+    def testDifferentLengthArrays(self):
+        i1 = self.getTypicalInstance(protocol.GACallSet)
+        i2 = protocol.GACallSet.fromJSONDict(i1.toJSONDict())
+        i2.variantSetIds.append("extra")
+        self.assertFalse(i1 == i2)
+
 
 class SerialisationTest(SchemaTest):
     """
@@ -278,8 +284,12 @@ class SerialisationTest(SchemaTest):
     def validateClasses(self, factory):
         for cls in self.getProtocolClasses():
             instance = factory(cls)
-            jsonStr = instance.toJSON()
-            otherInstance = cls.fromJSON(jsonStr)
+            jsonStr = instance.toJSONString()
+            otherInstance = cls.fromJSONString(jsonStr)
+            self.assertEqual(instance, otherInstance)
+
+            jsonDict = instance.toJSONDict()
+            otherInstance = cls.fromJSONDict(jsonDict)
             self.assertEqual(instance, otherInstance)
 
     def testSerialiseDefaultValues(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,7 +58,7 @@ class TestFrontend(unittest.TestCase):
                                  headers={'Content-type': 'application/json'},
                                  data='{"variantSetIds": [1, 2]}')
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantsResponse.fromJSON(
+        responseData = protocol.GASearchVariantsResponse.fromJSONString(
             response.data)
         self.assertEqual(responseData.variants, [])
 
@@ -67,6 +67,6 @@ class TestFrontend(unittest.TestCase):
                                  headers={'Content-type': 'application/json'},
                                  data='{"dataSetIds": [1, 2]}')
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantSetsResponse.fromJSON(
+        responseData = protocol.GASearchVariantSetsResponse.fromJSONString(
             response.data)
         self.assertEqual(responseData.variantSets, [])


### PR DESCRIPTION
These changes should increase readability and performance. JSON serialization shouldn't have any semantic changes, though equality testing will now exit early. The early exit should yield much better performance when dealing with large and complicated classes. This patch also removes the deprecated toJSON method because we are pre-release and there really isn't a reason to have deprecated code hanging around.

I'm hoping that there might be some other suggestions as to how to improve clarity here. I spent some time trying to create a unified interface to serialization and deserialization, but I was unable to get anything that I thought was actually more clear. The level of duplication here is fairly minimal and so far I've chosen the 15 lines of slight duplication devil vs 30 lines of generic generator code.