### PR TITLE
Paging test moved from wormtable to simulated backend.

### DIFF
--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -95,6 +95,12 @@ class AbstractVariantSet(object):
         """
         raise NotImplementedError()
 
+    # TODO trivial implementation to pass unit tests, remove once proper
+    # implementation written in HtslibVariantSet (issue #286)
+    def getCallSets(self, name, startPosition):
+        for i in []:
+            yield i
+
 
 class SimulatedVariantSet(AbstractVariantSet):
     """
@@ -117,10 +123,6 @@ class SimulatedVariantSet(AbstractVariantSet):
     def getMetadata(self):
         ret = []
         return ret
-
-    def getCallSets(self, name, startPosition):
-        for i in []:
-            yield i
 
     def getVariants(self, referenceName, startPosition, endPosition,
                     variantName, callSetIds):

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,7 +1,7 @@
 """
-Tests for the backend objects. We instantiate local copies of the backends
-and invoke the entry points for the protocol methods. We do not set up
-any server processes or communicate over sockets.
+Tests for the backend objects. We instantiate local copies of
+the backends and invoke the entry points for the protocol methods.
+We do not set up any server processes or communicate over sockets.
 """
 from __future__ import division
 from __future__ import print_function
@@ -15,6 +15,7 @@ import unittest
 import itertools
 import subprocess
 
+import pysam
 import wormtable as wt
 
 import tests.utils as utils
@@ -22,6 +23,187 @@ import ga4gh.backend as backend
 import ga4gh.protocol as protocol
 
 
+def convertInfoValue(column, value):
+    """
+    Converts a value from the specified info column into the format
+    expected by the protocol.
+    """
+    if column.get_num_elements() == 1 or column.get_type() == wt.WT_CHAR:
+        ret = [str(value)]
+    else:
+        ret = [str(listElement) for listElement in value]
+    return ret
+
+
+class TestAbstractBackend(unittest.TestCase):
+    """
+    Provides testing harness for testing methods in AbstractBackend,
+    using an instance of the mock SimulatedBackend object.
+    """
+    def setUp(self):
+        self._backend = backend.SimulatedBackend(
+            numCalls=100, numVariantSets=10)
+        # TODO arbitrary values, pepper to taste
+
+    def resultIterator(
+            self, request, pageSize, searchMethod, ResponseClass, listMember):
+        """
+        Returns an iterator over the list of results from the specified
+        request.  All results are returned, and paging is handled
+        automatically.
+        """
+        notDone = True
+        request.pageSize = pageSize
+        while notDone:
+            # TODO validate the response there.
+            responseStr = searchMethod(request.toJsonString())
+            response = ResponseClass.fromJsonString(responseStr)
+            objectList = getattr(response, listMember)
+            self.assertLessEqual(len(objectList), pageSize)
+            for obj in objectList:
+                yield obj
+            notDone = response.nextPageToken is not None
+            request.pageToken = response.nextPageToken
+
+    def getVariantSets(self, pageSize=100):
+        """
+        Returns an iterator over the variantSets, abstracting away
+        the details of the pageSize.
+        """
+        request = protocol.GASearchVariantSetsRequest()
+        return self.resultIterator(
+            request, pageSize, self._backend.searchVariantSets,
+            protocol.GASearchVariantSetsResponse, "variantSets")
+
+    def getVariants(
+            self, variantSetIds, referenceName, start=0, end=2 ** 32,
+            pageSize=100, callSetIds=None):
+        """
+        Returns an iterator over the specified list of variants,
+        abstracting out paging details.
+        """
+        request = protocol.GASearchVariantsRequest()
+        request.variantSetIds = variantSetIds
+        request.referenceName = referenceName
+        request.start = start
+        request.end = end
+        request.callSetIds = callSetIds
+        return self.resultIterator(
+            request, pageSize, self._backend.searchVariants,
+            protocol.GASearchVariantsResponse, "variants")
+
+    def getCallSets(self, variantSetId, pageSize=100):
+        """
+        Returns an iterator over the callsets in a specified
+        variant set.
+        """
+        request = protocol.GASearchCallSetsRequest()
+        request.variantSetIds = [variantSetId]
+        return self.resultIterator(
+            request, pageSize, self._backend.searchCallSets,
+            protocol.GASearchCallSetsResponse, "callSets")
+
+    def testGetVariantSets(self):
+        sortedVariantSetsFromGetter = sorted(self._backend.getVariantSets())
+        sortedVariantSetMapValues = sorted(
+            self._backend._variantSetIdMap.values())
+        self.assertEqual(
+            sortedVariantSetMapValues, sortedVariantSetsFromGetter)
+
+    def testGetVariantSetIdMap(self):
+        variantSetMapFromGetter = self._backend.getVariantSetIdMap()
+        variantSetMap = self._backend._variantSetIdMap
+        self.assertEqual(variantSetMapFromGetter, variantSetMap)
+
+    def testGetCallSetIdMap(self):
+        callSetMapFromGetter = self._backend.getCallSetIdMap()
+        callSetMap = self._backend._callSetIdMap
+        self.assertEqual(callSetMapFromGetter, callSetMap)
+
+    def testParsePageToken(self):
+        goodPageToken = "12:34:567:8:9000"
+        parsedToken = self._backend.parsePageToken(goodPageToken, 5)
+        self.assertEqual(parsedToken[2], 567)
+
+    def testRunSearchRequest(self):
+        request = protocol.GASearchVariantSetsRequest()
+        responseStr = self._backend.runSearchRequest(
+            request.toJsonString(), protocol.GASearchVariantSetsRequest,
+            protocol.GASearchVariantSetsResponse, "variantSets",
+            self._backend.variantSetsGenerator)
+        response = protocol.GASearchVariantSetsResponse.fromJsonString(
+            responseStr)
+        self.assertTrue(
+            isinstance(response, protocol.GASearchVariantSetsResponse))
+
+    def testSearchVariantSets(self):
+        request = protocol.GASearchVariantSetsRequest()
+        responseStr = self._backend.searchVariantSets(request.toJsonString())
+        response = protocol.GASearchVariantSetsResponse.fromJsonString(
+            responseStr)
+        self.assertTrue(
+            isinstance(response, protocol.GASearchVariantSetsResponse))
+
+    def testSearchVariants(self):
+        request = protocol.GASearchVariantsRequest()
+        responseStr = self._backend.searchVariants(request.toJsonString())
+        response = protocol.GASearchVariantsResponse.fromJsonString(
+            responseStr)
+        self.assertTrue(
+            isinstance(response, protocol.GASearchVariantsResponse))
+
+    def testSearchCallSets(self):
+        request = protocol.GASearchCallSetsRequest()
+        responseStr = self._backend.searchCallSets(request.toJsonString())
+        response = protocol.GASearchCallSetsResponse.fromJsonString(
+            responseStr)
+        self.assertTrue(
+            isinstance(response, protocol.GASearchCallSetsResponse))
+
+    def testVariantSetPagination(self):
+        results = []
+        for pageSize in range(1, 100):
+            variantSetIds = [
+                variantSet.id for variantSet in self.getVariantSets(
+                    pageSize=pageSize)]
+            results.append(variantSetIds)
+        for result in results[1:]:
+            self.assertEqual(result, results[0])
+
+
+class TestFileSystemBackend(TestAbstractBackend):
+    """
+    Tests proper initialization of the filesystem backend using indexed
+    files in the tests/data directory.
+    """
+    def setUp(self):
+        self._dataDir = os.path.join("tests", "data")
+        self._variantsDir = os.path.join(self._dataDir, "variants")
+        self._vcfs = {}
+        self._variants = []
+        self._referenceNames = set()
+        self._chromFileMap = {}
+        for relativePath in os.listdir(self._variantsDir):
+            pathToFiles = os.path.join(self._variantsDir, relativePath)
+            self._vcfs[relativePath] = []
+            for vcfFile in glob.glob(os.path.join(
+                    pathToFiles, "*.vcf.gz")):
+                self._chromFileMap[relativePath] = {}
+                self._vcfs[relativePath].append(vcfFile)
+                vcf = pysam.VariantFile(filename=vcfFile)
+                for chrom in vcf.index:
+                    self._chromFileMap[relativePath][chrom] = vcf
+        self._backend = backend.FileSystemBackend(self._dataDir)
+
+    def testVariantSetIds(self):
+        variantSets = [variantSet for variantSet in self.getVariantSets()]
+        self.assertEqual(len(variantSets), len(self._vcfs))
+        ids = set(variantSet.id for variantSet in variantSets)
+        self.assertEqual(ids, set(self._vcfs.keys()))
+
+
+# Everything below here is wormtable related, can be removed on resolving
+# Issue #210 (Removing wormtable dependency)
 class WormtableTestFixture(object):
     """
     Class representing the test fixtures used for the wormtable tests.
@@ -81,19 +263,7 @@ def tearDown():
     _wormtableTestFixture.tearDown()
 
 
-def convertInfoValue(column, value):
-    """
-    Converts a value from the specified info column into the format
-    expected by the protocol.
-    """
-    if column.get_num_elements() == 1 or column.get_type() == wt.WT_CHAR:
-        ret = [str(value)]
-    else:
-        ret = [str(listElement) for listElement in value]
-    return ret
-
-
-class TestWormtableBackend(unittest.TestCase):
+class TestWormtableBackend(TestAbstractBackend):
 
     def setUp(self):
         global _wormtableTestFixture
@@ -114,68 +284,11 @@ class TestWormtableBackend(unittest.TestCase):
         for table in self._tables.values():
             table.close()
 
-    def resultIterator(
-            self, request, pageSize, searchMethod, ResponseClass, listMember):
-        """
-        Returns an iterator over the list of results from the specified
-        request.  All results are returned, and paging is handled
-        automatically.
-        """
-        notDone = True
-        request.pageSize = pageSize
-        while notDone:
-            # TODO validate the response there.
-            responseStr = searchMethod(request.toJsonString())
-            response = ResponseClass.fromJsonString(responseStr)
-            objectList = getattr(response, listMember)
-            self.assertLessEqual(len(objectList), pageSize)
-            for obj in objectList:
-                yield obj
-            notDone = response.nextPageToken is not None
-            request.pageToken = response.nextPageToken
-
-    def getVariantSets(self, pageSize=100):
-        """
-        Returns an iterator over the variantSets, abstracting away the details
-        of the pageSize.
-        """
-        request = protocol.GASearchVariantSetsRequest()
-        return self.resultIterator(
-            request, pageSize, self._backend.searchVariantSets,
-            protocol.GASearchVariantSetsResponse, "variantSets")
-
     def getVariantSetIds(self):
         """
         Return all variantSetIds.
         """
         return [variantSet.id for variantSet in self.getVariantSets()]
-
-    def getVariants(
-            self, variantSetIds, referenceName, start=0, end=2 ** 32,
-            pageSize=100, callSetIds=[]):
-        """
-        Returns an iterator over the specified list of variants, abstracting
-        out paging details.
-        """
-        request = protocol.GASearchVariantsRequest()
-        request.variantSetIds = variantSetIds
-        request.referenceName = referenceName
-        request.start = start
-        request.end = end
-        request.callSetIds = callSetIds
-        return self.resultIterator(
-            request, pageSize, self._backend.searchVariants,
-            protocol.GASearchVariantsResponse, "variants")
-
-    def getCallSets(self, variantSetId, pageSize=100):
-        """
-        Returns an iterator over the callsets in a specified variant set.
-        """
-        request = protocol.GASearchCallSetsRequest()
-        request.variantSetIds = [variantSetId]
-        return self.resultIterator(
-            request, pageSize, self._backend.searchCallSets,
-            protocol.GASearchCallSetsResponse, "callSets")
 
     def getReferenceNames(self, variantSetId):
         """
@@ -247,7 +360,7 @@ class TestWormtableBackend(unittest.TestCase):
         return callSetIds
 
 
-class TestVariantSets(TestWormtableBackend):
+class TestWormtableVariantSets(TestWormtableBackend):
     """
     Test the searchVariantSets end point
     """
@@ -270,7 +383,7 @@ class TestVariantSets(TestWormtableBackend):
         self.assertEqual(ids, set(self._tables.keys()))
 
 
-class TestVariants(TestWormtableBackend):
+class TestWormtableVariants(TestWormtableBackend):
     """
     Tests the searchVariants end point.
     """
@@ -448,7 +561,7 @@ class TestVariants(TestWormtableBackend):
                             pageSize=pageSize)
 
 
-class TestCallSets(TestWormtableBackend):
+class TestWormtableCallSets(TestWormtableBackend):
     """
     Tests the searchCallSets end point.
     """


### PR DESCRIPTION
New `TestAbstractBackend` class introduced in `unit/test_backends.py`,
gathers together backend implementation independent logic,
`TestSimulatedBackend` and `TestWormtableBackend` classes inherit from it.
`TestPaging` is a new subclass of `TestSimulatedBackend`. This setup
should provide a clean migration path out of Wormtable for testing backend.

 For now, I could only pull `TestVariantSets.testPagination()` out of 
`TestWormtableBackend`, as `SimulatedBackend` only provides mock objects
for `VariantSet`s. As `SimulatedBackend` grows, the other tests in `test_backends.py`
can be pulled out as well.

I could technically pull out `TestVariantSets.testIds()` now as well, but this doesn't fit
the new `TestPaging` class's focus on pagination. 

Addresses issue #241