### PR TITLE
Updated docs for new lib requirement.

### DIFF
--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -27,13 +27,13 @@ packages using:
 
 .. code-block:: bash
 
-    $ sudo apt-get install python-dev python-virtualenv zlib1g-dev
+    $ sudo apt-get install python-dev python-virtualenv zlib1g-dev libxslt1-dev
 
 On Fedora 22+ (current), the equivalent would be:
 
 .. code-block:: bash
 
-    $ sudo dnf install python-devel python-virtualenv zlib-devel
+    $ sudo dnf install python-devel python-virtualenv zlib-devel libxslt-devel
 
 First, we create a virtualenv sandbox to isolate the demo from the
 rest of the system, and then activate it:

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -23,7 +23,7 @@ libraries. On Debian or Ubuntu, we can install these using
 
 .. code-block:: bash
 
-    $ sudo apt-get install python-dev zlib1g-dev git
+    $ sudo apt-get install python-dev zlib1g-dev git libxslt1-dev
 
 .. note::
     TODO: Document this basic step for other platforms? We definitely want
@@ -319,7 +319,7 @@ To generate a new ``_protocol_definitions.py`` file, use
 
    $ python scripts/process_schemas.py -i path/to/schemas desiredVersion
 
-Where ``desiredVersion`` is the version that will be written to the 
+Where ``desiredVersion`` is the version that will be written to the
 ``_protocol_definitions.py`` file.  This version must be in the form
 ``major.minor.revision`` where major, minor and revision can be any
 alphanumeric string.


### PR DESCRIPTION
Since bringing some extra requirements for the OIC extension, we need some extra low-level libraries to make it compile. We've hit this issue already in #484.

This updates the documentation to include the required package for ubuntu. I'll open an issue to update the docker configs as well.