### PR TITLE
Certain non-mapped URLs now return 404s

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -315,7 +315,14 @@ def index():
 
 @app.route('/<version>')
 def indexRedirect(version):
-    return index()
+    try:
+        isCurrentVersion = Version.isCurrentVersion(version)
+    except TypeError:  # malformed "version string"
+        raise exceptions.PathNotFoundException()
+    if isCurrentVersion:
+        return index()
+    else:
+        raise exceptions.PathNotFoundException()
 
 
 @app.route('/<version>/references/<id>')

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -131,10 +131,16 @@ class TestFrontend(unittest.TestCase):
         return response
 
     def test404sReturnJson(self):
-        path = utils.applyVersion('/doesNotExist')
-        response = self.app.get(path)
-        protocol.GAException.fromJsonString(response.get_data())
-        self.assertEqual(404, response.status_code)
+        paths = [
+            '/doesNotExist',
+            utils.applyVersion('/doesNotExist'),
+            utils.applyVersion('/reads/sea'),
+            utils.applyVersion('/variantsets/id/doesNotExist'),
+        ]
+        for path in paths:
+            response = self.app.get(path)
+            protocol.GAException.fromJsonString(response.get_data())
+            self.assertEqual(404, response.status_code)
 
     def testCors(self):
         def assertHeaders(response):


### PR DESCRIPTION
Issue #449

Kinda weird this wasn't caught by the `tests.unit.test_views:TestFrontend.test404sReturnJson` test.  Not sure what accounts for the behavior discrepancy between the test and requesting the nonexistant page in a browser...