### PR TITLE
Added support for flake8 checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_script:
   - chmod og-w $HOME/.python-eggs
 
 script: 
-  - pep8 ga4gh tests scripts 
+  # We ignore 'from module import *' as we use this legitimately
+  # in ga4gh/protocol.py
+  - flake8 --ignore=F403 tests ga4gh scripts
   - nosetests --with-coverage --cover-package ga4gh
               --cover-inclusive --cover-min-percentage 80

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -39,7 +39,7 @@ def server_main(parser=None):
     subparsers = parser.add_subparsers(title='subcommands',)
 
     # help
-    helpParser = subparsers.add_parser(
+    subparsers.add_parser(
         "help",
         description="ga4gh_server help",
         help="show this help message and exit")
@@ -367,7 +367,7 @@ def client_main(parser=None):
     subparsers = parser.add_subparsers(title='subcommands',)
 
     # help
-    helpParser = subparsers.add_parser(
+    subparsers.add_parser(
         "help", description="ga4gh_client help",
         help="show this help message and exit")
 

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -5,10 +5,3 @@ objects.
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
-
-import pysam
-
-import ga4gh.protocol as protocol
-
-# TODO use pysam to translate reads from SAM/BAM files into GA4GH objects.

--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -5,9 +5,3 @@ objects.
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
-
-import ga4gh.protocol as protocol
-
-# TODO use something to translate reference data in FASTA format into
-# GA4GH native objects.

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -26,7 +26,7 @@ def configure(config="DefaultConfig", config_file=None):
     if os.environ.get('GA4GH_CONFIGURATION') is not None:
         app.config.from_envvar('GA4GH_CONFIGURATION')
     if config_file is not None:
-        app.config.from_pyfile(args.config_file)
+        app.config.from_pyfile(config_file)
     cors.CORS(app, allow_headers='Content-Type')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-API
 Flask-Cors
 avro
 coverage
+flake8
 guppy
 mock
 nose

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -139,7 +139,7 @@ class TestWormtableBackend(unittest.TestCase):
             protocol.GASearchVariantSetsResponse, "variantSets")
 
     def getVariants(
-            self, variantSetIds, referenceName, start=0, end=2**32,
+            self, variantSetIds, referenceName, start=0, end=2 ** 32,
             pageSize=100, callSetIds=[]):
         """
         Returns an iterator over the specified list of variants, abstracting
@@ -174,7 +174,7 @@ class TestWormtableBackend(unittest.TestCase):
         return commonNames
 
     def getWormtableVariants(
-            self, variantSetIds, referenceName, start=0, end=2**32,
+            self, variantSetIds, referenceName, start=0, end=2 ** 32,
             callSetIds=[]):
         """
         Returns the rows from the table corresponding to the specified values.
@@ -529,7 +529,7 @@ class TestVariants(TestWormtableBackend):
         for variantSet in self.getVariantSets():
             for referenceName in self.getReferenceNames(variantSet.id):
                 self.verifySearchVariants(
-                    [variantSet.id], referenceName, 0, 2**32)
+                    [variantSet.id], referenceName, 0, 2 ** 32)
 
     def testSearchVariantSlices(self):
         for variantSet in self.getVariantSets():
@@ -566,7 +566,7 @@ class TestVariants(TestWormtableBackend):
             for subset in tests.powerset(callSetIds, 20):
                 for referenceName in self.getReferenceNames(variantSet.id):
                     self.verifySearchByCallSetIds(
-                        variantSet.id, referenceName, 0, 2**32, subset)
+                        variantSet.id, referenceName, 0, 2 ** 32, subset)
 
     def testUniqueIds(self):
         ids = set()
@@ -585,5 +585,5 @@ class TestVariants(TestWormtableBackend):
                 for referenceName in self.getCommonRefNames(variantSets):
                     for pageSize in [1, 2, 3, 5, 1000]:
                         self.verifySearchVariants(
-                            variantSets, referenceName, 0, 2**32,
+                            variantSets, referenceName, 0, 2 ** 32,
                             pageSize=pageSize)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import unittest
 import argparse
 
-import tests
 import ga4gh.cli as cli
 import ga4gh.protocol as protocol
 import ga4gh.client as client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,9 +10,7 @@ import unittest
 import json
 
 import mock
-import requests
 
-import tests
 import ga4gh.client as client
 import ga4gh.protocol as protocol
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -79,7 +79,7 @@ class EndToEndWormtableTest(unittest.TestCase):
         self.assertEqual([], responseData.variants)
 
         # Larger request window, expect results
-        request.end = 2**16
+        request.end = 2 ** 16
         response = self.sendJSONPostRequest('/variants/search',
                                             request.toJSONString())
         self.assertEqual(200, response.status_code)
@@ -92,7 +92,7 @@ class EndToEndWormtableTest(unittest.TestCase):
         # Verify all results are in the correct range, set and reference
         for variant in responseData.variants:
             self.assertGreaterEqual(variant.start, 0)
-            self.assertLessEqual(variant.end, 2**16)
+            self.assertLessEqual(variant.end, 2 ** 16)
             self.assertTrue(variant.variantSetId in expectedIds)
             self.assertEqual(variant.referenceName, referenceName)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import unittest
 import inspect
 
-import tests
 import ga4gh.frontend_exceptions as frontendExceptions
 
 


### PR DESCRIPTION
Flake8 combines pep8 checks with some other lint checks. See http://flake8.readthedocs.org/en/2.2.3/ for details. These are the minimum changes required to get flake8 checks passing.

This also fixes a bug in the configure function in `frontend.py` which flake8 caught.