### PR TITLE
Adds html info page served at /

### DIFF
--- a/ga4gh/frontend_exceptions.py
+++ b/ga4gh/frontend_exceptions.py
@@ -6,6 +6,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import flask.ext.api as api
+
 
 class FrontendException(Exception):
 
@@ -74,3 +76,20 @@ class ServerException(FrontendException):
         self.httpStatus = 500
         self.message = "Internal server error"
         self.code = 7
+
+
+class UnsupportedMediaTypeException(FrontendException):
+
+    def __init__(self):
+        super(FrontendException, self).__init__()
+        self.httpStatus = 415
+        self.message = "Unsupported media type"
+        self.code = 8
+
+
+# exceptions thrown by the underlying system that we want to
+# translate to exceptions that we define before they are
+# serialized and returned to the client
+exceptionMap = {
+    api.exceptions.UnsupportedMediaType: UnsupportedMediaTypeException,
+}

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -1,0 +1,25 @@
+<html>
+    <head>
+        <title>GA4GH reference server {{ info.version }}</title>
+    </head>
+    <body>
+        <h2>GA4GH reference server {{ info.version }}</h2>
+        <div>
+            <h3>Operations available</h3>
+            <table>
+                <th>Method</th>
+                <th>Path</th>
+            {% for rule in info.urls %}
+            <tr>
+                <td>{{ rule[1] }}</td>
+                <td>{{ rule[0] }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+        </div>
+        <div>
+            <h3>Uptime</h3>
+            Running since {{ info.uptime.natural }} ({{ info.uptime.datetime }})
+        </div>
+    </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ avro
 coverage
 flake8
 guppy
+humanize
 mock
 nose
 pep8

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,51 @@ from __future__ import unicode_literals
 import unittest
 import inspect
 
+import mock
+
 import ga4gh.frontend_exceptions as frontendExceptions
+import ga4gh.frontend as frontend
+
+
+class TestExceptionHandler(unittest.TestCase):
+    """
+    Test that caught exceptions are handled correctly
+    """
+    class UnknownException(Exception):
+        pass
+
+    class DummyFlask(object):
+
+        def __call__(self, *args):
+            return TestExceptionHandler.DummyResponse()
+
+    class DummyResponse(object):
+        pass
+
+    def run(self, *args, **kwargs):
+        # patching is required because flask.jsonify throws an exception
+        # if not being called in a running app context
+        dummyFlask = self.DummyFlask()
+        with mock.patch('flask.jsonify', dummyFlask):
+            super(TestExceptionHandler, self).run(*args, **kwargs)
+
+    def testMappedException(self):
+        for originalExceptionClass, mappedExceptionClass in \
+                frontendExceptions.exceptionMap.items():
+            originalException = originalExceptionClass()
+            mappedException = mappedExceptionClass()
+            response = frontend.handleException(originalException)
+            self.assertEquals(response.status_code, mappedException.httpStatus)
+
+    def testFrontendException(self):
+        exception = frontendExceptions.ObjectNotFoundException()
+        response = frontend.handleException(exception)
+        self.assertEquals(response.status_code, 404)
+
+    def testUnknownExceptionBecomesServerError(self):
+        exception = self.UnknownException()
+        response = frontend.handleException(exception)
+        self.assertEquals(response.status_code, 500)
 
 
 class TestFrontendExceptionConsistency(unittest.TestCase):
@@ -18,24 +62,33 @@ class TestFrontendExceptionConsistency(unittest.TestCase):
     - every frontend exception has a non-None error code
         - except FrontendException, which does
     - every frontend exception has a unique error code
+    - every value in exceptionMap
+        - is able to instantiate a new no-argument exception instance
+        - derives from the base frontend exception type
     """
 
     def _getFrontendExceptionClasses(self):
 
-        def isClassAndExceptionSubclass(clazz):
-            return inspect.isclass(clazz) and issubclass(clazz, Exception)
+        def isClassAndExceptionSubclass(class_):
+            return inspect.isclass(class_) and issubclass(class_, Exception)
 
         classes = inspect.getmembers(
             frontendExceptions, isClassAndExceptionSubclass)
-        return [clazz for _, clazz in classes]
+        return [class_ for _, class_ in classes]
 
     def testCodeInvariants(self):
         codes = set()
-        for clazz in self._getFrontendExceptionClasses():
-            instance = clazz()
-            assert instance.code not in codes
+        for class_ in self._getFrontendExceptionClasses():
+            instance = class_()
+            self.assertTrue(instance.code not in codes)
             codes.add(instance.code)
-            if clazz == frontendExceptions.FrontendException:
-                assert instance.code is None
+            if class_ == frontendExceptions.FrontendException:
+                self.assertIsNone(instance.code)
             else:
-                assert instance.code is not None
+                self.assertIsNotNone(instance.code)
+
+    def testExceptionMap(self):
+        for exceptionClass in frontendExceptions.exceptionMap.values():
+            exception = exceptionClass()
+            self.assertIsInstance(
+                exception, frontendExceptions.FrontendException)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,7 +30,7 @@ class TestFrontend(unittest.TestCase):
                              data=data)
 
     def testServer(self):
-        self.assertEqual(404, self.app.get('/').status_code)
+        self.assertEqual(404, self.app.get('/doesNotExist').status_code)
 
     def testCors(self):
         def assertHeaders(response):


### PR DESCRIPTION
Displays the following info:
```
GA4GH reference server 0.5.1

Operations available

Method	Path
POST	/callsets/search
POST	/readgroupsets/search
POST	/reads/search
GET	/references/<id>
GET	/references/<id>/bases
POST	/references/search
GET	/referencesets/<id>
POST	/referencesets/search
POST	/variants/search
POST	/variantsets/search

Uptime

Running since 18 minutes ago (03:04:56 03 Feb 2015)
```

Issue #111