### PR TITLE
Added testing config and moved default config file

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -16,7 +16,7 @@ app = api.FlaskAPI(__name__)
 
 
 def configure(config):
-    configStr = 'ga4gh.server.config:{0}'.format(config)
+    configStr = 'ga4gh.serverconfig:{0}'.format(config)
     app.config.from_object(configStr)
     if os.environ.get('GA4GH_CONFIGURATION') is not None:
         app.config.from_envvar('GA4GH_CONFIGURATION')

--- a/ga4gh/server/__init__.py
+++ b/ga4gh/server/__init__.py
@@ -1,3 +1,0 @@
-"""
-Server package.
-"""

--- a/ga4gh/serverconfig.py
+++ b/ga4gh/serverconfig.py
@@ -14,3 +14,10 @@ class DefaultConfig(object):
     Simplest default server configuration.
     """
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024  # 2MB
+
+
+class TestConfig(DefaultConfig):
+    """
+    Configuration used in frontend unit tests.
+    """
+    TESTING = True

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,7 +15,7 @@ import ga4gh.protocol as protocol
 class TestFrontend(unittest.TestCase):
 
     def setUp(self):
-        frontend.app.config['TESTING'] = True
+        frontend.configure("TestConfig")
         frontend.app.backend = backend.MockBackend()
         self.app = frontend.app.test_client()
 


### PR DESCRIPTION
This PR moves the `ga4gh.server.config.py` file to `ga4gh.serverconfig.py`, completing the removal of the `server` package. Also adds a stub `TestConfig` class used to set up flask frontend tests.

This fixes the current build breakage in Travis, and should be small and uncontroversial, so it would be good to vote and merge this as soon as possible.