### PR TITLE
oidc-provider requirements

### DIFF
--- a/oidc-provider/INSTALL.txt
+++ b/oidc-provider/INSTALL.txt
@@ -1,0 +1,7 @@
+INSTALLATION INSTRUCTIONS
+--------------------------
+
+Here are the packages needed to install the oidc provider
+
+Ubuntu:
+- sudo apt-get install libffi-dev libxml2-dev


### PR DESCRIPTION
This is related to issue #448. I added instructions for Ubuntu only but we would need to add the requirements for an installation on Mac OS X.