### PR TITLE
Implement GET /readgroups/{id}

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -534,6 +534,14 @@ class AbstractBackend(object):
         dataset = self.getDataset(compoundId.datasetId)
         return self.runGetRequest(dataset.getReadGroupSetIdMap(), id_)
 
+    def runGetReadGroup(self, id_):
+        """
+        Returns a read group with the given id_
+        """
+        compoundId = reads.CompoundReadGroupId(id_)
+        dataset = self.getDataset(compoundId.datasetId)
+        return self.runGetRequest(dataset.getReadGroupIdMap(), id_)
+
     def runGetReference(self, id_):
         """
         Runs a getReference request for the specified ID.

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -531,6 +531,17 @@ class GetReadGroupSetRunner(AbstractGetRunner):
         self._run(self._httpClient.getReadGroupSet)
 
 
+class GetReadGroupRunner(AbstractGetRunner):
+    """
+    Runner class for the references/{id} method
+    """
+    def __init__(self, args):
+        super(GetReadGroupRunner, self).__init__(args)
+
+    def run(self):
+        self._run(self._httpClient.getReadGroup)
+
+
 class BenchmarkRunner(SearchVariantsRunner):
     """
     Runner class for the client side benchmarking. This is intended to give
@@ -831,6 +842,15 @@ def addReadGroupSetsGetParser(subparsers):
     addGetArguments(parser)
 
 
+def addReadGroupsGetParser(subparsers):
+    parser = subparsers.add_parser(
+        "readgroups-get",
+        description="Get a read group",
+        help="Get a read group")
+    parser.set_defaults(runner=GetReadGroupRunner)
+    addGetArguments(parser)
+
+
 def addReferencesBasesListParser(subparsers):
     parser = subparsers.add_parser(
         "references-list-bases",
@@ -861,6 +881,7 @@ def client_main(parser=None):
     addReferenceSetsGetParser(subparsers)
     addReferencesGetParser(subparsers)
     addReadGroupSetsGetParser(subparsers)
+    addReadGroupsGetParser(subparsers)
     addReferencesBasesListParser(subparsers)
 
     args = parser.parse_args()

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -198,6 +198,12 @@ class HttpClient(object):
         return self.runGetRequest(
             "readgroupsets", protocol.ReadGroupSet, id_)
 
+    def getReadGroup(self, id_):
+        """
+        Returns a read group from the server
+        """
+        return self.runGetRequest("readgroups", protocol.ReadGroup, id_)
+
     def listReferenceBases(self, protocolRequest, id_):
         """
         Returns an iterator over the bases from the server

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -578,6 +578,12 @@ def getReadGroupSet(version, id):
         version, id, flask.request, app.backend.runGetReadGroupSet)
 
 
+@DisplayedRoute('/<version>/readgroups/<id>')
+def getReadGroup(version, id):
+    return handleFlaskGetRequest(
+        version, id, flask.request, app.backend.runGetReadGroup)
+
+
 @app.route('/oauth2callback', methods=['GET'])
 def oidcCallback():
     """
@@ -653,11 +659,6 @@ def getVariant(version, id):
 
 @app.route('/<version>/datasets/<no(search):id>')
 def getDataset(version, id):
-    raise exceptions.NotImplementedException()
-
-
-@app.route('/<version>/readgroups/<id>')
-def getReadGroup(version, id):
     raise exceptions.NotImplementedException()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -152,6 +152,9 @@ class TestClientArguments(unittest.TestCase):
     def testReadGroupSetGetArguments(self):
         self.cliInput = """readgroupsets-get ID"""
 
+    def testReadGroupGetArguments(self):
+        self.cliInput = """readgroups-get ID"""
+
     def testReferenceBasesListArguments(self):
         self.cliInput = """references-list-bases ID
         --start 1 --end 2"""

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -137,6 +137,11 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient.runGetRequest.assert_called_once_with(
             "readgroupsets", protocol.ReadGroupSet, self._id)
 
+    def testGetReadGroup(self):
+        self.httpClient.getReadGroup(self._id)
+        self.httpClient.runGetRequest.assert_called_once_with(
+            "readgroups", protocol.ReadGroup, self._id)
+
     def testListReferenceBases(self):
         self.httpClient.listReferenceBases(self.protocolRequest, self._id)
         self.httpClient.runListRequest.assert_called_once_with(

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -112,6 +112,13 @@ class TestFrontend(unittest.TestCase):
         response = self.sendGetRequest(path)
         return response
 
+    def sendGetReadGroup(self, id_=None):
+        if id_ is None:
+            id_ = 'simulatedDataset1:aReadGroupSet:one'
+        path = "/readgroups/{}".format(id_)
+        response = self.sendGetRequest(path)
+        return response
+
     def sendGetReference(self, id_=None):
         if id_ is None:
             id_ = 'simple:simple'
@@ -180,6 +187,7 @@ class TestFrontend(unittest.TestCase):
         assertHeaders(self.sendGetReference())
         assertHeaders(self.sendGetReferenceSet())
         assertHeaders(self.sendGetReadGroupSet())
+        assertHeaders(self.sendGetReadGroup())
         # TODO: Test other methods as they are implemented
 
     def verifySearchRouting(self, path, getDefined=False):
@@ -282,6 +290,14 @@ class TestFrontend(unittest.TestCase):
             response.data)
         self.assertEqual(responseData.id, 'simulatedDataset1:aReadGroupSet')
 
+    def testGetReadGroup(self):
+        response = self.sendGetReadGroup()
+        self.assertEqual(200, response.status_code)
+        responseData = protocol.ReadGroup.fromJsonString(
+            response.data)
+        self.assertEqual(
+            responseData.id, 'simulatedDataset1:aReadGroupSet:one')
+
     def testCallSetsSearch(self):
         response = self.sendCallSetsSearch()
         self.assertEqual(200, response.status_code)
@@ -325,7 +341,6 @@ class TestFrontend(unittest.TestCase):
             '/callsets/<id>',
             '/variants/<id>',
             '/datasets/<id>',
-            '/readgroups/<id>',
         ]
 
         def runRequest(method, path):


### PR DESCRIPTION
No tests yet.

```
$ python client_dev.py -O readgroups-get dataset1:remote:wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample http://localhost:8000/current
dataset1:remote:wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample
```

Issue #525