### PR TITLE
Heap profiling inside server_benchmark

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -57,6 +57,7 @@ class Backend(object):
         (object, nextPageToken) pairs, and be able to resume iteration from
         any point using the nextPageToken attribute of the request object.
         """
+        self.startProfile()
         # TODO change this to fromJSONDict and validate
         request = requestClass.fromJSONString(requestStr)
         pageList = []
@@ -68,6 +69,7 @@ class Backend(object):
         response = responseClass()
         response.nextPageToken = nextPageToken
         setattr(response, pageListName, pageList)
+        self.endProfile()
         return response.toJSONString()
 
     def searchVariantSets(self, request):
@@ -132,6 +134,12 @@ class Backend(object):
                     nextPageToken = "{0}:{1}".format(
                         variantSetIndex, variant.start + 1)
                     yield variant, nextPageToken
+
+    def startProfile(self):
+        pass
+
+    def endProfile(self):
+        pass
 
 
 class MockBackend(Backend):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-API
 Flask-Cors
 avro
 coverage
+guppy
 mock
 nose
 pep8


### PR DESCRIPTION
If "--profile heap" is passed to server_benchmark.py, prints out
a heap snapshot inside Backend.runSearchRequest(), which currently
has high peak memory allocation.

Adds a dependency on guppy (currently 0.1.10).

Addresses https://github.com/ga4gh/server/issues/46.