### PR TITLE
Added data summary for reads.

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -42,6 +42,12 @@ class AbstractBackend(object):
         """
         return list(self._variantSetIdMap.values())
 
+    def getReadGroupSets(self):
+        """
+        Returns the list of ReadGroupSets in this backend.
+        """
+        return list(self._readGroupSetIdMap.values())
+
     def parsePageToken(self, pageToken, numValues):
         """
         Parses the specified pageToken and returns a list of the specified

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -75,6 +75,10 @@ class AbstractReadGroupSet(object):
         self._id = id_
         self._readGroups = []
 
+    def getId(self):
+        # TODO move into the superclass
+        return self._id
+
     def getReadGroups(self):
         """
         Returns the read groups in this read group set

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -128,15 +128,17 @@ class ServerStatus(object):
         urls.sort()
         return urls
 
-    def getVariantSetSummaries(self):
+    def getVariantSets(self):
         """
-        Returns a list of (variantSetId, numVariants) tuples for this
-        server.
+        Returns the list of variant sets for this server.
         """
-        ret = []
-        for variantSet in app.backend.getVariantSets():
-            ret.append((variantSet.getId(), str(variantSet.getNumVariants())))
-        return ret
+        return app.backend.getVariantSets()
+
+    def getReadGroupSets(self):
+        """
+        Returns the list of ReadGroupSets for this server.
+        """
+        return app.backend.getReadGroupSets()
 
 
 def configure(configFile=None, baseConfig="ProductionConfig", extraConfig={}):

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -40,15 +40,27 @@
         </div>
         <div>
             <h3>Data</h3>
+            <h4>VariantSets</h4>
             <table>
-                <th>VariantSetId</th>
-                <th>NumVariants</th>
-                {% for variantSetId, numVariants in info.getVariantSetSummaries() %}
+                {% for variantSet in info.getVariantSets() %}
                 <tr>
-                    <td>{{ variantSetId }}</td>
-                    <td>{{ numVariants }}</td>
+                    <td>{{ variantSet.getId() }}</td>
                 </tr>
                 {% endfor %}
+            </table>
+            <h4>ReadGroupSets</h4>
+            <table>
+                {% for readGroupSet in info.getReadGroupSets() %}
+                <tr>
+                    <td>{{ readGroupSet.getId() }}</td>
+                </tr>
+                    {% for readGroup in readGroupSet.getReadGroups() %}
+                <tr>
+                    <td></td>
+                    <td>{{ readGroup.getId() }}</td>
+                </tr>
+                {% endfor %}
+            {% endfor %}
             </table>
         </div>
     </body>


### PR DESCRIPTION
This updates the info frontpage to include information on readgroupsets. Here is a snapshot:
```
GA4GH reference server 0.1.0a2
Protocol version 0.5.1
Operations availableMethod	Path
POST	/v0.5.1/callsets/search
POST	/v0.5.1/readgroupsets/search
POST	/v0.5.1/reads/search
GET	/v0.5.1/references/<id>
GET	/v0.5.1/references/<id>/bases
POST	/v0.5.1/references/search
GET	/v0.5.1/referencesets/<id>
POST	/v0.5.1/referencesets/search
POST	/v0.5.1/variants/search
POST	/v0.5.1/variantsets/search

Uptime
 Running since a second ago (14:49:27 31 Mar 2015) 
ConfigurationKey	Value
DEBUG	True
REQUEST_VALIDATION	False
RESPONSE_VALIDATION	True

Data
VariantSets

1kg-phase1
1kg-phase3

ReadGroupSets

low-coverage
	low-coverage:HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522
	low-coverage:HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522
	low-coverage:HG00534.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522
```

It's not very pretty, but it does give useful information.

I've also removed the `numVariants` bit, as we can't calculate this at the moment for VCFs and it would be confusing to leave it as 0.