### PR TITLE
fixed some demo docs, and the build

### DIFF
--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -79,8 +79,8 @@ server using `cURL <http://curl.haxx.se/>`_:
 
 .. code-block:: bash
 
-    $ curl --data '{"datasetIds":[], "name":null}' --header 'Content-Type: application/json' \
-    http://localhost:8000/v0.5.1/readgroupsets/search
+    $ curl --data '{"datasetIds":[XXXX], "name":null}' --header 'Content-Type: application/json' \
+    http://localhost:8000/current/readgroupsets/search
 
 In this example, we used the `searchReadGroupSets
 <http://ga4gh.org/documentation/api/v0.5.1/ga4gh_api.html#/schema/org.ga4gh.searchReadGroupSets>`_
@@ -95,7 +95,7 @@ equivalent command using:
 .. code-block:: bash
 
     $ source ga4gh-env/bin/activate
-    (ga4gh-env) $ ga4gh_client readgroupsets-search http://localhost:8000/v0.5.1
+    (ga4gh-env) $ ga4gh_client readgroupsets-search --datasetIds XXXX http://localhost:8000/current
 
 The output of this command is a simple summary of the ReadGroupSets that
 are present on the server. We can also see the JSON messages passing
@@ -103,7 +103,7 @@ between the client and the server if we increase the verbosity level:
 
 .. code-block:: bash
 
-    (ga4gh-env) $ ga4gh_client -vv readgroupsets-search http://localhost:8000/v0.5.1
+    (ga4gh-env) $ ga4gh_client -vv readgroupsets-search --datasetIds XXXX http://localhost:8000/current
 
 We can perform similar queries for variant data using the
 `searchVariants
@@ -115,7 +115,7 @@ method:
 
 .. code-block:: bash
 
-    (ga4gh-env) $ ga4gh_client variantsets-search http://localhost:8000/v0.5.1
+    (ga4gh-env) $ ga4gh_client variantsets-search --datasetIds XXXX http://localhost:8000/current
     1kg-phase1
     1kg-phase3
 
@@ -128,7 +128,7 @@ as follows:
 
 .. code-block:: bash
 
-    (ga4gh-env) $ ga4gh_client variants-search http://localhost:8000/v0.5.1 \
+    (ga4gh-env) $ ga4gh_client variants-search --datasetIds XXXX http://localhost:8000/v0.5.1 \
     --variantSetIds=1kg-phase1 --referenceName=2 --start=33100 --end=34000
 
 The output of the client program is a summary of the data received in a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask
-Flask-API
 Flask-Cors
 Twisted
 avro

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ f.close()
 ga4ghVersion = parseVersion("ga4gh/__init__.py")
 # Flask must come after all other requirements that have "flask" as a prefix
 # due to a setuptools bug.
-requirements = ["avro", "Flask-API", "flask-cors", "flask", "humanize",
+requirements = ["avro", "flask-cors", "flask", "humanize",
                 "pysam>=0.8.2", "requests"]
 
 setup(


### PR DESCRIPTION
The master branch was broken by a new version of flask-api on pypi. We don't use flask-api, so dependency removed. Also, the documentation for the demo was invalidated by the recent support for datasets. Sort of fixed.