### PR TITLE
Forward-port of 'Fixes for reads/search'

### DIFF
--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -51,6 +51,9 @@ class PysamDatamodelMixin(object):
     fastaMin = 0
     fastaMax = 2**30 - 1
 
+    rNameMin = 0
+    rNameMax = 85
+
     maxStringLength = 2**10  # arbitrary
 
     @classmethod
@@ -92,6 +95,12 @@ class PysamDatamodelMixin(object):
         return start, end
 
     @classmethod
+    def sanitizeGetRName(cls, referenceId):
+        cls.assertInt(referenceId, 'referenceId')
+        cls.assertInRange(
+            referenceId, cls.rNameMin, cls.rNameMax, 'referenceId')
+
+    @classmethod
     def assertValidRange(cls, start, end, startName, endName):
         if start > end:
             message = "invalid coordinates: {} ({}) " \
@@ -99,10 +108,24 @@ class PysamDatamodelMixin(object):
             raise exceptions.DatamodelValidationException(message)
 
     @classmethod
-    def sanitizeInt(cls, attr, minVal, maxVal, attrName):
+    def assertInRange(cls, attr, minVal, maxVal, attrName):
+        message = "invalid {} '{}' outside of range [{}, {}]"
+        if attr < minVal:
+            raise exceptions.DatamodelValidationException(message.format(
+                attrName, attr, minVal, maxVal))
+        if attr > maxVal:
+            raise exceptions.DatamodelValidationException(message.format(
+                attrName, attr, minVal, maxVal))
+
+    @classmethod
+    def assertInt(cls, attr, attrName):
         if not isinstance(attr, int):
             message = "invalid {} '{}' not an int".format(attrName, attr)
             raise exceptions.DatamodelValidationException(message)
+
+    @classmethod
+    def sanitizeInt(cls, attr, minVal, maxVal, attrName):
+        cls.assertInt(attr, attrName)
         if attr < minVal:
             attr = minVal
         if attr > maxVal:

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -235,6 +235,7 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
         # including unmapped reads.
         referenceName = ""
         if referenceId is not None:
+            self.sanitizeGetRName(referenceId)
             referenceName = self._samFile.getrname(referenceId)
         referenceName, start, end = self.sanitizeAlignmentFileFetch(
             referenceName, start, end)
@@ -255,6 +256,7 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
         ret.alignment = protocol.LinearAlignment()
         ret.alignment.mappingQuality = read.mapping_quality
         ret.alignment.position = protocol.Position()
+        self.sanitizeGetRName(read.reference_id)
         ret.alignment.position.referenceName = self._samFile.getrname(
             read.reference_id)
         ret.alignment.position.position = read.reference_start
@@ -278,6 +280,7 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
         ret.nextMatePosition = None
         if read.next_reference_id != -1:
             ret.nextMatePosition = protocol.Position()
+            self.sanitizeGetRName(read.next_reference_id)
             ret.nextMatePosition.referenceName = self._samFile.getrname(
                 read.next_reference_id)
             ret.nextMatePosition.position = read.next_reference_start

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -60,6 +60,26 @@ class TestPysamSanitizer(datamodel.PysamDatamodelMixin, unittest.TestCase):
         # correct range should not throw error
         self.assertValidRange(0, 100, 'start', 'end')
 
+    def testAssertInRange(self):
+        # too low
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInRange(-1, 0, 100, 'example')
+
+        # too high
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInRange(101, 0, 100, 'example')
+
+        # in range
+        self.assertInRange(50, 0, 100, 'example')
+
+    def testAssertInt(self):
+        # is an int
+        self.assertInt(5, 'example')
+
+        # is not an int
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.assertInt('5', 'example')
+
     def testSanitizeVariantFileFetch(self):
         contigArg = 'x' * (self.maxStringLength + 1)
         startArg = self.vcfMin - 1
@@ -87,3 +107,19 @@ class TestPysamSanitizer(datamodel.PysamDatamodelMixin, unittest.TestCase):
         start, end = self.sanitizeFastaFileFetch(startArg, endArg)
         self.assertEqual(start, self.fastaMin)
         self.assertEqual(end, self.fastaMax)
+
+    def testSanitizeGetRName(self):
+        # too high
+        referenceId = self.rNameMax + 1
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)
+
+        # too low
+        referenceId = self.rNameMin - 1
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)
+
+        # not an int
+        referenceId = '1'
+        with self.assertRaises(exceptions.DatamodelValidationException):
+            self.sanitizeGetRName(referenceId)


### PR DESCRIPTION
Cherry-pick of 9f68e90c4c9a5206d0c80da5ae477f5a38074834

- sanitize pysam getrname calls

Issue #455