### PR TITLE
added kwargs field to protocol __init__ methods

### DIFF
--- a/scripts/process_schemas.py
+++ b/scripts/process_schemas.py
@@ -155,10 +155,12 @@ class SchemaClass(object):
         self._writeWrappedWithIndent(slotString, outputFile, 2)
         self._writeWithIndent("]", outputFile)
         self._writeNewline(outputFile)
-        self._writeWithIndent("def __init__(self):", outputFile)
+        self._writeWithIndent("def __init__(self, **kwargs):", outputFile)
         for field in self.getFields():
-            string_ = "self.{0} = {1}".format(field.name, field.default)
+            string_ = "self.{} = kwargs.get(".format(field.name)
             self._writeWithIndent(string_, outputFile, 2)
+            string_ = "'{}', {})".format(field.name, field.default)
+            self._writeWithIndent(string_, outputFile, 3)
 
     def writeEmbeddedTypesClassMethods(self, outputFile):
         """


### PR DESCRIPTION
I'm not sure if we want to merge this now or later, since we can't really run `process_schemas.py` successfully to generate a new `_protocol_definitions.py` until the schemas repo is fixed

Issue #372