### PR TITLE
Typo fixed in README deploy instructions.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -157,7 +157,7 @@ To deploy on Apache on Debian/Ubuntu platforms, do the following.
 
 - Restart Apache::
 
-  $ sudo service apache restart
+  $ sudo service apache2 restart
 
 - Test the installation by pointing a web-browser at the root URL; for example,
   to test on the installation server use::


### PR DESCRIPTION
Restart server with `sudo service apache2 restart` on default apache2 install on ubuntu.