### PR TITLE
Refactor backend to make application edge clearer.

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -501,73 +501,73 @@ def indexRedirect(version):
 @DisplayedRoute('/<version>/references/<id>')
 def getReference(version, id):
     return handleFlaskGetRequest(
-        version, id, flask.request, app.backend.getReference)
+        version, id, flask.request, app.backend.runGetReference)
 
 
 @DisplayedRoute('/<version>/referencesets/<id>')
 def getReferenceSet(version, id):
     return handleFlaskGetRequest(
-        version, id, flask.request, app.backend.getReferenceSet)
+        version, id, flask.request, app.backend.runGetReferenceSet)
 
 
 @DisplayedRoute('/<version>/references/<id>/bases')
 def listReferenceBases(version, id):
     return handleFlaskListRequest(
-        version, id, flask.request, app.backend.listReferenceBases)
+        version, id, flask.request, app.backend.runListReferenceBases)
 
 
 @DisplayedRoute('/<version>/callsets/search', postMethod=True)
 def searchCallSets(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchCallSets)
+        version, flask.request, app.backend.runSearchCallSets)
 
 
 @DisplayedRoute('/<version>/readgroupsets/search', postMethod=True)
 def searchReadGroupSets(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchReadGroupSets)
+        version, flask.request, app.backend.runSearchReadGroupSets)
 
 
 @DisplayedRoute('/<version>/reads/search', postMethod=True)
 def searchReads(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchReads)
+        version, flask.request, app.backend.runSearchReads)
 
 
 @DisplayedRoute('/<version>/referencesets/search', postMethod=True)
 def searchReferenceSets(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchReferenceSets)
+        version, flask.request, app.backend.runSearchReferenceSets)
 
 
 @DisplayedRoute('/<version>/references/search', postMethod=True)
 def searchReferences(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchReferences)
+        version, flask.request, app.backend.runSearchReferences)
 
 
 @DisplayedRoute('/<version>/variantsets/search', postMethod=True)
 def searchVariantSets(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchVariantSets)
+        version, flask.request, app.backend.runSearchVariantSets)
 
 
 @DisplayedRoute('/<version>/variants/search', postMethod=True)
 def searchVariants(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchVariants)
+        version, flask.request, app.backend.runSearchVariants)
 
 
 @DisplayedRoute('/<version>/datasets/search', postMethod=True)
 def searchDatasets(version):
     return handleFlaskPostRequest(
-        version, flask.request, app.backend.searchDatasets)
+        version, flask.request, app.backend.runSearchDatasets)
 
 
 @DisplayedRoute('/<version>/variantsets/<no(search):id>')
 def getVariantSet(version, id):
     return handleFlaskGetRequest(
-        version, id, flask.request, app.backend.getVariantSet)
+        version, id, flask.request, app.backend.runGetVariantSet)
 
 
 @app.route('/oauth2callback', methods=['GET'])

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -57,7 +57,7 @@ class TestAbstractBackend(unittest.TestCase):
         request = protocol.SearchVariantSetsRequest()
         request.datasetId = self._backend.getDatasetIds()[0]
         return self.resultIterator(
-            request, pageSize, self._backend.searchVariantSets,
+            request, pageSize, self._backend.runSearchVariantSets,
             protocol.SearchVariantSetsResponse, "variantSets")
 
     def getVariants(
@@ -74,7 +74,7 @@ class TestAbstractBackend(unittest.TestCase):
         request.end = end
         request.callSetIds = callSetIds
         return self.resultIterator(
-            request, pageSize, self._backend.searchVariants,
+            request, pageSize, self._backend.runSearchVariants,
             protocol.SearchVariantsResponse, "variants")
 
     def getCallSets(self, variantSetId, pageSize=100):
@@ -85,7 +85,7 @@ class TestAbstractBackend(unittest.TestCase):
         request = protocol.SearchCallSetsRequest()
         request.variantSetIds = [variantSetId]
         return self.resultIterator(
-            request, pageSize, self._backend.searchCallSets,
+            request, pageSize, self._backend.runSearchCallSets,
             protocol.SearchCallSetsResponse, "callSets")
 
     def testGetVariantSets(self):
@@ -130,7 +130,8 @@ class TestAbstractBackend(unittest.TestCase):
     def testSearchVariantSets(self):
         request = protocol.SearchVariantSetsRequest()
         request.datasetId = self._backend.getDatasetIds()[0]
-        responseStr = self._backend.searchVariantSets(request.toJsonString())
+        responseStr = self._backend.runSearchVariantSets(
+            request.toJsonString())
         response = protocol.SearchVariantSetsResponse.fromJsonString(
             responseStr)
         self.assertTrue(
@@ -141,7 +142,7 @@ class TestAbstractBackend(unittest.TestCase):
             variantSet.id for variantSet in self.getVariantSets(pageSize=1)]
         request = protocol.SearchVariantsRequest()
         request.variantSetId = variantSetIds[0]
-        responseStr = self._backend.searchVariants(request.toJsonString())
+        responseStr = self._backend.runSearchVariants(request.toJsonString())
         response = protocol.SearchVariantsResponse.fromJsonString(
             responseStr)
         self.assertTrue(
@@ -152,7 +153,7 @@ class TestAbstractBackend(unittest.TestCase):
             variantSet.id for variantSet in self.getVariantSets(pageSize=1)]
         request = protocol.SearchCallSetsRequest()
         request.variantSetId = variantSetIds[0]
-        responseStr = self._backend.searchCallSets(request.toJsonString())
+        responseStr = self._backend.runSearchCallSets(request.toJsonString())
         response = protocol.SearchCallSetsResponse.fromJsonString(
             responseStr)
         self.assertTrue(
@@ -170,7 +171,7 @@ class TestAbstractBackend(unittest.TestCase):
 
     def runListReferenceBases(self, id_):
         requestArgs = {"start": 5, "end": 10, "pageToken": "0"}
-        responseStr = self._backend.listReferenceBases(id_, requestArgs)
+        responseStr = self._backend.runListReferenceBases(id_, requestArgs)
         response = protocol.ListReferenceBasesResponse.fromJsonString(
             responseStr)
         self.assertTrue(


### PR DESCRIPTION
This is a purely syntactic refactor and reorganisation to make the backend easier to work with. The basic idea is to change all of the API entry points to start with ``runX``, so that we can distinguish them from internal methods.

Also reorganised the class so that methods are grouped together more logically for readability.