### PR TITLE
Change the README so that the example usage works

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -90,12 +90,12 @@ for example, here we run the ``variants/search`` method over the
 ``1000g_2013`` variant set, where the reference name is ``1``, the end coordinate
 is 60000 and we only want calls returned for call set ID HG03279::
 
-    $ ga4gh_client variants-search http://localhost:8000 -v 1000g_2013 -r 1 -e 60000 -c HG03279 | less -S
+    $ ga4gh_client variants-search http://localhost:8000 -V 1000g_2013 -r 1 -e 60000 -c HG03279 | less -S
 
 We can also query against the *variant name*; here we return the variant that
 has variant name ``rs75454623``::
 
-    $ ga4gh_client variants-search http://localhost:8000 -v 1000g_2013 -r 1 -e 60000 -n rs75454623  | less -S
+    $ ga4gh_client variants-search http://localhost:8000 -V 1000g_2013 -r 1 -e 60000 -n rs75454623  | less -S
 
 +++++++++++++++++++++
 Converting 1000G data


### PR DESCRIPTION
We changed the variantId option from -v to -V previously to avoid conflicts with the verbose flag, but didn't update the README to reflect that.