### PR TITLE
Added getVariantSet + framework for ga2vcf.

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -423,6 +423,13 @@ class AbstractBackend(object):
             protocol.SearchReferencesResponse,
             self.referencesGenerator)
 
+    def getVariantSet(self, id_):
+        """
+        Returns a variantSet with the given id.
+        """
+        dataset = self._getDatasetFromCompoundId(id_)
+        return self.runGetRequest(dataset.getVariantSetIdMap(), id_)
+
     def searchVariantSets(self, request):
         """
         Returns a GASearchVariantSetsResponse for the specified

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -180,15 +180,13 @@ class HttpClient(object):
         """
         Returns a referenceSet from the server
         """
-        return self.runGetRequest(
-            "referencesets", protocol.ReferenceSet, id_)
+        return self.runGetRequest("referencesets", protocol.ReferenceSet, id_)
 
     def getReference(self, id_):
         """
         Returns a reference from the server
         """
-        return self.runGetRequest(
-            "references", protocol.Reference, id_)
+        return self.runGetRequest("references", protocol.Reference, id_)
 
     def listReferenceBases(self, protocolRequest, id_):
         """
@@ -204,6 +202,12 @@ class HttpClient(object):
         """
         return self.runSearchRequest(
             protocolRequest, "variants", protocol.SearchVariantsResponse)
+
+    def getVariantSet(self, id_):
+        """
+        Returns a variantSet from the server
+        """
+        return self.runGetRequest("variantsets", protocol.VariantSet, id_)
 
     def searchVariantSets(self, protocolRequest):
         """

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -551,6 +551,12 @@ def searchDatasets(version):
         version, flask.request, app.backend.searchDatasets)
 
 
+@DisplayedRoute('/<version>/variantsets/<no(search):id>')
+def getVariantSet(version, id):
+    return handleFlaskGetRequest(
+        version, id, flask.request, app.backend.getVariantSet)
+
+
 # The below paths have not yet been implemented
 
 
@@ -571,11 +577,6 @@ def getVariant(version, id):
 
 @app.route('/<version>/variantsets/<vsid>/sequences/<sid>')
 def getVariantSetSequence(version, vsid, sid):
-    raise exceptions.NotImplementedException()
-
-
-@app.route('/<version>/variantsets/<no(search):id>')
-def getVariantSet(version, id):
     raise exceptions.NotImplementedException()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -48,11 +48,9 @@ class TestGa2VcfArguments(unittest.TestCase):
     def testVariantsSearchArguments(self):
         cliInput = """--workarounds WORK,AROUND
         --key KEY -O --outputFile /dev/null
-        variants-search --referenceName REFERENCENAME
+        --referenceName REFERENCENAME
         --variantName VARIANTNAME --callSetIds CALL,SET,IDS --start 0
-        --end 1 --pageSize 2 --variantSetIds VARIANT,SET,IDS
-        --datasetIds DATASET,IDS --maxCalls 5
-        BASEURL"""
+        --end 1 --pageSize 2 BASEURL VARIANTSETID"""
         stubConverterModule = StubConverterModuleVcf(self)
         with mock.patch(
                 'ga4gh.converters.VcfConverter',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -123,6 +123,11 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient.runGetRequest.assert_called_once_with(
             "referencesets", protocol.ReferenceSet, self._id)
 
+    def testGetVariantSet(self):
+        self.httpClient.getVariantSet(self._id)
+        self.httpClient.runGetRequest.assert_called_once_with(
+            "variantsets", protocol.VariantSet, self._id)
+
     def testGetReference(self):
         self.httpClient.getReference(self._id)
         self.httpClient.runGetRequest.assert_called_once_with(


### PR DESCRIPTION
This PR:

1. Adds the GET endpoint for variantsets, along with various infrastructure for that; and 
2. Adds the framework for ga2vcf.

The background for this is that @bioinformed asked me to provide an outline to give him a better idea of what we need for his VCF write support in pysam. Once this PR has been merged I'll create an issue for filling in the gaps in ga2vcf, which I'll assign to @bioinformed (if he still wants to work on it!).