### PR TITLE
Generalised the datamodel file system code.

### DIFF
--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -157,7 +157,7 @@ class ObjectNotFoundException(NotFoundException):
     message = "The requested object was not found"
 
 
-class VariantSetNotFound(NotFoundException):
+class VariantSetNotFoundException(NotFoundException):
     def __init__(self, variantSetId):
         self.message = "The requested VariantSet '{}' was not found".format(
             variantSetId)

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -11,7 +11,7 @@ import ga4gh.datamodel as datamodel
 import ga4gh.exceptions as exceptions
 
 
-class TestPysamSanitizer(datamodel.PysamSanitizer, unittest.TestCase):
+class TestPysamSanitizer(datamodel.PysamDatamodelMixin, unittest.TestCase):
     """
     Test the pysam sanitizer
     """


### PR DESCRIPTION
Addresses issue #232. 

The idea here is push code that is common to variants and the reads datamodel code into a new mixin,  `PysamDatamodelMixin`. 

Also fixes a bug in the exceptions for missing VariantSets.