### PR TITLE
Use __slots__ for ProtocolElements

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -37,7 +37,9 @@ null, "doc": "", "type": ["null", "string"], "name": "allele"}]}
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['allele', 'chromosome', 'coordinate', 'populationId', 'referenceVersion']
+    __slots__ = ['allele', 'chromosome', 'coordinate', 'populationId',
+                 'referenceVersion']
+
     def __init__(self):
         self.allele = None
         self.chromosome = None
@@ -70,6 +72,7 @@ No documentation
         return embeddedTypes[fieldName]
 
     __slots__ = ['exists', 'frequency']
+
     def __init__(self):
         self.exists = None
         self.frequency = None
@@ -106,7 +109,9 @@ null, "doc": "", "type": ["null", "string"], "name": "callSetName"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['callSetId', 'callSetName', 'genotype', 'genotypeLikelihood', 'info', 'phaseset']
+    __slots__ = ['callSetId', 'callSetName', 'genotype', 'genotypeLikelihood',
+                 'info', 'phaseset']
+
     def __init__(self):
         self.callSetId = None
         self.callSetName = None
@@ -149,7 +154,9 @@ null, "doc": "", "type": ["null", "string"], "name": "name"}, {"doc":
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['created', 'id', 'info', 'name', 'sampleId', 'updated', 'variantSetIds']
+    __slots__ = ['created', 'id', 'info', 'name', 'sampleId', 'updated',
+                 'variantSetIds']
+
     def __init__(self):
         self.created = None
         self.id = None
@@ -243,6 +250,7 @@ A structure for an instance of a CIGAR operation.
         return embeddedTypes[fieldName]
 
     __slots__ = ['operation', 'operationLength', 'referenceSequence']
+
     def __init__(self):
         self.operation = None
         self.operationLength = None
@@ -272,6 +280,7 @@ No documentation
         return embeddedTypes[fieldName]
 
     __slots__ = ['description', 'id']
+
     def __init__(self):
         self.description = None
         self.id = None
@@ -300,6 +309,7 @@ A general exception type.
         return embeddedTypes[fieldName]
 
     __slots__ = ['errorCode', 'message']
+
     def __init__(self):
         self.errorCode = -1
         self.message = None
@@ -333,7 +343,9 @@ No documentation
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['instrumentModel', 'libraryId', 'platformUnit', 'sequencingCenter']
+    __slots__ = ['instrumentModel', 'libraryId', 'platformUnit',
+                 'sequencingCenter']
+
     def __init__(self):
         self.instrumentModel = None
         self.libraryId = None
@@ -381,6 +393,7 @@ A linear alignment can be represented by one CIGAR string.
         return embeddedTypes[fieldName]
 
     __slots__ = ['cigar', 'mappingQuality', 'position']
+
     def __init__(self):
         self.cigar = []
         self.mappingQuality = None
@@ -415,6 +428,7 @@ example:
         return embeddedTypes[fieldName]
 
     __slots__ = ['end', 'pageToken', 'start']
+
     def __init__(self):
         self.end = None
         self.pageToken = None
@@ -446,6 +460,7 @@ The response from `GET /references/{id}/bases` expressed as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'offset', 'sequence']
+
     def __init__(self):
         self.nextPageToken = None
         self.offset = 0
@@ -483,6 +498,7 @@ forward or reverse strand that we're talking about.
         return embeddedTypes[fieldName]
 
     __slots__ = ['position', 'referenceName', 'reverseStrand']
+
     def __init__(self):
         self.position = None
         self.referenceName = None
@@ -516,6 +532,7 @@ No documentation
         return embeddedTypes[fieldName]
 
     __slots__ = ['commandLine', 'id', 'name', 'prevProgramId', 'version']
+
     def __init__(self):
         self.commandLine = None
         self.id = None
@@ -589,7 +606,15 @@ null, "doc": "", "type": ["null", "string"], "name": "alignedSequence"},
         }
         return embeddedTypes[fieldName]
 
-    __slots__ = ['alignedQuality', 'alignedSequence', 'alignment', 'duplicateFragment', 'failedVendorQualityChecks', 'fragmentLength', 'fragmentName', 'id', 'info', 'nextMatePosition', 'numberReads', 'properPlacement', 'readGroupId', 'readNumber', 'secondaryAlignment', 'supplementaryAlignment']
+    __slots__ = ['alignedQuality', 'alignedSequence', 'alignment',
+                 'duplicateFragment',
+                 'failedVendorQualityChecks',
+                 'fragmentLength', 'fragmentName', 'id',
+                 'info', 'nextMatePosition', 'numberReads',
+                 'properPlacement', 'readGroupId',
+                 'readNumber', 'secondaryAlignment',
+                 'supplementaryAlignment']
+
     def __init__(self):
         self.alignedQuality = []
         self.alignedSequence = None
@@ -664,7 +689,11 @@ null, "doc": "", "type": ["null", "string"], "name": "prevProgramId"},
         }
         return embeddedTypes[fieldName]
 
-    __slots__ = ['created', 'datasetId', 'description', 'experiment', 'id', 'info', 'name', 'predictedInsertSize', 'programs', 'referenceSetId', 'sampleId', 'updated']
+    __slots__ = ['created', 'datasetId', 'description', 'experiment', 'id',
+                 'info', 'name', 'predictedInsertSize',
+                 'programs', 'referenceSetId', 'sampleId',
+                 'updated']
+
     def __init__(self):
         self.created = None
         self.datasetId = None
@@ -734,6 +763,7 @@ null, "doc": "", "type": ["null", "string"], "name": "referenceSetId"},
         return embeddedTypes[fieldName]
 
     __slots__ = ['datasetId', 'id', 'name', 'readGroups']
+
     def __init__(self):
         self.datasetId = None
         self.id = None
@@ -778,7 +808,10 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['id', 'isDerived', 'length', 'md5checksum', 'name', 'ncbiTaxonId', 'sourceAccessions', 'sourceDivergence', 'sourceURI']
+    __slots__ = ['id', 'isDerived', 'length', 'md5checksum', 'name',
+                 'ncbiTaxonId', 'sourceAccessions',
+                 'sourceDivergence', 'sourceURI']
+
     def __init__(self):
         self.id = None
         self.isDerived = False
@@ -827,7 +860,10 @@ false, "doc": "", "type": "boolean", "name": "isDerived"}], "doc": ""}
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['assemblyId', 'description', 'id', 'isDerived', 'md5checksum', 'ncbiTaxonId', 'referenceIds', 'sourceAccessions', 'sourceURI']
+    __slots__ = ['assemblyId', 'description', 'id', 'isDerived', 'md5checksum',
+                 'ncbiTaxonId', 'referenceIds',
+                 'sourceAccessions', 'sourceURI']
+
     def __init__(self):
         self.assemblyId = None
         self.description = None
@@ -867,6 +903,7 @@ This request maps to the body of `POST /callsets/search` as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['name', 'pageSize', 'pageToken', 'variantSetIds']
+
     def __init__(self):
         self.name = None
         self.pageSize = None
@@ -911,6 +948,7 @@ This is the response from `POST /callsets/search` expressed as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['callSets', 'nextPageToken']
+
     def __init__(self):
         self.callSets = []
         self.nextPageToken = None
@@ -943,6 +981,7 @@ This request maps to the body of `POST /readgroupsets/search` as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['datasetIds', 'name', 'pageSize', 'pageToken']
+
     def __init__(self):
         self.datasetIds = []
         self.name = None
@@ -1008,6 +1047,7 @@ null, "doc": "", "type": ["null", "string"], "name": "prevProgramId"},
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'readGroupSets']
+
     def __init__(self):
         self.nextPageToken = None
         self.readGroupSets = []
@@ -1046,7 +1086,9 @@ null, "doc": "", "type": ["null", "string"], "name": "referenceName"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['end', 'pageSize', 'pageToken', 'readGroupIds', 'referenceId', 'referenceName', 'start']
+    __slots__ = ['end', 'pageSize', 'pageToken', 'readGroupIds', 'referenceId',
+                 'referenceName', 'start']
+
     def __init__(self):
         self.end = None
         self.pageSize = None
@@ -1119,6 +1161,7 @@ null, "doc": "", "type": ["null", "string"], "name": "nextPageToken"}],
         return embeddedTypes[fieldName]
 
     __slots__ = ['alignments', 'nextPageToken']
+
     def __init__(self):
         self.alignments = []
         self.nextPageToken = None
@@ -1152,7 +1195,9 @@ as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['accessions', 'assemblyId', 'md5checksums', 'pageSize', 'pageToken']
+    __slots__ = ['accessions', 'assemblyId', 'md5checksums', 'pageSize',
+                 'pageToken']
+
     def __init__(self):
         self.accessions = []
         self.assemblyId = None
@@ -1201,6 +1246,7 @@ expressed as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'referenceSets']
+
     def __init__(self):
         self.nextPageToken = None
         self.referenceSets = []
@@ -1234,6 +1280,7 @@ as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['accessions', 'md5checksums', 'pageSize', 'pageToken']
+
     def __init__(self):
         self.accessions = []
         self.md5checksums = []
@@ -1279,6 +1326,7 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'references']
+
     def __init__(self):
         self.nextPageToken = None
         self.references = []
@@ -1310,6 +1358,7 @@ This request maps to the body of `POST /variantsets/search` as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['datasetIds', 'pageSize', 'pageToken']
+
     def __init__(self):
         self.datasetIds = []
         self.pageSize = None
@@ -1355,6 +1404,7 @@ This is the response from `POST /variantsets/search` expressed as JSON.
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'variantSets']
+
     def __init__(self):
         self.nextPageToken = None
         self.variantSets = []
@@ -1393,7 +1443,9 @@ This request maps to the body of `POST /variants/search` as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
-    __slots__ = ['callSetIds', 'end', 'pageSize', 'pageToken', 'referenceName', 'start', 'variantName', 'variantSetIds']
+    __slots__ = ['callSetIds', 'end', 'pageSize', 'pageToken', 'referenceName',
+                 'start', 'variantName', 'variantSetIds']
+
     def __init__(self):
         self.callSetIds = []
         self.end = None
@@ -1455,6 +1507,7 @@ null, "doc": "", "type": ["null", "long"], "name": "updated"}, {"doc":
         return embeddedTypes[fieldName]
 
     __slots__ = ['nextPageToken', 'variants']
+
     def __init__(self):
         self.nextPageToken = None
         self.variants = []
@@ -1516,7 +1569,10 @@ This is equivalent to a row in VCF.
         }
         return embeddedTypes[fieldName]
 
-    __slots__ = ['alternateBases', 'calls', 'created', 'end', 'id', 'info', 'names', 'referenceBases', 'referenceName', 'start', 'updated', 'variantSetId']
+    __slots__ = ['alternateBases', 'calls', 'created', 'end', 'id', 'info',
+                 'names', 'referenceBases', 'referenceName',
+                 'start', 'updated', 'variantSetId']
+
     def __init__(self):
         self.alternateBases = []
         self.calls = []
@@ -1572,6 +1628,7 @@ The variant set is equivalent to a VCF file.
         return embeddedTypes[fieldName]
 
     __slots__ = ['datasetId', 'id', 'metadata']
+
     def __init__(self):
         self.datasetId = None
         self.id = None
@@ -1613,6 +1670,7 @@ This metadata represents VCF header information.
         return embeddedTypes[fieldName]
 
     __slots__ = ['description', 'id', 'info', 'key', 'number', 'type', 'value']
+
     def __init__(self):
         self.description = None
         self.id = None
@@ -1623,24 +1681,24 @@ This metadata represents VCF header information.
         self.value = None
 
 postMethods = \
-    [('/callsets/search',
-      GASearchCallSetsRequest,
-      GASearchCallSetsResponse),
-     ('/readgroupsets/search',
+    [('/readgroupsets/search',
       GASearchReadGroupSetsRequest,
-      GASearchReadGroupSetsResponse),
-     ('/reads/search',
-      GASearchReadsRequest,
+      GASearchVariantSetsResponse),
+     ('/variantsets/search',
+      GASearchVariantSetsRequest,
       GASearchReadsResponse),
      ('/referencesets/search',
       GASearchReferenceSetsRequest,
+      GASearchVariantsResponse),
+     ('/variants/search',
+      GASearchVariantsRequest,
+      GASearchCallSetsResponse),
+     ('/reads/search',
+      GASearchReadsRequest,
       GASearchReferenceSetsResponse),
      ('/references/search',
       GASearchReferencesRequest,
       GASearchReferencesResponse),
-     ('/variantsets/search',
-      GASearchVariantSetsRequest,
-      GASearchVariantSetsResponse),
-     ('/variants/search',
-      GASearchVariantsRequest,
-      GASearchVariantsResponse)]
+     ('/callsets/search',
+      GASearchCallSetsRequest,
+      GASearchReadGroupSetsResponse)]

--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -37,6 +37,7 @@ null, "doc": "", "type": ["null", "string"], "name": "allele"}]}
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['allele', 'chromosome', 'coordinate', 'populationId', 'referenceVersion']
     def __init__(self):
         self.allele = None
         self.chromosome = None
@@ -68,6 +69,7 @@ No documentation
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['exists', 'frequency']
     def __init__(self):
         self.exists = None
         self.frequency = None
@@ -104,6 +106,7 @@ null, "doc": "", "type": ["null", "string"], "name": "callSetName"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['callSetId', 'callSetName', 'genotype', 'genotypeLikelihood', 'info', 'phaseset']
     def __init__(self):
         self.callSetId = None
         self.callSetName = None
@@ -146,6 +149,7 @@ null, "doc": "", "type": ["null", "string"], "name": "name"}, {"doc":
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['created', 'id', 'info', 'name', 'sampleId', 'updated', 'variantSetIds']
     def __init__(self):
         self.created = None
         self.id = None
@@ -238,6 +242,7 @@ A structure for an instance of a CIGAR operation.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['operation', 'operationLength', 'referenceSequence']
     def __init__(self):
         self.operation = None
         self.operationLength = None
@@ -266,6 +271,7 @@ No documentation
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['description', 'id']
     def __init__(self):
         self.description = None
         self.id = None
@@ -293,6 +299,7 @@ A general exception type.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['errorCode', 'message']
     def __init__(self):
         self.errorCode = -1
         self.message = None
@@ -326,6 +333,7 @@ No documentation
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['instrumentModel', 'libraryId', 'platformUnit', 'sequencingCenter']
     def __init__(self):
         self.instrumentModel = None
         self.libraryId = None
@@ -372,6 +380,7 @@ A linear alignment can be represented by one CIGAR string.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['cigar', 'mappingQuality', 'position']
     def __init__(self):
         self.cigar = []
         self.mappingQuality = None
@@ -405,6 +414,7 @@ example:
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['end', 'pageToken', 'start']
     def __init__(self):
         self.end = None
         self.pageToken = None
@@ -435,6 +445,7 @@ The response from `GET /references/{id}/bases` expressed as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'offset', 'sequence']
     def __init__(self):
         self.nextPageToken = None
         self.offset = 0
@@ -471,6 +482,7 @@ forward or reverse strand that we're talking about.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['position', 'referenceName', 'reverseStrand']
     def __init__(self):
         self.position = None
         self.referenceName = None
@@ -503,6 +515,7 @@ No documentation
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['commandLine', 'id', 'name', 'prevProgramId', 'version']
     def __init__(self):
         self.commandLine = None
         self.id = None
@@ -576,6 +589,7 @@ null, "doc": "", "type": ["null", "string"], "name": "alignedSequence"},
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['alignedQuality', 'alignedSequence', 'alignment', 'duplicateFragment', 'failedVendorQualityChecks', 'fragmentLength', 'fragmentName', 'id', 'info', 'nextMatePosition', 'numberReads', 'properPlacement', 'readGroupId', 'readNumber', 'secondaryAlignment', 'supplementaryAlignment']
     def __init__(self):
         self.alignedQuality = []
         self.alignedSequence = None
@@ -650,6 +664,7 @@ null, "doc": "", "type": ["null", "string"], "name": "prevProgramId"},
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['created', 'datasetId', 'description', 'experiment', 'id', 'info', 'name', 'predictedInsertSize', 'programs', 'referenceSetId', 'sampleId', 'updated']
     def __init__(self):
         self.created = None
         self.datasetId = None
@@ -718,6 +733,7 @@ null, "doc": "", "type": ["null", "string"], "name": "referenceSetId"},
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['datasetId', 'id', 'name', 'readGroups']
     def __init__(self):
         self.datasetId = None
         self.id = None
@@ -762,6 +778,7 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['id', 'isDerived', 'length', 'md5checksum', 'name', 'ncbiTaxonId', 'sourceAccessions', 'sourceDivergence', 'sourceURI']
     def __init__(self):
         self.id = None
         self.isDerived = False
@@ -810,6 +827,7 @@ false, "doc": "", "type": "boolean", "name": "isDerived"}], "doc": ""}
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['assemblyId', 'description', 'id', 'isDerived', 'md5checksum', 'ncbiTaxonId', 'referenceIds', 'sourceAccessions', 'sourceURI']
     def __init__(self):
         self.assemblyId = None
         self.description = None
@@ -848,6 +866,7 @@ This request maps to the body of `POST /callsets/search` as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['name', 'pageSize', 'pageToken', 'variantSetIds']
     def __init__(self):
         self.name = None
         self.pageSize = None
@@ -891,6 +910,7 @@ This is the response from `POST /callsets/search` expressed as JSON.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['callSets', 'nextPageToken']
     def __init__(self):
         self.callSets = []
         self.nextPageToken = None
@@ -922,6 +942,7 @@ This request maps to the body of `POST /readgroupsets/search` as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['datasetIds', 'name', 'pageSize', 'pageToken']
     def __init__(self):
         self.datasetIds = []
         self.name = None
@@ -986,6 +1007,7 @@ null, "doc": "", "type": ["null", "string"], "name": "prevProgramId"},
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'readGroupSets']
     def __init__(self):
         self.nextPageToken = None
         self.readGroupSets = []
@@ -1024,6 +1046,7 @@ null, "doc": "", "type": ["null", "string"], "name": "referenceName"},
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['end', 'pageSize', 'pageToken', 'readGroupIds', 'referenceId', 'referenceName', 'start']
     def __init__(self):
         self.end = None
         self.pageSize = None
@@ -1095,6 +1118,7 @@ null, "doc": "", "type": ["null", "string"], "name": "nextPageToken"}],
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['alignments', 'nextPageToken']
     def __init__(self):
         self.alignments = []
         self.nextPageToken = None
@@ -1128,6 +1152,7 @@ as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['accessions', 'assemblyId', 'md5checksums', 'pageSize', 'pageToken']
     def __init__(self):
         self.accessions = []
         self.assemblyId = None
@@ -1175,6 +1200,7 @@ expressed as JSON.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'referenceSets']
     def __init__(self):
         self.nextPageToken = None
         self.referenceSets = []
@@ -1207,6 +1233,7 @@ as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['accessions', 'md5checksums', 'pageSize', 'pageToken']
     def __init__(self):
         self.accessions = []
         self.md5checksums = []
@@ -1251,6 +1278,7 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'references']
     def __init__(self):
         self.nextPageToken = None
         self.references = []
@@ -1281,6 +1309,7 @@ This request maps to the body of `POST /variantsets/search` as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['datasetIds', 'pageSize', 'pageToken']
     def __init__(self):
         self.datasetIds = []
         self.pageSize = None
@@ -1325,6 +1354,7 @@ This is the response from `POST /variantsets/search` expressed as JSON.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'variantSets']
     def __init__(self):
         self.nextPageToken = None
         self.variantSets = []
@@ -1363,6 +1393,7 @@ This request maps to the body of `POST /variants/search` as JSON.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['callSetIds', 'end', 'pageSize', 'pageToken', 'referenceName', 'start', 'variantName', 'variantSetIds']
     def __init__(self):
         self.callSetIds = []
         self.end = None
@@ -1423,6 +1454,7 @@ null, "doc": "", "type": ["null", "long"], "name": "updated"}, {"doc":
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['nextPageToken', 'variants']
     def __init__(self):
         self.nextPageToken = None
         self.variants = []
@@ -1484,6 +1516,7 @@ This is equivalent to a row in VCF.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['alternateBases', 'calls', 'created', 'end', 'id', 'info', 'names', 'referenceBases', 'referenceName', 'start', 'updated', 'variantSetId']
     def __init__(self):
         self.alternateBases = []
         self.calls = []
@@ -1538,6 +1571,7 @@ The variant set is equivalent to a VCF file.
         }
         return embeddedTypes[fieldName]
 
+    __slots__ = ['datasetId', 'id', 'metadata']
     def __init__(self):
         self.datasetId = None
         self.id = None
@@ -1578,6 +1612,7 @@ This metadata represents VCF header information.
         embeddedTypes = {}
         return embeddedTypes[fieldName]
 
+    __slots__ = ['description', 'id', 'info', 'key', 'number', 'type', 'value']
     def __init__(self):
         self.description = None
         self.id = None

--- a/ga4gh/protocol.py
+++ b/ga4gh/protocol.py
@@ -29,7 +29,7 @@ class ProtocolElementEncoder(json.JSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, ProtocolElement):
-            ret = obj.__dict__
+            ret = { a: getattr(obj, a) for a in obj.__slots__ }
         else:
             ret = super(ProtocolElementEncoder, self).default(obj)
         return ret
@@ -81,7 +81,7 @@ class ProtocolElement(object):
         """
         out = {}
         for field in self.schema.fields:
-            val = self.__dict__[field.name]
+            val = getattr(self, field.name)
             if self.isEmbeddedType(field.name):
                 if isinstance(val, list):
                     out[field.name] = list(el.toJSONDict() for el in val)
@@ -128,7 +128,7 @@ class ProtocolElement(object):
                     instanceVal = cls._decodeEmbedded(field, val)
                 else:
                     instanceVal = val
-            instance.__dict__[field.name] = instanceVal
+            setattr(instance, field.name, instanceVal)
         return instance
 
     @classmethod

--- a/ga4gh/protocol.py
+++ b/ga4gh/protocol.py
@@ -29,7 +29,7 @@ class ProtocolElementEncoder(json.JSONEncoder):
     """
     def default(self, obj):
         if isinstance(obj, ProtocolElement):
-            ret = { a: getattr(obj, a) for a in obj.__slots__ }
+            ret = {a: getattr(obj, a) for a in obj.__slots__}
         else:
             ret = super(ProtocolElementEncoder, self).default(obj)
         return ret

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -17,6 +17,7 @@ import tempfile
 import requests
 import argparse
 import subprocess
+import textwrap
 import re
 
 import avro.schema
@@ -135,8 +136,11 @@ class SchemaClass(object):
         # when a query returns hundreds of thousands of calls this can
         # save a hundred megabytes or more.
         print("    __slots__ = ['",
-              "', '".join([field.name for field in self.getFields()]), "']",
+              textwrap.fill(
+                  "', '".join([field.name for field in self.getFields()]),
+                  62, subsequent_indent='                 '), "']",
               sep='', file=outputFile)
+        print(file=outputFile)
         print("    def __init__(self):", file=outputFile)
         for field in self.getFields():
             print("        self.{0} = {1}".format(

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -131,6 +131,12 @@ class SchemaClass(object):
         return string
 
     def writeConstructor(self, outputFile):
+        # Force using slots to avoid the overhead of a dict per object;
+        # when a query returns hundreds of thousands of calls this can
+        # save a hundred megabytes or more.
+        print("    __slots__ = ['",
+              "', '".join([field.name for field in self.getFields()]), "']",
+              sep='', file=outputFile)
         print("    def __init__(self):", file=outputFile)
         for field in self.getFields():
             print("        self.{0} = {1}".format(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,7 @@ import ga4gh.protocol as protocol
 
 class DummyRequest(protocol.ProtocolElement):
 
+    __slots__ = ["stringVal", "intVal", "arrayVal", "pageToken"]
     def __init__(self):
         self.stringVal = "stringVal"
         self.intVal = 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,7 @@ import ga4gh.protocol as protocol
 class DummyRequest(protocol.ProtocolElement):
 
     __slots__ = ["stringVal", "intVal", "arrayVal", "pageToken"]
+
     def __init__(self):
         self.stringVal = "stringVal"
         self.intVal = 1

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -213,7 +213,7 @@ class SchemaTest(unittest.TestCase):
         """
         Sets the required values in the specified instance to typical values.
         """
-        for key in instance.__dict__.keys():
+        for key in instance.__slots__:
             if key in instance.requiredFields:
                 value = self.getTypicalValue(type(instance), key)
                 setattr(instance, key, value)


### PR DESCRIPTION
Replaces `__dict__` with `__slots__` for all ProtocolElement subclasses,
leading to significant space savings. Switches unit test from `__dict__`
to `__slots__`.

Addresses https://github.com/ga4gh/server/issues/92

-------
This cuts memory usage during our benchmark variants search by 250MB.

In master, server_benchmark.py --profile heap shows:
Partition of a set of 1253757 objects. Total size = 402956592 bytes.
```
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 250400  20 262419200  65 262419200  65 dict of ga4gh._protocol_definitions.GACall
     1 250500  20 70140000  17 332559200  83 dict (no owner)
     2 501502  40 54216624  13 386775824  96 list
     3 250400  20 16025600   4 402801424 100 ga4gh._protocol_definitions.GACall
     4    100   0   104800   0 402906224 100 dict of ga4gh._protocol_definitions.GAVariant
     5    406   0    19440   0 402925664 100 str
     6    139   0    15496   0 402941160 100 unicode
     7    100   0     6400   0 402947560 100 ga4gh._protocol_definitions.GAVariant
     8    200   0     6400   0 402953960 100 long
     9      1   0     1048   0 402955008 100 dict of
                                             ga4gh._protocol_definitions.GASearchVariantsRequest
```

With this patch in place:
Partition of a set of 1003255 objects. Total size = 152460144 bytes.
```
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 250500  25 70140000  46  70140000  46 dict (no owner)
     1 501502  50 54216624  36 124356624  82 list
     2 250400  25 28044800  18 152401424 100 ga4gh._protocol_definitions.GACall
     3    406   0    19440   0 152420864 100 str
     4    100   0    16000   0 152436864 100 ga4gh._protocol_definitions.GAVariant
     5    139   0    15496   0 152452360 100 unicode
     6    200   0     6400   0 152458760 100 long
     7      2   0      888   0 152459648 100 types.FrameType
     8      3   0      264   0 152459912 100 __builtin__.weakref
     9      1   0      128   0 152460040 100 ga4gh._protocol_definitions.GASearchVariantsRequest
```
