### PR TITLE
Easier paging

### DIFF
--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -279,6 +279,19 @@ class WormtableVariantSet(VariantSet):
                     ret.append(buildMetadata(infoField, col))
         return ret
 
+    def search(self, request, depth):
+        startPosition = 0
+        if request.pageToken is not None:
+            tokens = request.pageToken.split(":")
+            startPosition = int(tokens[1])
+        iterator = self.getVariants(
+                request.referenceName, startPosition, request.end,
+                request.variantName, request.callSetIds)
+        for variant in iterator:
+            pageToken = "{}:{}".format(variant.variantSetId, variant.start + 1)
+            yield variant, pageToken
+
+
 
 class TabixVariantSet(VariantSet):
     """

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -22,6 +22,21 @@ class VariantSet(object):
     """
     # TODO abstract details shared by wormtable and tabix based backends.
 
+    def getId(self):
+        # TODO temporary method before we abstract all of this upwards into
+        # the DataObject class.
+        return self._variantSetId
+
+
+    def toProtocolElement(self):
+        """
+        Converts this data object into it's equivalent GA4GH protocol element.
+        """
+        protocolElement = protocol.GAVariantSet()
+        protocolElement.id = self.getId()
+        protocolElement.datasetId = "NotImplemented"
+        protocolElement.metadata = self.getMetadata()
+        return protocolElement
 
 class WormtableVariantSet(VariantSet):
     """

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -574,6 +574,7 @@ class TestVariants(TestWormtableBackend):
             for referenceName in self.getReferenceNames(variantSet.id):
                 for variant in self.getVariants(
                         [variantSet.id], referenceName):
+                        print(ids)
                     self.assertTrue(variant.id not in ids)
                     ids.add(variant.id)
 


### PR DESCRIPTION
This is a very rough first pass at making paging easier. This supersedes #134 and #121, as I think we need to resolve this problem before we make any progress on adding support for datasets or references.

Paging is currently too hard. At the moment, we're using different mechanisms to handle paging when we're dealing with `VariantSets` and `Variants`. This is very awkward, and makes it difficult and error prone to add support for more parts of the protocol. We need a single unified approach that makes it trivial to add support for new objects.

This is a very tentative first pass at doing this. Instead of having a sorted list of IDs that we use as our way of indexing into the variantSets, we abstract the details away into a `DataObjectCollection`, which is supposed to make this easy. The DataObjectCollection should handle searches in a generic way for high level objects (e.g., Datasets, VariantSets, ReferenceSets), and pass the search query down to more specialised classes when we are deeper in the tree.

In the generic case, we keep an ordered map of the IDs to the objects, stored here in an AVL tree. The pageToken we pass back is the ID of the next object, which is simple and straight forward to implement. See the definition of search here when `depth == 1`, which works well and I'm quite happy with. I've cobbled together something that sort-of works for depth == 2 here. It's very nasy, and shouldn't be taken too seriously. Ultimately, I hope we can have some elegant recursive approach here which makes the tree traversal logic completely transparent.

Questions:
1. Is this a good way to proceed? Is mapping the `nextPageToken` to the ID of the next object in the stream the right thing to do?
2. Is `DataObjectContainer` a good abstraction? Will this abstraction work when we try to support other parts of the protocol?

This is a crucial aspect of the design of the server in my opinion, so I'd really appreciate it if people (especially @Naburimannu, @pashields and @dcolligan) could think about it a bit and give me feedback. It's a critical blocker in the way of making progress on  backend support for the rest of the protocol, so I think it's very important we get our heads together to try and figure this one out.