### PR TITLE
Htslib data driven tests

### DIFF
--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -459,7 +459,8 @@ class HtslibVariantSet(VariantSet):
         variant.start = record.start          # 0-based inclusive
         variant.end = record.stop             # 0-based exclusive
         variant.referenceBases = record.ref
-        variant.alternateBases = list(record.alts)
+        if record.alts is not None:
+            variant.alternateBases = list(record.alts)
         # record.filter and record.qual are also available, when supported
         # by GAVariant.
         for key, value in record.info.iteritems():
@@ -488,7 +489,7 @@ class HtslibVariantSet(VariantSet):
         if variantName is not None:
             raise NotImplementedError(
                 "Searching by variantName is not supported")
-        if len(callSetIds) != 0:
+        if callSetIds is not None:
             raise NotImplementedError(
                 "Specifying call set ids is not supported")
         if referenceName in self._chromFileMap:

--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -78,6 +78,14 @@ class DataDrivenTest(object):
         """
         raise NotImplementedError()
 
+    def assertEqual(self, a, b):
+        """
+        Tests if a an b are equal. If not, output an error and raise
+        an assertion error.
+        """
+        if a != b:
+            raise AssertionError("{} != {}".format(a, b))
+
     def testProtocolElementValid(self):
         protocolElement = self._gaObject.toProtocolElement()
         jsonDict = protocolElement.toJsonDict()

--- a/tests/datadriven/test_references.py
+++ b/tests/datadriven/test_references.py
@@ -50,4 +50,4 @@ class ReferenceSetTest(datadriven.DataDrivenTest):
 
     def testNumReferences(self):
         references = list(self._gaObject.getReferences())
-        assert len(self._idFastaFileMap) == len(references)
+        self.assertEqual(len(self._idFastaFileMap), len(references))


### PR DESCRIPTION
Initial POC for data driven tests in the HtslibVariantSet.  Adds the `self.assertEqual` method to the data driven tests, which might solve our issues with not using unittest.

This PR depends on #208.