### PR TITLE
Add backend_exceptions

### DIFF
--- a/ga4gh/backend_exceptions.py
+++ b/ga4gh/backend_exceptions.py
@@ -1,0 +1,30 @@
+"""
+Exceptions for the backend
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+class BackendException(Exception):
+    """
+    Base class of backend exceptions
+    """
+    def __init__(self):
+        super(BackendException, self).__init__()
+
+
+class CallSetNotInVariantSetException(BackendException):
+    """
+    Indicates a request was made for a callSet not in the actual variantSet
+    """
+    exceptionMessage = "callSet '{0}' not in variantSet '{1}'"
+
+    def __init__(self, callSetId, variantSetId):
+        super(CallSetNotInVariantSetException, self).__init__()
+        self.callSetId = callSetId
+        self.variantSetId = variantSetId
+
+    def toErrorMessage(self):
+        return self.exceptionMessage.format(
+            self.callSetId, self.variantSetId)

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -14,6 +14,7 @@ import pysam
 import wormtable as wt
 
 import ga4gh.protocol as protocol
+import ga4gh.backend_exceptions as backendExceptions
 
 
 def convertVCFPhaseset(vcfPhaseset):
@@ -208,7 +209,11 @@ class WormtableVariantSet(VariantSet):
         else:
             readCols = self._table.columns()[:self._firstSamplePosition]
             for callSetId in callSetIds:
-                cols = [col for name, col in self._sampleCols[callSetId]]
+                try:
+                    cols = [col for name, col in self._sampleCols[callSetId]]
+                except KeyError:
+                    raise backendExceptions.CallSetNotInVariantSetException(
+                        callSetId, self._variantSetId)
                 readCols.extend(cols)
         # Now we get the row positions for the sample columns
         sampleRowPositions = {}

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -93,19 +93,34 @@ def handleHttpOptions():
 
 @app.errorhandler(Exception)
 def handleException(exception):
+    # if the caught exception implements toErrorMessage, extract the
+    # message to be returned to the client at this point (because
+    # the exception object may get overwritten later in the method)
+    errorMessage = None
+    if hasattr(exception, 'toErrorMessage'):
+        errorMessage = exception.toErrorMessage()
+
+    # if the type of exception is one we have registered in the exceptionMap,
+    # convert the exception to one that we want to return to the client
     exceptionClass = exception.__class__
     if exceptionClass in frontendExceptions.exceptionMap:
         newExceptionClass = frontendExceptions.exceptionMap[exceptionClass]
         exception = newExceptionClass()
 
+    # if at this point the exception is still unrecognized
+    # send the client a 500 error
     if not isinstance(exception, frontendExceptions.FrontendException):
         if app.config['DEBUG']:
             print(traceback.format_exc(exception))
         exception = frontendExceptions.ServerException()
 
+    # serialize the exception
     error = protocol.GAException()
     error.errorCode = exception.code
-    error.message = exception.message
+    if errorMessage is not None:
+        error.message = errorMessage
+    else:
+        error.message = exception.message
     response = flask.jsonify(error.toJsonDict())
     response.status_code = exception.httpStatus
     return response

--- a/ga4gh/frontend_exceptions.py
+++ b/ga4gh/frontend_exceptions.py
@@ -1,12 +1,13 @@
 """
-Module containing error objects we return to clients
+Error objects we return to clients
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
 import flask.ext.api as api
+
+import ga4gh.backend_exceptions as backendExceptions
 
 
 class FrontendException(Exception):
@@ -92,4 +93,6 @@ class UnsupportedMediaTypeException(FrontendException):
 # serialized and returned to the client
 exceptionMap = {
     api.exceptions.UnsupportedMediaType: UnsupportedMediaTypeException,
+    backendExceptions.BackendException: ServerException,
+    backendExceptions.CallSetNotInVariantSetException: NotFoundException,
 }

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -12,6 +12,7 @@ import inspect
 import mock
 
 import ga4gh.frontend_exceptions as frontendExceptions
+import ga4gh.backend_exceptions as backendExceptions
 import ga4gh.frontend as frontend
 
 
@@ -40,7 +41,11 @@ class TestExceptionHandler(unittest.TestCase):
     def testMappedException(self):
         for originalExceptionClass, mappedExceptionClass in \
                 frontendExceptions.exceptionMap.items():
-            originalException = originalExceptionClass()
+            # some exceptions require more than zero arguments to create
+            numInitArgs = len(inspect.getargspec(
+                originalExceptionClass.__init__).args) - 1
+            args = ['arg' for _ in range(numInitArgs)]
+            originalException = originalExceptionClass(*args)
             mappedException = mappedExceptionClass()
             response = frontend.handleException(originalException)
             self.assertEquals(response.status_code, mappedException.httpStatus)
@@ -50,10 +55,20 @@ class TestExceptionHandler(unittest.TestCase):
         response = frontend.handleException(exception)
         self.assertEquals(response.status_code, 404)
 
+    def testBackendException(self):
+        exception = backendExceptions.CallSetNotInVariantSetException(
+            'csId', 'vsId')
+        response = frontend.handleException(exception)
+        self.assertEquals(response.status_code, 404)
+
     def testUnknownExceptionBecomesServerError(self):
         exception = self.UnknownException()
         response = frontend.handleException(exception)
         self.assertEquals(response.status_code, 500)
+
+
+def isClassAndExceptionSubclass(class_):
+    return inspect.isclass(class_) and issubclass(class_, Exception)
 
 
 class TestFrontendExceptionConsistency(unittest.TestCase):
@@ -66,12 +81,7 @@ class TestFrontendExceptionConsistency(unittest.TestCase):
         - is able to instantiate a new no-argument exception instance
         - derives from the base frontend exception type
     """
-
     def _getFrontendExceptionClasses(self):
-
-        def isClassAndExceptionSubclass(class_):
-            return inspect.isclass(class_) and issubclass(class_, Exception)
-
         classes = inspect.getmembers(
             frontendExceptions, isClassAndExceptionSubclass)
         return [class_ for _, class_ in classes]
@@ -92,3 +102,18 @@ class TestFrontendExceptionConsistency(unittest.TestCase):
             exception = exceptionClass()
             self.assertIsInstance(
                 exception, frontendExceptions.FrontendException)
+
+
+class TestBackendExceptionConsistency(unittest.TestCase):
+    """
+    Ensure invariants of backend exceptions:
+    - every backend exception is mapped
+    """
+    def _getBackendExceptionClasses(self):
+        classes = inspect.getmembers(
+            backendExceptions, isClassAndExceptionSubclass)
+        return [class_ for _, class_ in classes]
+
+    def testBackendExceptionsMapped(self):
+        for exceptionClass in self._getBackendExceptionClasses():
+            self.assertTrue(exceptionClass in frontendExceptions.exceptionMap)


### PR DESCRIPTION
The payload that comes back from an exception with a defined more-specific message is now something like:
```
{
  "errorCode": 4,
  "message": "callSet 'HG03279' not in variantSet '1000g_2011'"
}
```

Issue #160