### PR TITLE
Basic infrastructure for top-level objects.

### DIFF
--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -5,3 +5,59 @@ objects.
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import os
+import glob
+
+import pysam
+
+import ga4gh.protocol as protocol
+
+
+class ReadGroupSet(object):
+    """
+    Class representing a logical collection ReadGroups.
+    """
+    def __init__(self, id_, dataDir):
+        self._id = id_
+        self._dataDir = dataDir
+        self._readGroups = []
+        for fileType in ["sam", "bam"]:
+            pattern = "*.{}".format(fileType)
+            for path in glob.glob(os.path.join(self._dataDir, pattern)):
+                filename = os.path.split(path)[1]
+                localId = filename.split(".")[0]
+                readGroupId = "{}:{}".format(self._id, localId)
+                readGroup = ReadGroup(readGroupId, path)
+                self._readGroups.append(readGroup)
+
+    def toProtocolElement(self):
+        """
+        Returns the GA4GH protocol representation of this ReadGroupSet.
+        """
+        readGroupSet = protocol.GAReadGroupSet()
+        readGroupSet.id = self._id
+        readGroupSet.readGroups = [
+            readGroup.toProtocolElement() for readGroup in self._readGroups]
+        # TODO fill out details
+        return readGroupSet
+
+
+class ReadGroup(object):
+    """
+    Class representing a ReadGroup. A ReadGroup is all the data that's
+    processed the same way by the sequencer.  There are typically 1-10
+    ReadGroups in a ReadGroupSet.
+    """
+    def __init__(self, id_, dataFile):
+        self._id = id_
+        self._samFile = pysam.AlignmentFile(dataFile)
+
+    def toProtocolElement(self):
+        """
+        Returns the GA4GH protocol representation of this ReadGroup.
+        """
+        readGroup = protocol.GAReadGroup()
+        readGroup.id = self._id
+        # TODO fill out details
+        return readGroup

--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -5,3 +5,61 @@ objects.
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import os
+import glob
+
+import pysam
+
+import ga4gh.protocol as protocol
+
+
+class ReferenceSet(object):
+    """
+    Class representing ReferenceSets. A ReferenceSet is a set of
+    References which typically comprise a reference assembly, such as
+    GRCh38.
+    """
+    def __init__(self, id_, dataDir):
+        self._id = id_
+        self._dataDir = dataDir
+        self._referenceIdMap = {}
+        # TODO get metadata from a file within dataDir? How else will we
+        # fill in the fields like ncbiTaxonId etc?
+        for relativePath in glob.glob(os.path.join(self._dataDir, "*.fa.gz")):
+            filename = os.path.split(relativePath)[1]
+            localId = filename.split(".")[0]
+            referenceId = "{}:{}".format(self._id, localId)
+            reference = Reference(referenceId, relativePath)
+            self._referenceIdMap[referenceId] = reference
+        self._referenceIds = sorted(self._referenceIdMap.keys())
+
+    def toProtocolElement(self):
+        """
+        Returns the GA4GH protocol representation of this ReferenceSet.
+        """
+        referenceSet = protocol.GAReferenceSet()
+        referenceSet.id = self._id
+        # TODO fill out details
+        return referenceSet
+
+
+class Reference(object):
+    """
+    Class representing References. A Reference is a canonical
+    assembled contig, intended to act as a reference coordinate space
+    for other genomic annotations. A single Reference might represent
+    the human chromosome 1, for instance.
+    """
+    def __init__(self, id_, dataFile):
+        self._id = id_
+        self._fastaFile = pysam.FastaFile(dataFile)
+
+    def toProtocolElement(self):
+        """
+        Returns the GA4GH protocol representation of this Reference.
+        """
+        reference = protocol.GAReference()
+        reference.id = self._id
+        # TODO fill out details
+        return reference

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -54,6 +54,16 @@ class VariantSet(object):
     """
     # TODO abstract details shared by wormtable and tabix based backends.
 
+    def toProtocolElement(self):
+        """
+        Converts this VariantSet into its GA4GH protocol equivalent.
+        """
+        protocolElement = protocol.GAVariantSet()
+        protocolElement.id = self._variantSetId  # TODO should be self._id
+        protocolElement.datasetId = "NotImplemented"
+        protocolElement.metadata = self.getMetadata()
+        return protocolElement
+
 
 class WormtableVariantSet(VariantSet):
     """

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -193,7 +193,8 @@ def searchCallSets(version):
 
 @app.route('/<version>/readgroupsets/search', methods=['POST'])
 def searchReadGroupSets(version):
-    raise frontendExceptions.PathNotFoundException()
+    return handleFlaskPostRequest(
+        version, flask.request, app.backend.searchReadGroupSets)
 
 
 @app.route('/<version>/reads/search', methods=['POST'])
@@ -203,7 +204,8 @@ def searchReads(version):
 
 @app.route('/<version>/referencesets/search', methods=['POST'])
 def searchReferenceSets(version):
-    raise frontendExceptions.PathNotFoundException()
+    return handleFlaskPostRequest(
+        version, flask.request, app.backend.searchReferenceSets)
 
 
 @app.route('/<version>/references/search', methods=['POST'])

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -31,6 +31,12 @@ class WormtableTestFixture(object):
     """
     def __init__(self):
         self.dataDir = tempfile.mkdtemp(prefix="ga4gh_wt")
+        self.variantsDir = os.path.join(self.dataDir, "variants")
+        self.referencesDir = os.path.join(self.dataDir, "references")
+        self.readsDir = os.path.join(self.dataDir, "reads")
+        subdirs = [self.variantsDir, self.referencesDir, self.readsDir]
+        for subdir in subdirs:
+            os.mkdir(subdir)
 
     def convertVariantSet(self, vcfFile):
         """
@@ -38,7 +44,7 @@ class WormtableTestFixture(object):
         the data directory.
         """
         variantSetid = vcfFile.split("/")[-1].split(".")[0]
-        wtDir = os.path.join(self.dataDir, variantSetid)
+        wtDir = os.path.join(self.variantsDir, variantSetid)
         # convert the vcf to wormtable format.
         cmd = ["vcf2wt", "-q", vcfFile, wtDir]
         subprocess.check_call(cmd)
@@ -93,11 +99,13 @@ class TestWormtableBackend(unittest.TestCase):
     def setUp(self):
         global _wormtableTestFixture
         self._dataDir = _wormtableTestFixture.dataDir
+        self._variantsDir = _wormtableTestFixture.variantsDir
         self._tables = {}
         self._chromIndexes = {}
         self._chromPosIndexes = {}
-        for relativePath in os.listdir(self._dataDir):
-            table = wt.open_table(os.path.join(self._dataDir, relativePath))
+        for relativePath in os.listdir(self._variantsDir):
+            table = wt.open_table(
+                os.path.join(self._variantsDir, relativePath))
             self._tables[relativePath] = table
             self._chromIndexes[relativePath] = table.open_index("CHROM")
             self._chromPosIndexes[relativePath] = table.open_index("CHROM+POS")

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -47,44 +47,50 @@ class TestFrontend(unittest.TestCase):
         assertHeaders(self.sendVariantSetsSearch('{"dataSetIds": [1, 2]}'))
         # TODO: Test other methods as they are implemented
 
+    def verifySearchRouting(self, path, getDefined=False):
+        """
+        Verifies that the specified path has the correct routing for a search
+        command. If getDefined is False we check to see if it returns the
+        correct status code.
+        """
+        versionedPath = utils.applyVersion(path)
+        self.assertEqual(415, self.app.post(versionedPath).status_code)
+        # OPTIONS should return success
+        self.assertEqual(200, self.app.options(versionedPath).status_code)
+        if not getDefined:
+            self.assertEqual(405, self.app.get(versionedPath).status_code)
+        # TODO disabling this test until we correctly implement error
+        # handling in the frontend.
+        # self.assertEqual(400, self.app.post(
+        #     path,
+        #     headers={'Content-type': 'application/json'}).status_code)
+
     def testRouteReferences(self):
         paths = ['/references/1', 'references/1/bases', 'referencesets/1']
         for path in paths:
             versionedPath = utils.applyVersion(path)
             self.assertEqual(404, self.app.get(versionedPath).status_code)
-        paths = ['/referencesets/search', '/references/search']
+        paths = ['/references/search']
         for path in paths:
             versionedPath = utils.applyVersion(path)
             self.assertEqual(404, self.app.get(versionedPath).status_code)
+        self.verifySearchRouting('/referencesets/search', True)
 
     def testRouteCallsets(self):
         path = utils.applyVersion('/callsets/search')
         self.assertEqual(404, self.app.post(path).status_code)
 
     def testRouteReads(self):
-        paths = ['/reads/search', '/readgroupsets/search']
+        paths = ['/reads/search']
         for path in paths:
             versionedPath = utils.applyVersion(path)
             self.assertEqual(404, self.app.post(versionedPath).status_code)
+        for path in ['/readgroupsets/search']:
+            self.verifySearchRouting(path)
 
     def testRouteVariants(self):
-        paths = ['/variantsets/search', '/variants/search']
-        for path in paths:
-            # POST gets routed to input checking
-            versionedPath = utils.applyVersion(path)
-            self.assertEqual(415, self.app.post(versionedPath).status_code)
-
-            # TODO disabling this test until we correctly implement error
-            # handling in the frontend.
-            # self.assertEqual(400, self.app.post(
-            #     path,
-            #     headers={'Content-type': 'application/json'}).status_code)
-
-            # OPTIONS should return success
-            self.assertEqual(200, self.app.options(versionedPath).status_code)
-
-            # GET is not defined (handled by default route)
-            self.assertEqual(405, self.app.get(versionedPath).status_code)
+        for path in ['/variantsets/search', '/variants/search']:
+            self.verifySearchRouting(path)
 
     def testVariantsSearch(self):
         response = self.sendVariantsSearch('{"variantSetIds": [1, 2]}')


### PR DESCRIPTION
This PR is intended to add initial support for the top level objects in the reference and read hierarchies. It adds to the existing infrastructure in the simplest and least intrusive way, and should not be seen as 'finished work'.

The biggest difference here from a user perspective is that I've changed the required structure of the input `dataDir`. This was assumed to contain variantSets, and must now contain three directories: `variants`, `reads` and `references`. This is not the structure that we ultimately want (references should be independent of datasets), but it will get us going for now. If we agree on this structure I'll update the `ga4gh-example-data` set so that it follows this new layout.

There is no testing of the new code, since we don't have any example or test data to test it with. I'll be opening some issues for this. I hope that we can develop the code required to handle these top level objects independently of the changes we'll need to deal with the whole hierarchy in #158.

