### PR TITLE
Allow config to set a custom backend

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -225,6 +225,8 @@ def configure(configFile=None, baseConfig="ProductionConfig",
             numReferenceSets, numReferencesPerReferenceSet, numAlignments)
     elif dataSource == "__EMPTY__":
         theBackend = backend.EmptyBackend()
+    elif isinstance(dataSource, backend.AbstractBackend):
+        theBackend = dataSource
     else:
         theBackend = backend.FileSystemBackend(dataSource)
     theBackend.setRequestValidation(app.config["REQUEST_VALIDATION"])


### PR DESCRIPTION
I have a bunch of BAM files sitting on a file system and I wanted to serve them using the GA4GH API without reorganizing everything to fit the directory structure it expects. My BAM files may not have a `.bam` extension, and they may appear after the server starts up. So the plain vanilla `FileSystemBackend` isn't a great fit.

I only care about the `/reads/search` endpoint, so I hacked up a [new backend][1] and wanted to plug it in. This was the simplest way I could come up with. Any other ideas?

Thanks!

[1]: https://gist.github.com/danvk/0aa59b96de00213b5a27