### PR TITLE
Only display live routes on html page

### DIFF
--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -16,10 +16,10 @@
             <table>
                 <th>Method</th>
                 <th>Path</th>
-                {% for rule in info.getUrls() %}
+                {% for url in info.getUrls() %}
                 <tr>
-                    <td>{{ rule[1] }}</td>
-                    <td>{{ rule[0] }}</td>
+                    <td>{{ url[0] }}</td>
+                    <td>{{ url[1] }}</td>
                 </tr>
                 {% endfor %}
             </table>


### PR DESCRIPTION
Issue #472 

'Operations available' section now looks like:
```
Method	Path
GET	/0.6.e6d6074/references/<id>
GET	/0.6.e6d6074/references/<id>/bases
GET	/0.6.e6d6074/referencesets/<id>
POST	/0.6.e6d6074/callsets/search
POST	/0.6.e6d6074/datasets/search
POST	/0.6.e6d6074/readgroupsets/search
POST	/0.6.e6d6074/reads/search
POST	/0.6.e6d6074/references/search
POST	/0.6.e6d6074/referencesets/search
POST	/0.6.e6d6074/variants/search
POST	/0.6.e6d6074/variantsets/search
```