### PR TITLE
Implement  GET /readgroupsets/{id}

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -526,6 +526,14 @@ class AbstractBackend(object):
 
     # Get requests.
 
+    def runGetReadGroupSet(self, id_):
+        """
+        Returns a readGroupSet with the given id_
+        """
+        compoundId = reads.CompoundReadGroupSetId(id_)
+        dataset = self.getDataset(compoundId.datasetId)
+        return self.runGetRequest(dataset.getReadGroupSetIdMap(), id_)
+
     def runGetReference(self, id_):
         """
         Runs a getReference request for the specified ID.

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -520,6 +520,17 @@ class GetReferenceRunner(AbstractGetRunner):
         self._run(self._httpClient.getReference)
 
 
+class GetReadGroupSetRunner(AbstractGetRunner):
+    """
+    Runner class for the readgroupsets/{id} method
+    """
+    def __init__(self, args):
+        super(GetReadGroupSetRunner, self).__init__(args)
+
+    def run(self):
+        self._run(self._httpClient.getReadGroupSet)
+
+
 class BenchmarkRunner(SearchVariantsRunner):
     """
     Runner class for the client side benchmarking. This is intended to give
@@ -811,6 +822,15 @@ def addReferencesGetParser(subparsers):
     addGetArguments(parser)
 
 
+def addReadGroupSetsGetParser(subparsers):
+    parser = subparsers.add_parser(
+        "readgroupsets-get",
+        description="Get a read group set",
+        help="Get a read group set")
+    parser.set_defaults(runner=GetReadGroupSetRunner)
+    addGetArguments(parser)
+
+
 def addReferencesBasesListParser(subparsers):
     parser = subparsers.add_parser(
         "references-list-bases",
@@ -840,6 +860,7 @@ def client_main(parser=None):
     addDatasetsSearchParser(subparsers)
     addReferenceSetsGetParser(subparsers)
     addReferencesGetParser(subparsers)
+    addReadGroupSetsGetParser(subparsers)
     addReferencesBasesListParser(subparsers)
 
     args = parser.parse_args()

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -191,6 +191,13 @@ class HttpClient(object):
         """
         return self.runGetRequest("references", protocol.Reference, id_)
 
+    def getReadGroupSet(self, id_):
+        """
+        Returns a read group set from the server
+        """
+        return self.runGetRequest(
+            "readgroupsets", protocol.ReadGroupSet, id_)
+
     def listReferenceBases(self, protocolRequest, id_):
         """
         Returns an iterator over the bases from the server

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -570,6 +570,14 @@ def getVariantSet(version, id):
         version, id, flask.request, app.backend.runGetVariantSet)
 
 
+@DisplayedRoute(
+    '/<version>/readgroupsets/<no(search):id>',
+    pathDisplay='/<version>/readgroupsets/<id>')
+def getReadGroupSet(version, id):
+    return handleFlaskGetRequest(
+        version, id, flask.request, app.backend.runGetReadGroupSet)
+
+
 @app.route('/oauth2callback', methods=['GET'])
 def oidcCallback():
     """
@@ -645,11 +653,6 @@ def getVariant(version, id):
 
 @app.route('/<version>/datasets/<no(search):id>')
 def getDataset(version, id):
-    raise exceptions.NotImplementedException()
-
-
-@app.route('/<version>/readgroupsets/<no(search):id>')
-def getReadGroupSet(version, id):
     raise exceptions.NotImplementedException()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -149,6 +149,9 @@ class TestClientArguments(unittest.TestCase):
     def testReferenceGetArguments(self):
         self.cliInput = """references-get ID"""
 
+    def testReadGroupSetGetArguments(self):
+        self.cliInput = """readgroupsets-get ID"""
+
     def testReferenceBasesListArguments(self):
         self.cliInput = """references-list-bases ID
         --start 1 --end 2"""

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -132,6 +132,11 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient.runGetRequest.assert_called_once_with(
             "references", protocol.Reference, self._id)
 
+    def testGetReadGroupSets(self):
+        self.httpClient.getReadGroupSet(self._id)
+        self.httpClient.runGetRequest.assert_called_once_with(
+            "readgroupsets", protocol.ReadGroupSet, self._id)
+
     def testListReferenceBases(self):
         self.httpClient.listReferenceBases(self.protocolRequest, self._id)
         self.httpClient.runListRequest.assert_called_once_with(

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -119,6 +119,13 @@ class TestFrontend(unittest.TestCase):
         response = self.sendGetRequest(path)
         return response
 
+    def sendGetReadGroupSet(self, id_=None):
+        if id_ is None:
+            id_ = 'simulatedDataset1:aReadGroupSet'
+        path = "/readgroupsets/{}".format(id_)
+        response = self.sendGetRequest(path)
+        return response
+
     def sendGetReferenceSet(self, id_=None):
         if id_ is None:
             id_ = 'simple'
@@ -172,6 +179,7 @@ class TestFrontend(unittest.TestCase):
         assertHeaders(self.sendGetVariantSet())
         assertHeaders(self.sendGetReference())
         assertHeaders(self.sendGetReferenceSet())
+        assertHeaders(self.sendGetReadGroupSet())
         # TODO: Test other methods as they are implemented
 
     def verifySearchRouting(self, path, getDefined=False):
@@ -267,6 +275,13 @@ class TestFrontend(unittest.TestCase):
         response = self.sendGetVariantSet(str(compoundId))
         self.assertEqual(404, response.status_code)
 
+    def testGetReadGroupSet(self):
+        response = self.sendGetReadGroupSet()
+        self.assertEqual(200, response.status_code)
+        responseData = protocol.ReadGroupSet.fromJsonString(
+            response.data)
+        self.assertEqual(responseData.id, 'simulatedDataset1:aReadGroupSet')
+
     def testCallSetsSearch(self):
         response = self.sendCallSetsSearch()
         self.assertEqual(200, response.status_code)
@@ -310,7 +325,6 @@ class TestFrontend(unittest.TestCase):
             '/callsets/<id>',
             '/variants/<id>',
             '/datasets/<id>',
-            '/readgroupsets/<id>',
             '/readgroups/<id>',
         ]
 


### PR DESCRIPTION
Tests to come.

```
$ python client_dev.py -O readgroupsets-get dataset1:remote http://localhost:8000/currentdataset1:remote
```

Issue #524