### PR TITLE
Simple fix for variants-search.

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -362,12 +362,19 @@ class SearchVariantsRunner(AbstractSearchRunner):
         self._setRequest(request, args)
 
     def run(self):
-        if self._minimalOutput:
-            self._run(self._httpClient.searchVariants, 'id')
-        else:
-            results = self._httpClient.searchVariants(self._request)
-            for result in results:
-                self.printVariant(result)
+        # TODO this is a hack until we make a nicer interface to deal with
+        # multiple requests. The server does not support multiple values
+        # so we send of sequential requests instead.
+        request = self._request
+        variantSetIds = request.variantSetIds
+        for variantSetId in variantSetIds:
+            request.variantSetIds = [variantSetId]
+            if self._minimalOutput:
+                self._run(self._httpClient.searchVariants, 'id')
+            else:
+                results = self._httpClient.searchVariants(self._request)
+                for result in results:
+                    self.printVariant(result)
 
     def printVariant(self, variant):
         """

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -117,7 +117,10 @@ class TestAbstractBackend(unittest.TestCase):
             isinstance(response, protocol.GASearchVariantSetsResponse))
 
     def testSearchVariants(self):
+        variantSetIds = [
+            variantSet.id for variantSet in self.getVariantSets(pageSize=1)]
         request = protocol.GASearchVariantsRequest()
+        request.variantSetIds = variantSetIds[:1]
         responseStr = self._backend.searchVariants(request.toJsonString())
         response = protocol.GASearchVariantsResponse.fromJsonString(
             responseStr)

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -57,13 +57,15 @@ class TestFrontend(unittest.TestCase):
             versionedPath, headers=headers,
             data=request.toJsonString())
 
-    def sendVariantsSearch(
-            self, variantSetIds=[""], referenceName="", start=0, end=0):
+    def sendVariantsSearch(self):
+        response = self.sendVariantSetsSearch()
+        variantSets = protocol.GASearchVariantSetsResponse().fromJsonString(
+            response.data).variantSets
         request = protocol.GASearchVariantsRequest()
-        request.variantSetIds = variantSetIds
-        request.referenceName = referenceName
-        request.start = start
-        request.end = end
+        request.variantSetIds = [variantSets[0].id]
+        request.referenceName = "1"
+        request.start = 0
+        request.end = 1
         return self.sendRequest('/variants/search', request)
 
     def sendVariantSetsSearch(self, datasetIds=[""]):
@@ -165,7 +167,7 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         responseData = protocol.GASearchVariantsResponse.fromJsonString(
             response.data)
-        self.assertEqual(responseData.variants, [])
+        self.assertEqual(len(responseData.variants), 1)
 
     def testVariantSetsSearch(self):
         response = self.sendVariantSetsSearch()


### PR DESCRIPTION
This is a straightforward fix for a logic bug in the variants/search method. Issue #301 states that this should be fixed by reusing the code from reads/search. However, this proved to be a little complex, and it seemed better to fix this bug quickly in a simple way.

We have also reduced to handling exactly one variant set only. The existing implementation was incorrect (see issue #180), and we had almost no test coverage on the multi-container case, so it seemed better to explicitly only support the case that works.

This  solves #180.
