### PR TITLE
Take out unused paths

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -257,21 +257,6 @@ def indexRedirect(version):
     return index()
 
 
-@app.route('/<version>/references/<id>', methods=['GET'])
-def getReference(version, id):
-    raise exceptions.PathNotFoundException()
-
-
-@app.route('/<version>/references/<id>/bases', methods=['GET'])
-def getReferenceBases(version, id):
-    raise exceptions.PathNotFoundException()
-
-
-@app.route('/<version>/referencesets/<id>', methods=['GET'])
-def getReferenceSet(version, id):
-    raise exceptions.PathNotFoundException()
-
-
 @app.route('/<version>/callsets/search', methods=['POST'])
 def searchCallSets(version):
     return handleFlaskPostRequest(
@@ -294,11 +279,6 @@ def searchReads(version):
 def searchReferenceSets(version):
     return handleFlaskPostRequest(
         version, flask.request, app.backend.searchReferenceSets)
-
-
-@app.route('/<version>/references/search', methods=['POST'])
-def searchReferences(version):
-    raise exceptions.PathNotFoundException()
 
 
 @app.route('/<version>/variantsets/search', methods=['POST', 'OPTIONS'])


### PR DESCRIPTION
Issue #385 

This is so the paths don't appear in the HTML display, which can be confusing to a new user when s/he tries to hit them and they don't work.  We're not losing any functionality here, and can look up this commit and incorporate its reversion when we actually do want to implement these paths.