### PR TITLE
Build docs as part of CI and run_tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
   - coverage erase
   - nosetests --with-coverage --cover-package ga4gh
               --cover-inclusive --cover-min-percentage 85
+  - make clean -C docs/source/
+  - make -C docs/source/

--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -32,7 +32,8 @@ packages using:
 On Fedora 22+ (current), the equivalent would be:
 
 .. code-block:: bash
-    $sudo dnf install python-devel python-virtualenv zlib-devel
+
+    $ sudo dnf install python-devel python-virtualenv zlib-devel
 
 First, we create a virtualenv sandbox to isolate the demo from the
 rest of the system, and then activate it:


### PR DESCRIPTION
Also fix error in docs wrt red hat setup

Strangely, the `make` command doesn't fail when the error was present, but it does emit the following:
```
...
reading sources... [100%] introduction
/Users/dannyc/ga4gh/server/docs/source/demo.rst:34: ERROR: Error in "code-block" directive:
maximum 1 argument(s) allowed, 7 supplied.

.. code-block:: bash
    $sudo dnf install python-devel python-virtualenv zlib-devel
looking for now-outdated files... none found
...
```