### PR TITLE
Fixes for reads/search

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -141,6 +141,7 @@ class ReadsIntervalIterator(IntervalIterator):
 
     def _getIterator(self):
         iterator = self._container.getReadAlignments(
+            self._request.referenceName,
             self._request.referenceId,
             self._startPosition, self._request.end)
         return iterator

--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -29,6 +29,9 @@ class PysamSanitizer(object):
     vcfMin = -2**31
     vcfMax = 2**31 - 1
 
+    rNameMin = 0
+    rNameMax = 85
+
     maxStringLength = 2**10  # arbitrary
 
     @classmethod
@@ -58,6 +61,12 @@ class PysamSanitizer(object):
         return referenceName, start, end
 
     @classmethod
+    def sanitizeGetRName(cls, referenceId):
+        cls.assertInt(referenceId, 'referenceId')
+        cls.assertInRange(
+            referenceId, cls.rNameMin, cls.rNameMax, 'referenceId')
+
+    @classmethod
     def assertValidRange(cls, start, end, startName, endName):
         if start > end:
             message = "invalid coordinates: {} ({}) " \
@@ -65,10 +74,24 @@ class PysamSanitizer(object):
             raise exceptions.DatamodelValidationException(message)
 
     @classmethod
-    def sanitizeInt(cls, attr, minVal, maxVal, attrName):
+    def assertInRange(cls, attr, minVal, maxVal, attrName):
+        message = "invalid {} '{}' outside of range [{}, {}]"
+        if attr < minVal:
+            raise exceptions.DatamodelValidationException(message.format(
+                attrName, attr, minVal, maxVal))
+        if attr > maxVal:
+            raise exceptions.DatamodelValidationException(message.format(
+                attrName, attr, minVal, maxVal))
+
+    @classmethod
+    def assertInt(cls, attr, attrName):
         if not isinstance(attr, int):
             message = "invalid {} '{}' not an int".format(attrName, attr)
             raise exceptions.DatamodelValidationException(message)
+
+    @classmethod
+    def sanitizeInt(cls, attr, minVal, maxVal, attrName):
+        cls.assertInt(attr, attrName)
         if attr < minVal:
             attr = minVal
         if attr > maxVal:

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -231,6 +231,7 @@ class HtslibReadGroup(datamodel.PysamSanitizer, AbstractReadGroup):
         if referenceName is not None and referenceId is not None:
             raise exceptions.BadReadsSearchRequestBothRefs()
         if referenceId is not None:
+            self.sanitizeGetRName(referenceId)
             referenceName = self._samFile.getrname(referenceId)
         referenceName, start, end = self.sanitizeAlignmentFileFetch(
             referenceName, start, end)
@@ -251,6 +252,7 @@ class HtslibReadGroup(datamodel.PysamSanitizer, AbstractReadGroup):
         ret.alignment = protocol.GALinearAlignment()
         ret.alignment.mappingQuality = read.mapping_quality
         ret.alignment.position = protocol.GAPosition()
+        self.sanitizeGetRName(read.reference_id)
         ret.alignment.position.referenceName = self._samFile.getrname(
             read.reference_id)
         ret.alignment.position.position = read.reference_start
@@ -273,6 +275,7 @@ class HtslibReadGroup(datamodel.PysamSanitizer, AbstractReadGroup):
         ret.nextMatePosition = None
         if read.next_reference_id != -1:
             ret.nextMatePosition = protocol.GAPosition()
+            self.sanitizeGetRName(read.next_reference_id)
             ret.nextMatePosition.referenceName = self._samFile.getrname(
                 read.next_reference_id)
             ret.nextMatePosition.position = read.next_reference_start

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -60,6 +60,26 @@ class TestPysamSanitizer(datamodel.PysamSanitizer, unittest.TestCase):
         # correct range should not throw error
         self.assertValidRange(0, 100, 'start', 'end')
 
+    def testAssertInRange(self):
+        # too low
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInRange(-1, 0, 100, 'example')
+
+        # too high
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInRange(101, 0, 100, 'example')
+
+        # in range
+        self.assertInRange(50, 0, 100, 'example')
+
+    def testAssertInt(self):
+        # is an int
+        self.assertInt(5, 'example')
+
+        # is not an int
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInt('5', 'example')
+
     def testSanitizeVariantFileFetch(self):
         contigArg = 'x' * (self.maxStringLength + 1)
         startArg = self.vcfMin - 1
@@ -80,3 +100,19 @@ class TestPysamSanitizer(datamodel.PysamSanitizer, unittest.TestCase):
             referenceNameArg[:self.maxStringLength], referenceName)
         self.assertEqual(start, self.samMin)
         self.assertEqual(end, self.samMaxEnd)
+
+    def testSanitizeGetRName(self):
+        # too high
+        referenceId = self.rNameMax + 1
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)
+
+        # too low
+        referenceId = self.rNameMin - 1
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)
+
+        # not an int
+        referenceId = '1'
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)


### PR DESCRIPTION
Reopening #456 against the release-0.1 branch

- fix referenceId and referenceName not getting passed correctly
- sanitize pysam getrname calls

Issue #455