### PR TITLE
Improve request/response failure error messages

### DIFF
--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -11,6 +11,7 @@ import zlib
 import inspect
 
 import ga4gh.protocol as protocol
+import ga4gh.avrotools as avrotools
 
 
 def getExceptionClass(errorCode):
@@ -124,9 +125,13 @@ class RequestValidationFailureException(BadRequestException):
     A validation of the request data failed
     """
     def __init__(self, jsonDict, requestClass):
-        self.message = (
-            "Request '{}' is not a valid instance of {}".format(
-                jsonDict, requestClass))
+        messageString = (
+            "Request '{}' is not a valid instance of {}; "
+            "invalid fields: {}")
+        self.message = messageString.format(
+            jsonDict, requestClass,
+            avrotools.ValidationTool.getInvalidFields(
+                requestClass, jsonDict))
 
 
 class BadReadsSearchRequestBothRefs(BadRequestException):
@@ -312,5 +317,8 @@ class ResponseValidationFailureException(ServerError):
     def __init__(self, jsonDict, requestClass):
         self.message = (
             "Response '{}' is not a valid instance of {}. "
+            "Invalid fields: {} "
             "Please file a bug report.".format(
-                jsonDict, requestClass))
+                jsonDict, requestClass,
+                avrotools.ValidationTool.getInvalidFields(
+                    requestClass, jsonDict)))

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -161,9 +161,10 @@ class ImportGraphLayerChecker(object):
         'datamodel': ['ga4gh/datamodel/reads.py',
                       'ga4gh/datamodel/references.py',
                       'ga4gh/datamodel/variants.py'],
-        'libraries': ['ga4gh/converters.py', 'ga4gh/avrotools.py'],
+        'libraries': ['ga4gh/converters.py'],
         'protocol': ['ga4gh/protocol.py', 'ga4gh/_protocol_definitions.py'],
         'config': ['ga4gh/serverconfig.py'],
+        'avrotools': ['ga4gh/avrotools.py'],
     }
 
     # each moduleGroupName has one and only one entry here
@@ -175,6 +176,7 @@ class ImportGraphLayerChecker(object):
         ['libraries'],
         ['datamodel'],
         ['exceptions'],
+        ['avrotools'],
         ['config'],
         ['protocol'],
     ]


### PR DESCRIPTION
Error messages now look like:
```
"Request '{u'referenceId': None, u'end': None, u'readGroupIds': [], u'pageSize': None, u'pageToken': None, u'start': u'thisIsWrong'}' is not a valid instance of <class 'ga4gh._protocol_definitions.SearchReadsRequest'>; invalid fields: {u'start': u'thisIsWrong'}"
```

Issue #382