### PR TITLE
wheels WIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libdb-dev
+  - wget 'http://www.well.ox.ac.uk/~jk/wheelhouse.tar'
+  - tar -xvf wheelhouse.tar
 
 install:
-  - pip install -r requirements.txt
+  - pip install --use-wheel --find-links=wheelhouse/ -r requirements.txt
   - python setup.py install
 
 before_script:


### PR DESCRIPTION
On my local system installing into a new virtualenv off of this branch successfully skips the pysam compile step, which is the most timely step in our build.  These changes drop the build time on my system from around 5 minutes to under 30 seconds. 

Wheels are OS/arch dependent, to an extent.  The one that I built doesn't work on the Travis environment, which uses a 64 bit Ubuntu build.  We just need to get a wheel that the Travis environment finds acceptable, which might take a bit of guess-and-check (building the wheel on an identical Ubuntu environment would work).    The wheel we need can be created with the command `pip wheel pysam`.

We would also need to check in a new version of the wheel whenever pysam had changes we wanted to incorporate.

Questions: 
- is it acceptable to check in the wheelhouse to source control, as I've done here, or do we want to download it off of some remote server every time a branch is pushed to GitHub?
- do we want to use a wheelhouse for only pysam, all our required packages, or something in between?

Issue #71 