### PR TITLE
Use compoundIds for variantSets and readGroupSets

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -107,7 +107,7 @@ class SimulatedDataset(AbstractDataset):
 
         # Variants
         for i in range(numVariantSets):
-            variantSetId = "simVs{}".format(i)
+            variantSetId = "{}:simVs{}".format(self._id, i)
             seed = self._randomGenerator.randint(0, 2**32 - 1)
             variantSet = variants.SimulatedVariantSet(
                 seed, numCalls, variantDensity, variantSetId)
@@ -115,7 +115,7 @@ class SimulatedDataset(AbstractDataset):
         self._variantSetIds = sorted(self._variantSetIdMap.keys())
 
         # Reads
-        readGroupSetId = "aReadGroupSet"
+        readGroupSetId = "{}:aReadGroupSet".format(self._id)
         readGroupSet = reads.SimulatedReadGroupSet(
             readGroupSetId, numAlignments)
         self._readGroupSetIdMap[readGroupSetId] = readGroupSet
@@ -137,21 +137,23 @@ class FileSystemDataset(AbstractDataset):
         # Variants
         variantSetDir = os.path.join(self._datasetDir, "variants")
         for variantSetId in os.listdir(variantSetDir):
+            compoundVsid = '{}:{}'.format(self._id, variantSetId)
             relativePath = os.path.join(variantSetDir, variantSetId)
             if os.path.isdir(relativePath):
-                self._variantSetIdMap[variantSetId] = \
+                self._variantSetIdMap[compoundVsid] = \
                     variants.HtslibVariantSet(
-                        variantSetId, relativePath)
+                        compoundVsid, relativePath)
         self._variantSetIds = sorted(self._variantSetIdMap.keys())
 
         # Reads
         readGroupSetDir = os.path.join(self._datasetDir, "reads")
         for readGroupSetId in os.listdir(readGroupSetDir):
+            compoundRgsid = '{}:{}'.format(self._id, readGroupSetId)
             relativePath = os.path.join(readGroupSetDir, readGroupSetId)
             if os.path.isdir(relativePath):
                 readGroupSet = reads.HtslibReadGroupSet(
-                    readGroupSetId, relativePath)
-                self._readGroupSetIdMap[readGroupSetId] = readGroupSet
+                    compoundRgsid, relativePath)
+                self._readGroupSetIdMap[compoundRgsid] = readGroupSet
                 for readGroup in readGroupSet.getReadGroups():
                     self._readGroupIdMap[readGroup.getId()] = readGroup
         self._readGroupSetIds = sorted(self._readGroupSetIdMap.keys())

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -186,6 +186,12 @@ class VariantSetNotFoundException(NotFoundException):
             variantSetId)
 
 
+class DatasetNotFoundException(NotFoundException):
+    def __init__(self, datasetId):
+        self.message = "The requested dataset '{}' was not found".format(
+            datasetId)
+
+
 class ReadGroupNotFoundException(ObjectNotFoundException):
     def __init__(self, readGroupId):
         self.message = "readGroupId '{}' not found".format(readGroupId)

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -75,7 +75,9 @@ class TestGestalt(server_test.ServerTest):
         self.runClientCmd(self.client, "variants-search -s0 -e2")
 
     def runReadsRequest(self):
-        cmd = "reads-search --readGroupIds 'aReadGroupSet:one'"
+        cmd = (
+            "reads-search --readGroupIds "
+            "'simulatedDataset1:aReadGroupSet:one'")
         self.runClientCmd(self.client, cmd)
 
     def runReferencesRequest(self):

--- a/tests/end_to_end/test_remote_fetch.py
+++ b/tests/end_to_end/test_remote_fetch.py
@@ -28,8 +28,9 @@ class TestRemoteFetchReads(RemoteServerTestReads):
     """
     def testBamFetch(self):
         self.client = client.ClientForTesting(self.server.getUrl())
-        self.readGroupIds = \
-            'remoteTest:wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample'
+        self.readGroupIds = (
+            'dataset1:remoteTest:'
+            'wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample')
         self.runClientCmd(
             self.client,
             "reads-search --readGroupIds '{}'".format(

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -38,8 +38,8 @@ class TestVariantsGenerator(unittest.TestCase):
     def setUp(self):
         self.request = protocol.SearchVariantsRequest()
         self.backend = backend.SimulatedBackend()
-        self.variantSetId = "variantSetId"
         self.datasetId = self.backend.getDatasetIds()[0]
+        self.variantSetId = "{}:variantSetId".format(self.datasetId)
 
     def testNoVariantSetsNotSupported(self):
         # a request for no variant sets should throw an exception
@@ -55,7 +55,7 @@ class TestVariantsGenerator(unittest.TestCase):
 
     def testNonexistantVariantSet(self):
         # a request for a variant set that doesn't exist should throw an error
-        self.request.variantSetIds = ["notFound"]
+        self.request.variantSetIds = ["{}:notFound".format(self.datasetId)]
         with self.assertRaises(exceptions.VariantSetNotFoundException):
             self.backend.variantsGenerator(self.request)
 
@@ -122,8 +122,8 @@ class TestReadsGenerator(unittest.TestCase):
     def setUp(self):
         self.request = protocol.SearchReadsRequest()
         self.backend = backend.SimulatedBackend()
-        self.readGroupId = "readGroupId"
         self.datasetId = self.backend.getDatasetIds()[0]
+        self.readGroupId = "{}:readGroupId".format(self.datasetId)
 
     def testNoReadGroupsNotSupported(self):
         # a request for no read groups should throw an exception
@@ -139,7 +139,7 @@ class TestReadsGenerator(unittest.TestCase):
 
     def testNonexistantReadGroup(self):
         # a request for a readGroup that doesn't exist should throw an error
-        self.request.readGroupIds = ["notFound"]
+        self.request.readGroupIds = ["{}:notFound".format(self.datasetId)]
         with self.assertRaises(exceptions.ReadGroupNotFoundException):
             self.backend.readsGenerator(self.request)
 

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -79,7 +79,7 @@ class TestFrontend(unittest.TestCase):
 
     def sendReadsSearch(self, readGroupIds=None):
         if readGroupIds is None:
-            readGroupIds = ['aReadGroupSet:one']
+            readGroupIds = ['simulatedDataset1:aReadGroupSet:one']
         request = protocol.SearchReadsRequest()
         request.readGroupIds = readGroupIds
         return self.sendPostRequest('/reads/search', request)
@@ -259,10 +259,10 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(len(responseData.alignments), 2)
         self.assertEqual(
             responseData.alignments[0].id,
-            "aReadGroupSet:one:simulated0")
+            "simulatedDataset1:aReadGroupSet:one:simulated0")
         self.assertEqual(
             responseData.alignments[1].id,
-            "aReadGroupSet:one:simulated1")
+            "simulatedDataset1:aReadGroupSet:one:simulated1")
 
     def testDatasetsSearch(self):
         response = self.sendDatasetsSearch()


### PR DESCRIPTION
A compound id is the former id plus the dataset id it belongs to

Issue #453