### PR TITLE
Renamed capitalized acronyms to camel-case

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -58,8 +58,8 @@ class Backend(object):
         any point using the nextPageToken attribute of the request object.
         """
         self.startProfile()
-        # TODO change this to fromJSONDict and validate
-        request = requestClass.fromJSONString(requestStr)
+        # TODO change this to fromJsonDict and validate
+        request = requestClass.fromJsonString(requestStr)
         pageList = []
         nextPageToken = None
         for obj, nextPageToken in objectGenerator(request):
@@ -70,7 +70,7 @@ class Backend(object):
         response.nextPageToken = nextPageToken
         setattr(response, pageListName, pageList)
         self.endProfile()
-        return response.toJSONString()
+        return response.toJsonString()
 
     def searchVariantSets(self, request):
         """

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -98,7 +98,7 @@ class AbstractSearchRunner(object):
         self._minimalOutput = args.minimalOutput
         self._request = request
         self._verbosity = args.verbose
-        self._httpClient = client.HTTPClient(
+        self._httpClient = client.HttpClient(
             args.baseUrl, args.verbose, self._workarounds, self._key)
 
     def _run(self, methodName, attrName=None):
@@ -142,7 +142,7 @@ class VariantSearchRunner(AbstractSearchRunner):
         request.variantName = args.variantName
         request.start = args.start
         request.end = args.end
-        if self.usingWorkaroundsFor(client.HTTPClient.workaroundGoogle):
+        if self.usingWorkaroundsFor(client.HttpClient.workaroundGoogle):
             request.maxCalls = args.maxCalls
         if args.callSetIds == []:
             request.callSetIds = []
@@ -189,7 +189,7 @@ class ReferenceSetSearchRunner(AbstractSearchRunner):
         request = protocol.GASearchReferenceSetsRequest()
         setCommaSeparatedAttribute(request, args, 'accessions')
         setCommaSeparatedAttribute(request, args, 'md5checksums')
-        if self.usingWorkaroundsFor(client.HTTPClient.workaroundGoogle):
+        if self.usingWorkaroundsFor(client.HttpClient.workaroundGoogle):
             # google says assemblyId not a valid field
             del request.__dict__['assemblyId']
         self.setHttpClient(request, args)
@@ -255,7 +255,7 @@ class ReadsSearchRunner(AbstractSearchRunner):
         request.end = args.end
         request.referenceId = args.referenceId
         request.referenceName = args.referenceName
-        if self.usingWorkaroundsFor(client.HTTPClient.workaroundGoogle):
+        if self.usingWorkaroundsFor(client.HttpClient.workaroundGoogle):
             # google says referenceId not a valid field
             del request.__dict__['referenceId']
         self.setHttpClient(request, args)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -15,7 +15,7 @@ import ga4gh.protocol as protocol
 requests.packages.urllib3.disable_warnings()
 
 
-class HTTPClient(object):
+class HttpClient(object):
 
     workaroundGoogle = 'google'
 
@@ -38,9 +38,9 @@ class HTTPClient(object):
         """
         notDone = True
         while notDone:
-            jsonString = request.toJSONString()
+            jsonString = request.toJsonString()
             if self._debugLevel > 1:
-                self.printJSONMessage("request:", jsonString)
+                self.printJsonMessage("request:", jsonString)
             headers = {"Content-type": "application/json"}
             # make sure we correctly join with/out trailing slashes
             fullUrl = posixpath.join(self._urlPrefix, url)
@@ -55,15 +55,15 @@ class HTTPClient(object):
             if self._debugLevel > 1:
                 # TODO use a logging output and integrate with HTTP client more
                 # nicely.
-                self.printJSONMessage("response:", jsonString)
-            resp = protocolClass.fromJSONString(jsonString)
+                self.printJsonMessage("response:", jsonString)
+            resp = protocolClass.fromJsonString(jsonString)
             # TODO handle HTTP errors from requests and display.
             for extract in getattr(resp, listAttr):
                 yield extract
             request.pageToken = resp.nextPageToken
             notDone = resp.nextPageToken is not None
 
-    def printJSONMessage(self, header, jsonString):
+    def printJsonMessage(self, header, jsonString):
         """
         Prints the specified jsonString to stdout for debugging purposes.
         """

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -70,7 +70,7 @@ def configure(config="DefaultConfig", config_file=None):
     app.serverStatus = ServerStatus()
 
 
-def handleHTTPPost(request, endpoint):
+def handleHttpPost(request, endpoint):
     """
     Handles the specified HTTP POST request, which maps to the specified
     protocol handler handpoint and protocol request class.
@@ -82,7 +82,7 @@ def handleHTTPPost(request, endpoint):
     return flask.Response(responseStr, status=200, mimetype=mimetype)
 
 
-def handleHTTPOptions():
+def handleHttpOptions():
     """
     Handles the specified HTTP OPTIONS request.
     """
@@ -106,7 +106,7 @@ def handleException(exception):
     error = protocol.GAException()
     error.errorCode = exception.code
     error.message = exception.message
-    response = flask.jsonify(error.toJSONDict())
+    response = flask.jsonify(error.toJsonDict())
     response.status_code = exception.httpStatus
     return response
 
@@ -160,14 +160,14 @@ def searchReferences():
 @app.route('/variantsets/search', methods=['POST', 'OPTIONS'])
 def searchVariantSets():
     if flask.request.method == "POST":
-        return handleHTTPPost(flask.request, app.backend.searchVariantSets)
+        return handleHttpPost(flask.request, app.backend.searchVariantSets)
     else:
-        return handleHTTPOptions()
+        return handleHttpOptions()
 
 
 @app.route('/variants/search', methods=['POST', 'OPTIONS'])
 def searchVariants():
     if flask.request.method == "POST":
-        return handleHTTPPost(flask.request, app.backend.searchVariants)
+        return handleHttpPost(flask.request, app.backend.searchVariants)
     else:
-        return handleHTTPOptions()
+        return handleHttpOptions()

--- a/ga4gh/protocol.py
+++ b/ga4gh/protocol.py
@@ -47,7 +47,7 @@ class ProtocolElement(object):
     # rigorous testing.
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, self.toJSONString())
+        return "{0}({1})".format(self.__class__.__name__, self.toJsonString())
 
     def __eq__(self, other):
         """
@@ -66,7 +66,7 @@ class ProtocolElement(object):
     def __ne__(self, other):
         return not self == other
 
-    def toJSONString(self):
+    def toJsonString(self):
         """
         Returns a JSON encoded string representation of this ProtocolElement.
 
@@ -75,7 +75,7 @@ class ProtocolElement(object):
         """
         return json.dumps(self, cls=ProtocolElementEncoder)
 
-    def toJSONDict(self):
+    def toJsonDict(self):
         """
         Returns a JSON dictionary representation of this ProtocolElement.
         """
@@ -84,11 +84,11 @@ class ProtocolElement(object):
             val = getattr(self, field.name)
             if self.isEmbeddedType(field.name):
                 if isinstance(val, list):
-                    out[field.name] = list(el.toJSONDict() for el in val)
+                    out[field.name] = list(el.toJsonDict() for el in val)
                 elif val is None:
                     out[field.name] = None
                 else:
-                    out[field.name] = val.toJSONDict()
+                    out[field.name] = val.toJsonDict()
             elif isinstance(val, list):
                 out[field.name] = list(val)
             else:
@@ -104,15 +104,15 @@ class ProtocolElement(object):
         return avro.io.validate(cls.schema, jsonDict)
 
     @classmethod
-    def fromJSONString(cls, jsonStr):
+    def fromJsonString(cls, jsonStr):
         """
         Returns a decoded ProtocolElement from the specified JSON string.
         """
         jsonDict = json.loads(jsonStr)
-        return cls.fromJSONDict(jsonDict)
+        return cls.fromJsonDict(jsonDict)
 
     @classmethod
-    def fromJSONDict(cls, jsonDict):
+    def fromJsonDict(cls, jsonDict):
         """
         Returns a decoded ProtocolElement from the specified JSON dictionary.
         """
@@ -138,9 +138,9 @@ class ProtocolElement(object):
 
         embeddedType = cls.getEmbeddedType(field.name)
         if isinstance(field.type, avro.schema.ArraySchema):
-            return list(embeddedType.fromJSONDict(elem) for elem in val)
+            return list(embeddedType.fromJsonDict(elem) for elem in val)
         else:
-            return embeddedType.fromJSONDict(val)
+            return embeddedType.fromJsonDict(val)
 
 # We can now import the definitions of the protocol elements from the
 # generated file.

--- a/server_benchmark.py
+++ b/server_benchmark.py
@@ -58,7 +58,7 @@ def timeOneSearch(queryString):
 
 def extractNextPageToken(resultString):
     """
-    Calling GASearchVariantsResponse.fromJSONString() can be slower
+    Calling GASearchVariantsResponse.fromJsonString() can be slower
     than doing the variant search in the first place; instead we use
     a regexp to extract the next page token.
     """
@@ -77,7 +77,7 @@ def benchmarkOneQuery(request, repeatLimit=3, pageLimit=3):
     processing to prepare queries or parse responses.
     """
     times = []
-    queryString = request.toJSONString()
+    queryString = request.toJsonString()
     for i in range(0, repeatLimit):
         resultString, elapsedTime = timeOneSearch(queryString)
         accruedTime = elapsedTime
@@ -87,7 +87,7 @@ def benchmarkOneQuery(request, repeatLimit=3, pageLimit=3):
         while token is not None and pageCount < pageLimit:
             pageRequest = request
             pageRequest.pageToken = token
-            pageRequestString = pageRequest.toJSONString()
+            pageRequestString = pageRequest.toJsonString()
             resultString, elapsedTime = timeOneSearch(pageRequestString)
             accruedTime += elapsedTime
             pageCount = pageCount + 1

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -119,8 +119,8 @@ class TestWormtableBackend(unittest.TestCase):
         request.pageSize = pageSize
         while notDone:
             # TODO validate the response there.
-            responseStr = searchMethod(request.toJSONString())
-            response = ResponseClass.fromJSONString(responseStr)
+            responseStr = searchMethod(request.toJsonString())
+            response = ResponseClass.fromJsonString(responseStr)
             objectList = getattr(response, listMember)
             self.assertLessEqual(len(objectList), pageSize)
             for obj in objectList:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ class TestClientArguments(unittest.TestCase):
 
         # ensure the correct attributes on the runner are set
         self.assertIsInstance(runner._request, protocol.ProtocolElement)
-        self.assertIsInstance(runner._httpClient, client.HTTPClient)
+        self.assertIsInstance(runner._httpClient, client.HttpClient)
 
     def run(self, *args, **kwargs):
         super(TestClientArguments, self).run(*args, **kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,7 +53,7 @@ def makeHttpClient():
     debugLevel = 1
     workarounds = set()
     key = "KEY"
-    httpClient = client.HTTPClient(url, debugLevel, workarounds, key)
+    httpClient = client.HttpClient(url, debugLevel, workarounds, key)
     return httpClient
 
 
@@ -136,7 +136,7 @@ class TestRunRequest(unittest.TestCase):
 
             # verify requests.post called correctly
             url = "http://example.com/referencesets/search"
-            jsonString = request.toJSONString()
+            jsonString = request.toJsonString()
             headers = {"Content-type": "application/json"}
             mockPost.assert_called_twice_with(
                 url, jsonString, headers=headers, verify=False)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -43,14 +43,14 @@ class EndToEndWormtableTest(unittest.TestCase):
         request = protocol.GASearchVariantSetsRequest()
         request.pageSize = len(expectedIds)
         response = self.sendJSONPostRequest('/variantsets/search',
-                                            request.toJSONString())
+                                            request.toJsonString())
 
         self.assertEqual(200, response.status_code)
 
-        responseData = protocol.GASearchVariantSetsResponse.fromJSONString(
+        responseData = protocol.GASearchVariantSetsResponse.fromJsonString(
             response.data)
         self.assertTrue(protocol.GASearchVariantSetsResponse.validate(
-            responseData.toJSONDict()))
+            responseData.toJsonDict()))
 
         self.assertIsNone(responseData.nextPageToken)
         self.assertEqual(len(expectedIds), len(responseData.variantSets))
@@ -71,9 +71,9 @@ class EndToEndWormtableTest(unittest.TestCase):
 
         # Request windows is too small, no results
         response = self.sendJSONPostRequest('/variants/search',
-                                            request.toJSONString())
+                                            request.toJsonString())
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantsResponse.fromJSONString(
+        responseData = protocol.GASearchVariantsResponse.fromJsonString(
             response.data)
         self.assertIsNone(responseData.nextPageToken)
         self.assertEqual([], responseData.variants)
@@ -81,12 +81,12 @@ class EndToEndWormtableTest(unittest.TestCase):
         # Larger request window, expect results
         request.end = 2 ** 16
         response = self.sendJSONPostRequest('/variants/search',
-                                            request.toJSONString())
+                                            request.toJsonString())
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantsResponse.fromJSONString(
+        responseData = protocol.GASearchVariantsResponse.fromJsonString(
             response.data)
         self.assertTrue(protocol.GASearchVariantsResponse.validate(
-            responseData.toJSONDict()))
+            responseData.toJsonDict()))
         self.assertNotEqual([], responseData.variants)
 
         # Verify all results are in the correct range, set and reference

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -255,7 +255,7 @@ class EqualityTest(SchemaTest):
         for cls in self.getProtocolClasses():
             for factory in factories:
                 i1 = factory(cls)
-                i2 = cls.fromJSONDict(i1.toJSONDict())
+                i2 = cls.fromJsonDict(i1.toJsonDict())
                 self.verifyEqualityOperations(i1, i2)
 
     def testDifferentValues(self):
@@ -274,7 +274,7 @@ class EqualityTest(SchemaTest):
 
     def testDifferentLengthArrays(self):
         i1 = self.getTypicalInstance(protocol.GACallSet)
-        i2 = protocol.GACallSet.fromJSONDict(i1.toJSONDict())
+        i2 = protocol.GACallSet.fromJsonDict(i1.toJsonDict())
         i2.variantSetIds.append("extra")
         self.assertFalse(i1 == i2)
 
@@ -286,12 +286,12 @@ class SerialisationTest(SchemaTest):
     def validateClasses(self, factory):
         for cls in self.getProtocolClasses():
             instance = factory(cls)
-            jsonStr = instance.toJSONString()
-            otherInstance = cls.fromJSONString(jsonStr)
+            jsonStr = instance.toJsonString()
+            otherInstance = cls.fromJsonString(jsonStr)
             self.assertEqual(instance, otherInstance)
 
-            jsonDict = instance.toJSONDict()
-            otherInstance = cls.fromJSONDict(jsonDict)
+            jsonDict = instance.toJsonDict()
+            otherInstance = cls.fromJsonDict(jsonDict)
             self.assertEqual(instance, otherInstance)
 
     def testSerialiseDefaultValues(self):
@@ -313,7 +313,7 @@ class ValidatorTest(SchemaTest):
     def validateClasses(self, factory):
         for cls in self.getProtocolClasses():
             instance = factory(cls)
-            jsonDict = instance.toJSONDict()
+            jsonDict = instance.toJsonDict()
             self.assertTrue(cls.validate(jsonDict))
 
     def testValidateDefaultValues(self):
@@ -328,7 +328,7 @@ class ValidatorTest(SchemaTest):
     def testValidateBadValues(self):
         for cls in self.getProtocolClasses():
             instance = self.getTypicalInstance(cls)
-            jsonDict = instance.toJSONDict()
+            jsonDict = instance.toJsonDict()
             self.assertFalse(cls.validate(None))
             self.assertFalse(cls.validate([]))
             self.assertFalse(cls.validate(1))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -77,13 +77,13 @@ class TestFrontend(unittest.TestCase):
     def testVariantsSearch(self):
         response = self.sendVariantsSearch('{"variantSetIds": [1, 2]}')
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantsResponse.fromJSONString(
+        responseData = protocol.GASearchVariantsResponse.fromJsonString(
             response.data)
         self.assertEqual(responseData.variants, [])
 
     def testVariantSetsSearch(self):
         response = self.sendVariantSetsSearch('{"dataSetIds": [1, 2]}')
         self.assertEqual(200, response.status_code)
-        responseData = protocol.GASearchVariantSetsResponse.fromJSONString(
+        responseData = protocol.GASearchVariantSetsResponse.fromJsonString(
             response.data)
         self.assertEqual(responseData.variantSets, [])


### PR DESCRIPTION
Issue #135 

Renamed the following names:
```
- toJSONString
- handleHTTPPost
- handleHTTPOptions
- printJSONMessage
- fromJSONString
- fromJSONDict
- toJSONDict
- HTTPClient
```