### PR TITLE
Delete cached coverage before computing coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ before_script:
 # under it that we want to run (and want to be able to run) as local tests
 script: 
   - flake8 tests ga4gh scripts
+  - coverage erase
   - nosetests --with-coverage --cover-package ga4gh
               --cover-inclusive --cover-min-percentage 80


### PR DESCRIPTION
This won't change how coverage is computed on Travis (presumably because there aren't any cached coverage files lying around in a fresh install), but it will change local numbers to be accurate when using `run_tests.py`

Issue #197