### PR TITLE
404s and 405s now return json instead of html

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -142,12 +142,9 @@ def handleException(exception):
         exception = frontendExceptions.ServerException()
 
     # serialize the exception
-    error = protocol.GAException()
-    error.errorCode = exception.code
+    error = exception.toGaException()
     if errorMessage is not None:
         error.message = errorMessage
-    else:
-        error.message = exception.message
     response = flask.jsonify(error.toJsonDict())
     response.status_code = exception.httpStatus
     return response
@@ -223,3 +220,24 @@ def searchVariantSets(version):
 def searchVariants(version):
     return handleFlaskPostRequest(
         version, flask.request, app.backend.searchVariants)
+
+
+# The below methods ensure that JSON is returned for various errors
+# instead of the default, html
+
+
+@app.errorhandler(404)
+def pathNotFoundHandler(errorString):
+    return handleHttpError(frontendExceptions.PathNotFoundException())
+
+
+@app.errorhandler(405)
+def methodNotAllowedHandler(errorString):
+    return handleHttpError(frontendExceptions.MethodNotAllowedException())
+
+
+def handleHttpError(exception):
+    error = exception.toGaException()
+    response = flask.jsonify(error.toJsonDict())
+    response.status_code = exception.httpStatus
+    return response

--- a/ga4gh/frontend_exceptions.py
+++ b/ga4gh/frontend_exceptions.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import flask.ext.api as api
 
 import ga4gh.backend_exceptions as backendExceptions
+import ga4gh.protocol as protocol
 
 
 class FrontendException(Exception):
@@ -18,6 +19,12 @@ class FrontendException(Exception):
         self.code = None
         self.description = ""
         self.httpStatus = None
+
+    def toGaException(self):
+        error = protocol.GAException()
+        error.errorCode = self.code
+        error.message = self.message
+        return error
 
 
 class BadRequestException(FrontendException):


### PR DESCRIPTION
To ensure correctness, we will probably need to do the same with just about every 4xx error message (at least), but I think we can just add these as time goes on and people hit html erroneously.

Issue #166