### PR TITLE
Changed version number.

### DIFF
--- a/ga4gh/__init__.py
+++ b/ga4gh/__init__.py
@@ -2,4 +2,4 @@
 Reference implementation of the GA4GH APIs.
 """
 
-__version__ = '0.5.0'  # Follows API version?
+__version__ = '0.1.0a1'


### PR DESCRIPTION
The version number is currently set arbitrarily to 0.5.0. The idea originally was to follow the API version number that we were implementing. However, this is less important now that we have automated generations of schemas from a specific protocol version, and we can find out what version of the protocol we are implementing using `ga4gh.protocol.version`.

We should therefore choose a different version number. Since we are currently pre-alpha, 0.1.0a1 seems a good choice. Any thoughts?