### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git
+.dockerignore
+*.swp

--- a/.whiskey/action_hooks/pre-build
+++ b/.whiskey/action_hooks/pre-build
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# This file is a pre-build hook executed by mod_wsgi-docker
+# More info on hooks at:
+# https://github.com/GrahamDumpleton/mod_wsgi-docker/blob/master/2.7/build.sh
+
+# Add the current directory (/app) to requirements.txt
+# This causes mod_wsgi_docker to install the local directory with pip
+echo "-e ." >> /app/requirements.txt
+
+# Copy application.wsgi into the location mod-wsgi_docker expects it
+cp /app/deploy/application.wsgi /app/ga4gh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+############################################################
+## Dockerfile to build the ga4gh server on mod_wsgi-express
+## Configurable to use a local dataset
+## Based on mod_wsgi-docker
+## Results of this build are available from Dockerhub as afirth/ga4gh_server_apache:prod
+############################################################
+FROM grahamdumpleton/mod-wsgi-docker:python-2.7-onbuild
+
+# File Author / Maintainer
+MAINTAINER Alastair Firth
+
+# Place the config, if an existing config is not in place
+ADD deploy/config.py /app/ga4gh/docker_config.py
+RUN cp --no-clobber /app/ga4gh/docker_config.py /app/ga4gh/config.py
+
+# Pass '-e GA4GH_DATA_SOURCE=/container/data/path' and '-v /host/data/path:/container/data/path:ro' to docker run to mount local data
+# See docs for more info
+
+CMD [ "--working-directory", "ga4gh", \
+      "--log-to-terminal", \
+      "ga4gh/application.wsgi" ]

--- a/deploy/application.wsgi
+++ b/deploy/application.wsgi
@@ -1,0 +1,5 @@
+# This file is copied into place by the .whiskey/action_hooks/pre-build hook during Docker build
+
+from ga4gh.frontend import app as application
+import ga4gh.frontend as frontend
+frontend.configure("/app/ga4gh/config.py")

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -1,0 +1,11 @@
+# This file needs to be copied to /app/ga4gh/config.py by default
+import os
+
+#TODO this logic could move to frontend.configure() or BaseConfig
+# For docker, if/when a default is set in serverconfig.py, run -v /localdata:/default-path
+# If the env variable GA4GH_DATA_SOURCE is set, use that path. Otherwise, use the default path
+DATA_SOURCE = os.getenv('GA4GH_DATA_SOURCE', "/ga4gh-example-data")
+
+# If the env variable GA4GH_DEBUG is set, use that. Otherwise, use the empty string (False)
+# Enable with True
+DEBUG = os.getenv('GA4GH_DEBUG', "")

--- a/deploy/variants/centos-demo-noapache/Dockerfile
+++ b/deploy/variants/centos-demo-noapache/Dockerfile
@@ -1,0 +1,52 @@
+############################################################
+# Dockerfile to build the ga4gh demo 
+# Based on CentOS7
+############################################################
+FROM centos:7
+
+# File Author / Maintainer
+MAINTAINER Alastair Firth
+
+
+################## BEGIN INSTALLATION ######################
+# Install ga4gh demo (non-apache)
+# NOT for production use
+# Ref: http://ga4gh-reference-implementation.readthedocs.org/en/stable/demo.html#demo
+
+#TODO add yum key
+
+# Install prereqs
+RUN yum -y update && yum -y install \
+  curl \
+  git \
+  python-backports \
+  python-backports-ssl_match_hostname \
+  python-devel \
+  python-setuptools \
+  tar \
+  wget \
+  zlib-devel
+RUN yum -y groupinstall "Development Tools"
+RUN yum clean all
+
+# Create the default data directory
+RUN mkdir -p /data/
+WORKDIR /data/
+
+#wget the example data
+RUN wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar -nv -O - | tar -x
+
+# Install setuptools and pip
+RUN easy_install setuptools
+RUN easy_install pip
+
+# Install ga4gh with pip
+RUN pip install ga4gh --pre
+
+##################### INSTALLATION END #####################
+
+# Expose the default port
+EXPOSE 8000
+
+ENTRYPOINT ["ga4gh_server"]
+

--- a/deploy/variants/demo/Dockerfile
+++ b/deploy/variants/demo/Dockerfile
@@ -1,0 +1,22 @@
+############################################################
+## Dockerfile to build the ga4gh server on mod_wsgi-express
+## Downloads and uses the demo dataset
+## Based on the prod build
+## Results of this build are available from Dockerhub as afirth/ga4gh_server_apache:demo
+############################################################
+FROM afirth/ga4gh_server_apache:prod
+
+# File Author / Maintainer
+MAINTAINER Alastair Firth
+
+# Create the data directory
+RUN mkdir -p /data/
+
+# Fetch the example data and extract
+# On some terminals the progress bar freezes during build
+WORKDIR /data/
+RUN curl http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar | tar -x
+WORKDIR /
+
+# Set the dataset location explicitly
+ENV GA4GH_DATA_SOURCE=/data/ga4gh-example-data

--- a/deploy/variants/ubuntu-demo-apache/Dockerfile
+++ b/deploy/variants/ubuntu-demo-apache/Dockerfile
@@ -1,6 +1,9 @@
 # Base image
 FROM ubuntu
 
+# Originally created by Steve Hershman GitHub @hershman
+MAINTAINER Steve Hershman
+
 # Update the sources list
 RUN apt-get update
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -157,26 +157,119 @@ error log (in Apache on Debian/Ubuntu, for example, this is ``/var/log/apache2/e
 --------------------
 Deployment on Docker
 --------------------
-
 It is also possible to deploy the server using Docker.
 
-First build the Docker Image.  From the ``deploy`` folder run:
+First, you need an environment running the docker daemon. For non-production use, we recommend `boot2docker <http://boot2docker.io/>`_. For production use you should install docker on a stable linux distro.
+Please reference the `platform specific Docker installation instructions <https://docs.docker.com/installation/>`_. OSX and Windows are instructions for boot2docker.
+
+**Local Dataset Mounted as Volume**
+
+If you already have a dataset on your machine, you can download and deploy the apache server in one command: 
 
 .. code-block:: bash
 
-  $ docker build .
+  $ docker run -e GA4GH_DATA_SOURCE=/data -v /my/ga4gh_data/:/data:ro -itd -p 8000:80 --name ga4gh_server afirth/ga4gh_apache_server:prod
 
-Find the ``id`` of the recently built image by running
+Replace ``/my/ga4gh_data/`` with the path to your data.
+
+This will:
+
+* pull the automatically built image from `Dockerhub <https://registry.hub.docker.com/u/afirth/ga4gh_server_apache/>`_
+* start an apache server running mod_wsgi on container port 80
+* mount your data read-only to the docker container 
+* assign a name to the container
+* forward port 8000 to the container.
+
+For more information on docker run options, see the `run reference <https://docs.docker.com/reference/run/>`_.
+
+**Demo Dataset Inside Container**
+
+If you do not have a dataset yet, you can deploy a container which includes the demo data:
 
 .. code-block:: bash
 
-  $ docker images
+  $ docker run -itd -p 8000:80 --name ga4gh_demo afirth/ga4gh_server_apache:demo
 
-Use that ``id`` to launch the server
+This is identical to the production container, except that a copy of the demo data is included and appropriate defaults are set. 
 
-.. code-block:: bash
-
-  $ docker run -d -p 8888:80 <id>
+**Ports**
 
 This will run the docker container in the background, and translate calls from your host environment
-port 8888 to the docker container port 80. At that point you should be able to access it like a normal website.
+port 8000 to the docker container port 80. At that point you should be able to access it like a normal website, albeit on port 8000.
+Running in `boot2docker <http://boot2docker.io/>`_, you will need to forward the port from the boot2docker VM to the host.
+From a terminal on the host to forward traffic from localhost:8000 to the VM 8000 on OSX:
+
+.. code-block:: bash
+
+  $ VBoxManage controlvm boot2docker-vm natpf1 "ga4gh,tcp,127.0.0.1,8000,,8000"
+
+For more info on port forwarding see `the VirtualBox manual <https://www.virtualbox.org/manual/ch06.html#natforward>`_ and this `wiki article <https://github.com/CenturyLinkLabs/panamax-ui/wiki/How-To%3A-Port-Forwarding-on-VirtualBox>`_.
+
+++++++++
+Advanced
+++++++++
+
+If you want to build the images yourself, that is possible. The `afirth/ga4gh_server_apache repo <https://registry.hub.docker.com/u/afirth/ga4gh_server_apache/>`_
+builds automatically on new commits, so this is only needed if you want to modify the Dockerfiles, or build from a different source.
+
+The prod and demo builds are based off of `mod_wsgi-docker <https://github.com/GrahamDumpleton/mod_wsgi-docker>`_, a project from the author of mod_wsgi.
+Please reference the Dockerfiles and documentation for that project during development on these builds.
+
+**Examples**
+
+Build the code at server/ and run for production, serving a dataset on local host located at ``/my/dataset``
+
+.. code-block:: bash
+
+ $ cd server/
+ $ docker build -t my-repo/my-image .
+ $ docker run -e GA4GH_DATA_SOURCE=/dataset -v /my/dataset:/dataset:ro -itd -p 8000:80 --name ga4gh_server my-repo/my-image
+
+Build and run the production build from above, with the demo dataset in the container
+(you will need to modify the FROM line in ``/deploy/variants/demo/Dockerfile`` if you want to use your image from above as the base):
+
+.. code-block:: bash
+
+ $ cd server/deploy/variants/demo
+ $ docker build -t my-repo/my-demo-image .
+ $ docker run -itd -p 8000:80 --name ga4gh_demo my-repo/my-demo-image
+
+**Variants**
+
+Other Dockerfile implementations are available in the variants folder which install manually.
+To build one of these images:
+
+.. code-block:: bash
+
+ $ cd server/deploy/variants/xxxx
+ $ docker build -t my-repo/my-image .
+ $ docker run -itd -p 8000:80 --name my_container my-repo/my-image
+
+++++++++++++++++++++++
+Troubleshooting Docker
+++++++++++++++++++++++
+
+**DNS**
+
+The docker daemon's DNS may be corrupted if you switch networks, especially if run in a VM.
+For boot2docker, running udhcpc on the VM usually fixes it. 
+From a terminal on the host:
+
+.. code-block:: bash
+
+  $ eval "$(boot2docker shellinit)"
+  $ boot2docker ssh
+  >	sudo udhcpc
+  (password is tcuser)
+
+**DEBUG**
+
+To enable DEBUG on your docker server, call docker run with ``-e GA4GH_DEBUG=True``
+
+.. code-block:: bash
+
+  $ docker run -itd -p 8000:80 --name ga4gh_demo -e GA4GH_DEBUG=True afirth/ga4gh_server_apache:demo
+
+This will set the environment variable which is read by config.py
+
+You can then get logs from the docker container by running ``docker logs (container)`` e.g. ``docker logs ga4gh_demo``


### PR DESCRIPTION
1) ./Dockerfile, which builds the server with mod_wsgi-express. Data and config.py are not placed.
2) demo/Dockerfile, which adds the example data and config.py to 1)
3) demo_light/Dockerfile, which builds only the python, as the demo in
existing docs