### PR TITLE
Adaptive pagesize and max request size.

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -6,6 +6,9 @@ you need to update the GA4GH protocol classes, please run the script
 on the appropriate schema version.
 """
 from protocol import ProtocolElement
+from protocol import SearchRequest
+from protocol import SearchResponse
+
 import avro.schema
 
 version = '0.5.1'
@@ -890,7 +893,7 @@ coordinate space for comparing reference-aligned experimental data.
         self.sourceURI = None
 
 
-class GASearchCallSetsRequest(ProtocolElement):
+class GASearchCallSetsRequest(SearchRequest):
     """
 This request maps to the body of `POST /callsets/search` as JSON.
     """
@@ -925,7 +928,7 @@ This request maps to the body of `POST /callsets/search` as JSON.
         self.variantSetIds = []
 
 
-class GASearchCallSetsResponse(ProtocolElement):
+class GASearchCallSetsResponse(SearchResponse):
     """
 This is the response from `POST /callsets/search` expressed as JSON.
     """
@@ -947,6 +950,7 @@ null, "doc": "", "type": ["null", "string"], "name": "name"}, {"doc":
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "callSets"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -969,7 +973,7 @@ null, "doc": "", "type": ["null", "string"], "name": "name"}, {"doc":
         self.nextPageToken = None
 
 
-class GASearchReadGroupSetsRequest(ProtocolElement):
+class GASearchReadGroupSetsRequest(SearchRequest):
     """
 This request maps to the body of `POST /readgroupsets/search` as JSON.
     """
@@ -1004,7 +1008,7 @@ This request maps to the body of `POST /readgroupsets/search` as JSON.
         self.pageToken = None
 
 
-class GASearchReadGroupSetsResponse(ProtocolElement):
+class GASearchReadGroupSetsResponse(SearchResponse):
     """
 This is the response from `POST /readgroupsets/search` expressed as JSON.
     """
@@ -1049,6 +1053,7 @@ null, "doc": "", "type": ["null", "string"], "name": "version"}],
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "readGroupSets"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -1071,7 +1076,7 @@ null, "doc": "", "type": ["null", "string"], "name": "version"}],
         self.readGroupSets = []
 
 
-class GASearchReadsRequest(ProtocolElement):
+class GASearchReadsRequest(SearchRequest):
     """
 This request maps to the body of `POST /reads/search` as JSON.
 
@@ -1117,7 +1122,7 @@ specified, all `GAReadGroup`s must be aligned to the same `GAReferenceSet`.
         self.start = 0
 
 
-class GASearchReadsResponse(ProtocolElement):
+class GASearchReadsResponse(SearchResponse):
     """
 This is the response from `POST /reads/search` expressed as JSON.
     """
@@ -1165,6 +1170,7 @@ false, "doc": "", "type": ["null", "boolean"], "name":
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "alignments"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -1187,7 +1193,7 @@ false, "doc": "", "type": ["null", "boolean"], "name":
         self.nextPageToken = None
 
 
-class GASearchReferenceSetsRequest(ProtocolElement):
+class GASearchReferenceSetsRequest(SearchRequest):
     """
 This request maps to the body of `POST /referencesets/search`
 as JSON.
@@ -1227,7 +1233,7 @@ as JSON.
         self.pageToken = None
 
 
-class GASearchReferenceSetsResponse(ProtocolElement):
+class GASearchReferenceSetsResponse(SearchResponse):
     """
 This is the response from `POST /referencesets/search`
 expressed as JSON.
@@ -1252,6 +1258,7 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "referenceSets"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -1274,7 +1281,7 @@ null, "doc": "", "type": ["null", "string"], "name": "sourceURI"},
         self.referenceSets = []
 
 
-class GASearchReferencesRequest(ProtocolElement):
+class GASearchReferencesRequest(SearchRequest):
     """
 This request maps to the body of `POST /references/search`
 as JSON.
@@ -1310,7 +1317,7 @@ as JSON.
         self.pageToken = None
 
 
-class GASearchReferencesResponse(ProtocolElement):
+class GASearchReferencesResponse(SearchResponse):
     """
 This is the response from `POST /references/search` expressed as JSON.
     """
@@ -1332,6 +1339,7 @@ null, "doc": "", "type": ["null", "int"], "name": "ncbiTaxonId"}]},
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "references"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -1354,7 +1362,7 @@ null, "doc": "", "type": ["null", "int"], "name": "ncbiTaxonId"}]},
         self.references = []
 
 
-class GASearchVariantSetsRequest(ProtocolElement):
+class GASearchVariantSetsRequest(SearchRequest):
     """
 This request maps to the body of `POST /variantsets/search` as JSON.
     """
@@ -1387,7 +1395,7 @@ This request maps to the body of `POST /variantsets/search` as JSON.
         self.pageToken = None
 
 
-class GASearchVariantSetsResponse(ProtocolElement):
+class GASearchVariantSetsResponse(SearchResponse):
     """
 This is the response from `POST /variantsets/search` expressed as JSON.
     """
@@ -1411,6 +1419,7 @@ This is the response from `POST /variantsets/search` expressed as JSON.
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "variantSets"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):
@@ -1433,7 +1442,7 @@ This is the response from `POST /variantsets/search` expressed as JSON.
         self.variantSets = []
 
 
-class GASearchVariantsRequest(ProtocolElement):
+class GASearchVariantsRequest(SearchRequest):
     """
 This request maps to the body of `POST /variants/search` as JSON.
     """
@@ -1481,7 +1490,7 @@ This request maps to the body of `POST /variants/search` as JSON.
         self.variantSetIds = []
 
 
-class GASearchVariantsResponse(ProtocolElement):
+class GASearchVariantsResponse(SearchResponse):
     """
 This is the response from `POST /variants/search` expressed as JSON.
     """
@@ -1517,6 +1526,7 @@ This is the response from `POST /variants/search` expressed as JSON.
 """
     schema = avro.schema.parse(_schemaSource)
     requiredFields = set([])
+    _valueListName = "variants"
 
     @classmethod
     def isEmbeddedType(cls, fieldName):

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -175,6 +175,7 @@ def configure(configFile=None, baseConfig="ProductionConfig", extraConfig={}):
     theBackend.setRequestValidation(app.config["REQUEST_VALIDATION"])
     theBackend.setResponseValidation(app.config["RESPONSE_VALIDATION"])
     theBackend.setDefaultPageSize(app.config["DEFAULT_PAGE_SIZE"])
+    theBackend.setMaxResponseLength(app.config["MAX_RESPONSE_LENGTH"])
     app.backend = theBackend
 
 

--- a/ga4gh/serverconfig.py
+++ b/ga4gh/serverconfig.py
@@ -14,6 +14,7 @@ class BaseConfig(object):
     Simplest default server configuration.
     """
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024  # 2MB
+    MAX_RESPONSE_LENGTH = 1024 * 1024  # 1MB
     REQUEST_VALIDATION = False
     RESPONSE_VALIDATION = False
     DEFAULT_PAGE_SIZE = 100

--- a/server_benchmark.py
+++ b/server_benchmark.py
@@ -20,7 +20,7 @@ import guppy
 
 
 class HeapProfilerBackend(ga4gh.backend.FileSystemBackend):
-    def __init__(self, dataDir, variantSetClass):
+    def __init__(self, dataDir):
         super(HeapProfilerBackend, self).__init__(dataDir)
         self.profiler = guppy.hpy()
 

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -129,7 +129,7 @@ class TestAbstractBackend(unittest.TestCase):
         request = protocol.GASearchVariantSetsRequest()
         responseStr = self._backend.runSearchRequest(
             request.toJsonString(), protocol.GASearchVariantSetsRequest,
-            protocol.GASearchVariantSetsResponse, "variantSets",
+            protocol.GASearchVariantSetsResponse,
             self._backend.variantSetsGenerator)
         response = protocol.GASearchVariantSetsResponse.fromJsonString(
             responseStr)


### PR DESCRIPTION
There are some serious issues with the current paging implementation:

1. It is trivial to perform a DOS/memory starvation attack. Simply provide a very large page size, and we will blindly try to fill it up until memory runs out.
2. There is no easy way to control latency. The only knob we have is the pageSize, but this is very crude as not all obejcts are equal. The pageSize controls the number of objects a page contains, _not_ the absolute size of the page in terms of bytes. Since objects like `Variant` can contain an arbitrarily large number of embedded objects (`Call` in the case of `Variant`) there's no way to know just how much memory we require.

Problem (1) could conceivably be tackled just by using the pageSize, but it would always be slightly tricky (what if there was 100k samples in the VCF?).  We could specify a MAX_PAGE_SIZE configuration variable, for example, but an administrator would have to work out roughly how much memory each object would require in worst-case and then figure out how many of these would correspond to a reasonable amount of memory. This puts a burden on the server admin, and is error prone. Problem (2) could also be tackled using this approach, but it's also quite tricky and error prone.

This is all a bit of a waste of time though, since all we really want to do is put a limit on the amount of *memory* each request is allowed to consume. This has the effect of solving (1) immediately, since an administrator can effectively cap the memory consumption per request. We also solve (2) which is good  for clients also, since they no longer need to worry about setting the appropriate page size to handle latency. The client knows they will be sent back appropriate sized packets of data, and does not need to worry about how to calculate the best page size for a given type of data. 

This PR adds a `MAX_RESPONSE_LENGTH` configuration variable, and sequentially encodes the JSON. Below we compare the time and memory requirements for requesting all calls in a range of 1000G data using a standard page size of 100 in the current master, and with a `MAX_RESPONSE_SIZE` of 1M in the current PR. 

Before:
```
$ /usr/bin/time -v python server_benchmark.py -c'*' --repeatLimit=1 --pageLimit=1000 1000g_2011.wt
31.87
        Command being timed: "python server_benchmark.py -c* --repeatLimit=1 --pageLimit=1000 1000g_2011.wt"
        User time (seconds): 32.13
        System time (seconds): 0.61
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:32.81
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 422648
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 258505
        Voluntary context switches: 1
        Involuntary context switches: 64
        Swaps: 0
        File system inputs: 0
        File system outputs: 48
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
After:
```
$ /usr/bin/time -v python server_benchmark.py -c'*' --repeatLimit=1 --pageLimit=1000 1000g_2011.wt
20.69
        Command being timed: "python server_benchmark.py -c* --repeatLimit=1 --pageLimit=1000 1000g_2011.wt"
        User time (seconds): 21.00
        System time (seconds): 0.56
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:21.61
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 75784
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 251632
        Voluntary context switches: 1
        Involuntary context switches: 62
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

We see we have reduced the CPU time by about 1/3 and reduced the memory footprint from ~420M to ~75M. This would seem like a clear win, and you might be wondering why I'm going to so much trouble to justify this change. There was a long discussion on this in #10, and there is the question of whether we should be making optimisations like this in the reference implementation.

So, pros:
1. We are (more) secure against memory starvation attacks.
2. We can control end-to-end latency much better.
3. Admins can get much better control over the memory usage of servers.
4. We are substantially faster and use less memory (over default page sizes on 1000G data).

Cons:
1. We break layering a little, and have some hand-written JSON encoding.

This PR is a proposal, and might be controversial. If people generally like it I'll update with some test cases for the new functionality.