### PR TITLE
Remove datadir arg

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -292,6 +292,12 @@ class AbstractBackend(object):
         self._responseValidation = responseValidation
 
 
+class EmptyBackend(AbstractBackend):
+    """
+    A GA4GH backend that contains no data.
+    """
+
+
 class SimulatedBackend(AbstractBackend):
     """
     A GA4GH backend backed by no data; used mostly for testing

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -11,11 +11,9 @@ import time
 import argparse
 import sys
 
-import ga4gh.backend as backend
 import ga4gh.client as client
 import ga4gh.protocol as protocol
 import ga4gh.converters as converters
-import ga4gh.datamodel.variants as variants
 import ga4gh.frontend as frontend
 
 
@@ -243,26 +241,11 @@ def addGlobalOptions(parser):
         "--port", "-P", default=8000, type=int,
         help="The port to listen on")
     parser.add_argument(
-        "--config", "-C", default='DefaultConfig', type=str,
+        "--config", "-c", default='DevelopmentConfig', type=str,
         help="The configuration to use")
     parser.add_argument(
-        "--config-file", "-F", type=str,
+        "--config-file", "-f", type=str, default=None,
         help="The configuration file to use")
-    parser.add_argument(
-        "dataDir",
-        help="The directory containing data")
-
-
-def addHtslibParser(subparsers):
-    parser = subparsers.add_parser(
-        "htslib",
-        description="Serve the API using a tabix based backend.",
-        help="Serve data from Htslib indexed VCF/BCFs")
-    parser.add_argument(
-        "dataDir",
-        help="The directory containing VCF/BCFs")
-    parser.set_defaults(variantSetClass=variants.HtslibVariantSet)
-    return parser
 
 
 def server_main(parser=None):
@@ -271,29 +254,8 @@ def server_main(parser=None):
             description="GA4GH reference server")
     addGlobalOptions(parser)
     args = parser.parse_args()
-    if 'dataDir' not in args:
-        parser.print_help()
-    else:
-        frontend.configure(args.config, args.config_file)
-        if args.dataDir == "simulated":
-            randomSeed = frontend.app.config[
-                "SIMULATED_BACKEND_RANDOM_SEED"]
-            numCalls = frontend.app.config[
-                "SIMULATED_BACKEND_NUM_CALLS"]
-            variantDensity = frontend.app.config[
-                "SIMULATED_BACKEND_VARIANT_DENSITY"]
-            numVariantSets = frontend.app.config[
-                "SIMULATED_BACKEND_NUM_VARIANT_SETS"]
-            theBackend = backend.SimulatedBackend(
-                randomSeed, numCalls, variantDensity, numVariantSets)
-        else:
-            theBackend = backend.FileSystemBackend(args.dataDir)
-        theBackend.setRequestValidation(
-            frontend.app.config["REQUEST_VALIDATION"])
-        theBackend.setResponseValidation(
-            frontend.app.config["RESPONSE_VALIDATION"])
-        frontend.app.backend = theBackend
-        frontend.app.run(host="0.0.0.0", port=args.port, debug=True)
+    frontend.configure(args.config, args.config_file)
+    frontend.app.run(host="0.0.0.0", port=args.port, debug=True)
 
 
 ##############################################################################

--- a/ga4gh/serverconfig.py
+++ b/ga4gh/serverconfig.py
@@ -16,10 +16,20 @@ class DefaultConfig(object):
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024  # 2MB
     REQUEST_VALIDATION = False
     RESPONSE_VALIDATION = False
+    DATA_SOURCE = "__EMPTY__"
+
+    # Options for the simulated backend.
     SIMULATED_BACKEND_RANDOM_SEED = 0
     SIMULATED_BACKEND_NUM_CALLS = 1
     SIMULATED_BACKEND_VARIANT_DENSITY = 0.5
     SIMULATED_BACKEND_NUM_VARIANT_SETS = 1
+
+
+class DevelopmentConfig(DefaultConfig):
+    """
+    Configuration used for development.
+    """
+    DATA_SOURCE = "ga4gh-example-data"
 
 
 class TestConfig(DefaultConfig):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,7 +16,9 @@ import ga4gh.client as client
 
 class TestNoInput(unittest.TestCase):
     """
-    Test the cli as if there was no input; print_help should be called
+    Test the cli as if there was no input; print_help should be called.
+    The development server is a special case here, as it works without
+    arguments.
     """
     def setUp(self):
         self.parser = StubArgumentParser(self)
@@ -34,9 +36,6 @@ class TestNoInput(unittest.TestCase):
 
     def testGa2SamNoInput(self):
         cli.ga2sam_main(self.parser)
-
-    def testServerNoInput(self):
-        cli.server_main(self.parser)
 
     def testCliNoInput(self):
         cli.client_main(self.parser)


### PR DESCRIPTION
This PR removes the mandatory DATADIR argument from the server CLI, and moves all configuration into the flask config space. This is an essential step towards deployability.

For development, we add a default configuration that we invoke from the CLI that makes the default data source ga4gh-example-data. This should make developers lives easy. We can override this with a config file specified on the command line though.

This will be updated and rebased once #212 has been merged. Feedback welcomed!