### PR TITLE
Change style guide abbreviations policy

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -11,6 +11,8 @@ Short variable names are OK when the scope is small (less than five lines)
 and the meaning is obvious. If the scope is longer or more complex,
 please use descriptive longer names.
 
+Contrary to PEP8, acronyms should be camel cased, not capitalized.  For instance, HTTPAPIClient should be written as HttpApiClient.
+
 ## Imports
 Imports should be structured into the following groups:
 


### PR DESCRIPTION
Breaking out this change from #108 

I'd like to advocate disobeying the part of PEP8 that says: "Note: When using abbreviations in CapWords, capitalize all the letters of the abbreviation. Thus HTTPServerError is better than HttpServerError." Noun boundaries are difficult to parse with all-caps acronyms, especially with a variable name that has multiple acronyms. For instance:

HttpClient is easier to read than HTTPClient
HttpApiClient is easier to read than HTTPAPIClient

PEP8 doesn't offer any rationale for the "Note" recommendation.