### PR TITLE
Replace samtools index runCommand with pysam call

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -207,4 +207,4 @@ class AlignmentFileTool(object):
             indexFilePath = "{}.{}".format(
                 outputFilePath, AlignmentFileConstants.BAI.lower())
             log("Creating index file '{}'".format(indexFilePath))
-            runCommand("samtools index {}".format(outputFilePath))
+            pysam.index(outputFilePath)


### PR DESCRIPTION
pysam provides the capability to call samtools methods directly...
we should use that instead of using shell commands!