### PR TITLE
Changes to Subgraph Endpoint in Graph Branch

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -133,9 +133,9 @@ class RequestFactory(object):
     def createExtractSubgraphRequest(self):
         request = protocol.ExtractSubgraphRequest()
         request.position = protocol.Position()
-        request.position.position = self.args.position
+        request.position.position = int(self.args.position)
         request.position.sequenceId = self.args.sequenceId
-        request.radius = self.args.radius
+        request.radius = int(self.args.radius)
         return request
 
     def createSearchReadsRequest(self):

--- a/ga4gh/sidegraph.py
+++ b/ga4gh/sidegraph.py
@@ -327,7 +327,7 @@ class SideGraph(object):
             sqLength = int(sq["length"])
             segStart = segEnd = pos
             if fwd:
-                segEnd = min(sqLength, pos + rad)
+                segEnd = min(sqLength-1, pos + rad)
             else:
                 segStart = max(sqStart, pos - rad)
 
@@ -360,7 +360,7 @@ class SideGraph(object):
             segments.append(dict(
                 sequenceID=seqId,
                 start=unionStart,
-                length=unionEnd - unionStart,
+                length=unionEnd - unionStart+1,
                 strandIsForward=SIDEGRAPH_TRUE))
             # With segments adjusted, now explore joins...
             foundJoins = self.getJoins(seqId, segStart, segEnd)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from ez_setup import use_setuptools
 from setuptools import setup
 
 MIN_SETUPTOOLS_VERSION = "5.4.1"
-use_setuptools (version=MIN_SETUPTOOLS_VERSION)
+use_setuptools(version=MIN_SETUPTOOLS_VERSION)
 
 
 # Following the recommendations of PEP 396 we parse the version number

--- a/tests/unit/test_sidegraph.py
+++ b/tests/unit/test_sidegraph.py
@@ -171,7 +171,7 @@ class TestCase(unittest.TestCase):
                 'sequenceID': '2'},
             {'strandIsForward': u'TRUE',
                 'start': 65,
-                'length': 20,
+                'length': 22,
                 'sequenceID': '1'}]
         expectedSegmentsSet = self.setOfDicts(expectedSegmentsArray)
         expectedJoinsArray = [


### PR DESCRIPTION
2 changes to subgraph endpoint:
    sends position,radius as ints
    fixes off-by-one errors in segment length and end position