### PR TITLE
Dataset support

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -2910,6 +2910,81 @@ This metadata represents VCF header information.
         self.type = None
         self.value = None
 
+
+class SearchDatasetsRequest(SearchRequest):
+    """
+    This request maps to the body of `POST /datasets/search` as JSON.
+    """
+    _schemaSource = """
+{"namespace": "org.ga4gh.methods", "type": "record", "name":
+"SearchDatasetsRequest", "fields": [{"default": null, "doc": "",
+"type": ["null", "int"], "name": "pageSize"}, {"default": null, "doc":
+"", "type": ["null", "string"], "name": "pageToken"}], "doc": ""}
+"""
+    schema = avro.schema.parse(_schemaSource)
+    requiredFields = set([])
+
+    @classmethod
+    def isEmbeddedType(cls, fieldName):
+        embeddedTypes = {}
+        return fieldName in embeddedTypes
+
+    @classmethod
+    def getEmbeddedType(cls, fieldName):
+        embeddedTypes = {}
+        return embeddedTypes[fieldName]
+
+    __slots__ = [
+        'pageSize', 'pageToken'
+    ]
+
+    def __init__(self):
+        self.pageSize = None
+        self.pageToken = None
+
+
+class SearchDatasetsResponse(SearchResponse):
+    """
+    This is the response from `POST /datasets/search` expressed as
+    JSON.
+    """
+    _schemaSource = """
+{"namespace": "org.ga4gh.methods", "type": "record", "name":
+"SearchDatasetsResponse", "fields": [{"default": [], "doc": "",
+"type": {"items": {"namespace": "org.ga4gh.models", "type": "record",
+"name": "Dataset", "fields": [{"doc": "", "type": "string", "name":
+"id"}, {"default": null, "doc": "", "type": ["null", "string"],
+"name": "description"}], "doc": ""}, "type": "array"}, "name":
+"datasets"}, {"default": null, "doc": "", "type": ["null", "string"],
+"name": "nextPageToken"}], "doc": ""}
+"""
+    schema = avro.schema.parse(_schemaSource)
+    requiredFields = set([])
+    _valueListName = "datasets"
+
+    @classmethod
+    def isEmbeddedType(cls, fieldName):
+        embeddedTypes = {
+            'datasets': Dataset,
+        }
+        return fieldName in embeddedTypes
+
+    @classmethod
+    def getEmbeddedType(cls, fieldName):
+        embeddedTypes = {
+            'datasets': Dataset,
+        }
+        return embeddedTypes[fieldName]
+
+    __slots__ = [
+        'datasets', 'nextPageToken'
+    ]
+
+    def __init__(self):
+        self.datasets = []
+        self.nextPageToken = None
+
+
 postMethods = \
     [('/analyses/search',
       SearchAnalysesRequest,

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -252,3 +252,10 @@ class HttpClient(object):
         """
         return self.runSearchRequest(
             protocolRequest, "reads", protocol.SearchReadsResponse)
+
+    def searchDatasets(self, protocolRequest):
+        """
+        Returns an iterator over the Datasets from the server
+        """
+        return self.runSearchRequest(
+            protocolRequest, "datasets", protocol.SearchDatasetsResponse)

--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import os
 import random
 
+import ga4gh.protocol as protocol
 import ga4gh.datamodel as datamodel
 import ga4gh.datamodel.variants as variants
 import ga4gh.datamodel.reads as reads
@@ -24,6 +25,17 @@ class AbstractDataset(datamodel.DatamodelObject):
         self._readGroupSetIdMap = {}
         self._readGroupIds = []
         self._readGroupIdMap = {}
+
+    def toProtocolElement(self):
+        dataset = protocol.Dataset()
+        dataset.id = self.getId()
+        return dataset
+
+    def getId(self):
+        """
+        Return the id of the dataset
+        """
+        return self._id
 
     def getDirectory(self):
         """
@@ -85,8 +97,10 @@ class SimulatedDataset(AbstractDataset):
     A simulated dataset
     """
     def __init__(
-            self, randomSeed, numCalls, variantDensity, numVariantSets):
+            self, datasetId, randomSeed, numCalls,
+            variantDensity, numVariantSets):
         super(SimulatedDataset, self).__init__()
+        self._id = datasetId
         self._randomSeed = randomSeed
         self._randomGenerator = random.Random()
         self._randomGenerator.seed(self._randomSeed)
@@ -116,6 +130,7 @@ class FileSystemDataset(AbstractDataset):
     """
     def __init__(self, datasetDir):
         super(FileSystemDataset, self).__init__()
+        self._id = os.path.basename(os.path.normpath(datasetDir))
         self._datasetDir = datasetDir
 
         # Variants

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -152,6 +152,13 @@ class DatamodelValidationException(BadRequestException):
     """
 
 
+class NotExactlyOneDatasetException(BadRequestException):
+    def __init__(self, requestedDatasetIds):
+        msg = "Not exactly one dataset requested: {}".format(
+            requestedDatasetIds)
+        super(NotExactlyOneDatasetException, self).__init__(msg)
+
+
 class NotFoundException(RuntimeException):
     """
     The superclass of all exceptions in which some resource was not
@@ -224,12 +231,6 @@ class DataException(BaseServerException):
     Exceptions thrown during the server startup, and processing faulty VCFs
     """
     message = "Faulty data found or data file is missing."
-
-
-class NotExactlyOneDatasetException(DataException):
-    def __init__(self, datasetDirs):
-        msg = "Not exactly one dataset found: {}".format(datasetDirs)
-        super(NotExactlyOneDatasetException, self).__init__(msg)
 
 
 class FileOpenFailedException(DataException):

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -139,17 +139,23 @@ class ServerStatus(object):
         urls.sort()
         return urls
 
-    def getVariantSets(self):
+    def getDatasetIds(self):
         """
-        Returns the list of variant sets for this server.
+        Returns the list of datasetIds for this backend
         """
-        return app.backend.getDataset().getVariantSets()
+        return app.backend.getDatasetIds()
 
-    def getReadGroupSets(self):
+    def getVariantSets(self, datasetId):
         """
-        Returns the list of ReadGroupSets for this server.
+        Returns the list of variant sets for the dataset
         """
-        return app.backend.getDataset().getReadGroupSets()
+        return app.backend.getDataset(datasetId).getVariantSets()
+
+    def getReadGroupSets(self, datasetId):
+        """
+        Returns the list of ReadGroupSets for the dataset
+        """
+        return app.backend.getDataset(datasetId).getReadGroupSets()
 
     def getReferenceSets(self):
         """
@@ -370,6 +376,12 @@ def searchVariantSets(version):
 def searchVariants(version):
     return handleFlaskPostRequest(
         version, flask.request, app.backend.searchVariants)
+
+
+@app.route('/<version>/datasets/search', methods=SEARCH_ENDPOINT_METHODS)
+def searchDatasets(version):
+    return handleFlaskPostRequest(
+        version, flask.request, app.backend.searchDatasets)
 
 
 # The below methods ensure that JSON is returned for various errors

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -40,28 +40,7 @@
         </div>
         <div>
             <h3>Data</h3>
-            <h4>VariantSets</h4>
-            <table>
-                {% for variantSet in info.getVariantSets() %}
-                <tr>
-                    <td>{{ variantSet.getId() }}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            <h4>ReadGroupSets</h4>
-            <table>
-                {% for readGroupSet in info.getReadGroupSets() %}
-                <tr>
-                    <td>{{ readGroupSet.getId() }}</td>
-                </tr>
-                    {% for readGroup in readGroupSet.getReadGroups() %}
-                <tr>
-                    <td></td>
-                    <td>{{ readGroup.getId() }}</td>
-                </tr>
-                {% endfor %}
-            {% endfor %}
-            </table>
+
             <h4>ReferenceSets</h4>
             <table>
                 {% for referenceSet in info.getReferenceSets() %}
@@ -76,6 +55,34 @@
                 {% endfor %}
             {% endfor %}
             </table>
+
+            <h4>DataSets</h4>
+            {% for datasetId in info.getDatasetIds() %}
+                <h5>{{ datasetId }}</h5>
+                <h6>VariantSets</h6>
+                <table>
+                    {% for variantSet in info.getVariantSets(datasetId) %}
+                    <tr>
+                        <td>{{ variantSet.getId() }}</td>
+                    </tr>
+                    {% endfor %}
+                </table>
+                <h6>ReadGroupSets</h6>
+                <table>
+                    {% for readGroupSet in info.getReadGroupSets(datasetId) %}
+                    <tr>
+                        <td>{{ readGroupSet.getId() }}</td>
+                        <td></td>
+                    </tr>
+                        {% for readGroup in readGroupSet.getReadGroups() %}
+                    <tr>
+                        <td></td>
+                        <td>{{ readGroup.getId() }}</td>
+                    </tr>
+                    {% endfor %}
+                {% endfor %}
+                </table>
+            {% endfor %}
         </div>
     </body>
 </html>

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -22,10 +22,11 @@ class TestGestalt(server_test.ServerTest):
     """
     def testEndToEnd(self):
         self.client = client.ClientForTesting(self.server.getUrl())
-        self.runVariantSetRequest()
+        self.runVariantsRequest()
         self.assertLogsWritten()
         self.runReadsRequest()
         self.runReferencesRequest()
+        self.runVariantSetsRequestDatasetTwo()
         self.client.cleanup()
 
     def assertLogsWritten(self):
@@ -56,7 +57,8 @@ class TestGestalt(server_test.ServerTest):
 
         # num of client stdout should be twice the value of
         # SIMULATED_BACKEND_NUM_VARIANT_SETS
-        expectedNumClientOutLines = 20
+        # times the number of datasets (currently 2)
+        expectedNumClientOutLines = 40
         self.assertEqual(len(clientOutLines), expectedNumClientOutLines)
 
         # client stderr should log at least one post
@@ -69,7 +71,7 @@ class TestGestalt(server_test.ServerTest):
             requestFound,
             "No request logged from the client to stderr")
 
-    def runVariantSetRequest(self):
+    def runVariantsRequest(self):
         self.runClientCmd(self.client, "variants-search -s0 -e2")
 
     def runReadsRequest(self):
@@ -88,4 +90,9 @@ class TestGestalt(server_test.ServerTest):
         cmd = "references-get {}".format(referenceId)
         self.runClientCmd(self.client, cmd)
         cmd = "references-list-bases {}".format(referenceId)
+        self.runClientCmd(self.client, cmd)
+
+    def runVariantSetsRequestDatasetTwo(self):
+        datasetId = "simulatedDataset2"
+        cmd = "variantsets-search --datasetIds {}".format(datasetId)
         self.runClientCmd(self.client, cmd)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -144,6 +144,9 @@ class TestClientArguments(unittest.TestCase):
         --readGroupIds READ,GROUP,IDS --referenceId REFERENCEID
         --referenceName REFERENCENAME"""
 
+    def testDatasetsSearchArguments(self):
+        self.cliInput = """datasets-search"""
+
     def testReferenceSetGetArguments(self):
         self.cliInput = """referencesets-get ID"""
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -112,6 +112,12 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
             self.protocolRequest, "reads",
             protocol.SearchReadsResponse)
 
+    def testSearchDatasets(self):
+        self.httpClient.searchDatasets(self.protocolRequest)
+        self.httpClient.runSearchRequest.assert_called_once_with(
+            self.protocolRequest, "datasets",
+            protocol.SearchDatasetsResponse)
+
     def testGetReferenceSet(self):
         self.httpClient.getReferenceSet(self._id)
         self.httpClient.runGetRequest.assert_called_once_with(

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,0 +1,21 @@
+"""
+Tests the datasets module
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import ga4gh.datamodel.datasets as datasets
+
+
+class TestDatasets(unittest.TestCase):
+    """
+    Tests the datasets class
+    """
+    def testToProtocolElement(self):
+        datasetId = 'ds1'
+        dataset = datasets.SimulatedDataset(datasetId, 1, 2, 3, 4)
+        gaDataset = dataset.toProtocolElement()
+        self.assertEqual(dataset.getId(), gaDataset.id)

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -37,8 +37,9 @@ class TestVariantsGenerator(unittest.TestCase):
     """
     def setUp(self):
         self.request = protocol.SearchVariantsRequest()
-        self.backend = backend.AbstractBackend()
+        self.backend = backend.SimulatedBackend()
         self.variantSetId = "variantSetId"
+        self.datasetId = self.backend.getDatasetIds()[0]
 
     def testNoVariantSetsNotSupported(self):
         # a request for no variant sets should throw an exception
@@ -88,7 +89,7 @@ class TestVariantsGenerator(unittest.TestCase):
 
     def _initVariantSet(self, numVariants):
         variantSet = MockVariantSet(self.variantSetId, numVariants)
-        self.backend.getDataset()._variantSetIdMap = {
+        self.backend.getDataset(self.datasetId)._variantSetIdMap = {
             self.variantSetId: variantSet}
         self.request.variantSetIds = [self.variantSetId]
 
@@ -120,8 +121,9 @@ class TestReadsGenerator(unittest.TestCase):
     """
     def setUp(self):
         self.request = protocol.SearchReadsRequest()
-        self.backend = backend.AbstractBackend()
+        self.backend = backend.SimulatedBackend()
         self.readGroupId = "readGroupId"
+        self.datasetId = self.backend.getDatasetIds()[0]
 
     def testNoReadGroupsNotSupported(self):
         # a request for no read groups should throw an exception
@@ -171,7 +173,7 @@ class TestReadsGenerator(unittest.TestCase):
 
     def _initReadGroup(self, numAlignments):
         readGroup = MockReadGroup(self.readGroupId, numAlignments)
-        self.backend.getDataset()._readGroupIdMap = {
+        self.backend.getDataset(self.datasetId)._readGroupIdMap = {
             self.readGroupId: readGroup}
         self.request.readGroupIds = [self.readGroupId]
 

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -38,9 +38,10 @@ class TestSimulatedStack(unittest.TestCase):
 
     def setUp(self):
         self.backend = frontend.app.backend
+        self.datasetId = self.backend.getDatasetIds()[0]
         self.variantSetIds = [
             variantSet.getId() for variantSet in
-            self.backend.getDataset().getVariantSets()]
+            self.backend.getDataset(self.datasetId).getVariantSets()]
 
     def sendJsonPostRequest(self, path, data):
         return self.app.post(
@@ -51,6 +52,7 @@ class TestSimulatedStack(unittest.TestCase):
         expectedIds = self.variantSetIds
         request = protocol.SearchVariantSetsRequest()
         request.pageSize = len(expectedIds)
+        request.datasetIds = [self.datasetId]
         path = utils.applyVersion('/variantsets/search')
         response = self.sendJsonPostRequest(
             path, request.toJsonString())

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -60,9 +60,9 @@ class TestFrontend(unittest.TestCase):
         request.end = 1
         return self.sendPostRequest('/variants/search', request)
 
-    def sendVariantSetsSearch(self, datasetIds=[""]):
+    def sendVariantSetsSearch(self):
         request = protocol.SearchVariantSetsRequest()
-        request.datasetIds = datasetIds
+        request.datasetIds = ["simulatedDataset1"]
         return self.sendPostRequest('/variantsets/search', request)
 
     def sendCallSetsSearch(self):
@@ -79,6 +79,10 @@ class TestFrontend(unittest.TestCase):
         request = protocol.SearchReadsRequest()
         request.readGroupIds = readGroupIds
         return self.sendPostRequest('/reads/search', request)
+
+    def sendDatasetsSearch(self):
+        request = protocol.SearchDatasetsRequest()
+        return self.sendPostRequest('/datasets/search', request)
 
     def sendGetRequest(self, path):
         versionedPath = utils.applyVersion(path)
@@ -145,6 +149,7 @@ class TestFrontend(unittest.TestCase):
         assertHeaders(self.sendReferenceSetsGet())
         assertHeaders(self.sendReferencesSearch())
         assertHeaders(self.sendReferenceBasesList())
+        assertHeaders(self.sendDatasetsSearch())
         # TODO: Test other methods as they are implemented
 
     def verifySearchRouting(self, path, getDefined=False):
@@ -248,6 +253,13 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(
             responseData.alignments[1].id,
             "aReadGroupSet:one:simulated1")
+
+    def testDatasetsSearch(self):
+        response = self.sendDatasetsSearch()
+        responseData = protocol.SearchDatasetsResponse.fromJsonString(
+            response.data)
+        datasets = list(responseData.datasets)
+        self.assertEqual('simulatedDataset1', datasets[0].id)
 
     def testWrongVersion(self):
         path = '/v0.1.2/variantsets/search'


### PR DESCRIPTION
TODO:
- the end-to-end tests are failing because our default for variants-search is to first to a variantsets-search to request all of the variantsets of the server.  With multiple datasets, however, we must also specify what dataset's variantSets we want (and we have a self-imposed restriction right now of only being able to request one dataset).  Knowing this datasetId is impossible without querying the server before the variantsets-search request, so we need to request it from the server.  There is a `/datasets/search` path specified in the most current schema, but it is not in our `_protocol_definitions.py`.  We can't get the response object into `_protocol_definitions.py` without running `process_schemas.py` on the most recent schemas, which is a questionable idea in and of itself (see #379).  An alternative is to just cut and paste the response object into `process_schemas.py`, resulting in an additionally-hacked `process_schemas.py` (which may be the best solution).  How to proceed here? 
- tests for multiple datasets

Issue #376