### PR TITLE
Make GET /{version} return the HTML page as well

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -244,6 +244,11 @@ def index():
     return flask.render_template('index.html', info=app.serverStatus)
 
 
+@app.route('/<version>')
+def indexRedirect(version):
+    return index()
+
+
 @app.route('/<version>/references/<id>', methods=['GET'])
 def getReference(version, id):
     raise exceptions.PathNotFoundException()

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -149,7 +149,13 @@ class TestFrontend(unittest.TestCase):
             self.verifySearchRouting(path)
 
     def testRouteIndex(self):
-        response = self.app.get("/")
+        self._routeIndex("/")
+
+    def testRouteIndexRedirect(self):
+        self._routeIndex("/{}".format(protocol.version))
+
+    def _routeIndex(self, path):
+        response = self.app.get(path)
         self.assertEqual(200, response.status_code)
         self.assertEqual("text/html", response.mimetype)
         self.assertGreater(len(response.data), 0)


### PR DESCRIPTION
Rationale:
Some might think /{version} not / is the base url and fire off a browser request to it.  Easy mistake to make.