### PR TITLE
Improve error on read query with invalid refName

### DIFF
--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -235,7 +235,11 @@ class HtslibReadGroup(datamodel.PysamSanitizer, AbstractReadGroup):
             referenceName = self._samFile.getrname(referenceId)
         referenceName, start, end = self.sanitizeAlignmentFileFetch(
             referenceName, start, end)
-        # TODO deal with errors from htslib
+        if referenceName is not None:
+            if self._samFile.gettid(referenceName) == -1:
+                raise exceptions.ReferenceNameNotFoundException(
+                    referenceName, self.getId())
+        # TODO deal with other errors from htslib
         readAlignments = self._samFile.fetch(referenceName, start, end)
         for readAlignment in readAlignments:
             yield self.convertReadAlignment(readAlignment)

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -168,6 +168,13 @@ class ReadGroupNotFoundException(ObjectNotFoundException):
         self.message = "readGroupId '{}' not found".format(readGroupId)
 
 
+class ReferenceNameNotFoundException(ObjectNotFoundException):
+    def __init__(self, referenceName, readGroupId):
+        self.message = (
+            "referenceName '{}' not found "
+            "in readGroupId '{}'".format(referenceName, readGroupId))
+
+
 class UnsupportedMediaTypeException(RuntimeException):
     httpStatus = 415
     message = "Unsupported media type"

--- a/tests/datadriven/test_reads.py
+++ b/tests/datadriven/test_reads.py
@@ -64,6 +64,13 @@ class ReadGroupSetTest(datadriven.DataDrivenTest):
     def getProtocolClass(self):
         return protocol.GAReadGroupSet
 
+    def testBadReferenceName(self):
+        # test that querying by a bad referenceName throws an error
+        readGroupSet = self._gaObject
+        readGroup = readGroupSet.getReadGroups()[0]
+        with self.assertRaises(exceptions.ReferenceNameNotFoundException):
+            list(readGroup.getReadAlignments("doesNotExist"))
+
     def testGetReadAlignmentsBothRefs(self):
         # test that querying by both referenceName and referenceId fails
         with self.assertRaises(exceptions.BadReadsSearchRequestBothRefs):


### PR DESCRIPTION
Issue #487 

Behavior after this patch:
```
$ curl http://localhost:8000/v0.5.1/reads/search --header 'Content-Type: application/json' --data '{"readGroupIds":["low-coverage:HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522"],"referenceName":"chr20","start":144700,"end":144800}'
{"errorCode": 1344119189, "message": "referenceName 'chr20' not found in readGroupId 'low-coverage:HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522'"}
```