### PR TITLE
Id cleanup

### DIFF
--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -230,13 +230,11 @@ class DataDrivenTest(TestCase):
     corresponding to this, and then test that these objects have the
     properties that we expect.
     """
-    def __init__(self, setId, baseDir, compoundSetId=None):
+    def __init__(self, parentContainer, setId, baseDir):
         self._setId = setId
-        if compoundSetId is not None:
-            self._setId = compoundSetId
         self._dataDir = os.path.join(baseDir, setId)
         self._gaObject = self.getDataModelClass()(
-            self._setId, self._dataDir)
+            parentContainer, self._setId, self._dataDir)
 
     def getSetId(self):
         """

--- a/tests/datadriven/test_references.py
+++ b/tests/datadriven/test_references.py
@@ -15,8 +15,8 @@ import hashlib
 # a different library here --- perhaps BioPython?
 import pysam
 
-import ga4gh.protocol as protocol
 import ga4gh.datamodel.references as references
+import ga4gh.protocol as protocol
 import tests.datadriven as datadriven
 
 
@@ -37,15 +37,11 @@ class ReferenceSetTest(datadriven.DataDrivenTest):
         Container class for information about a reference
         """
         def __init__(self, referenceSetId, fastaFileName):
-            filename = os.path.split(fastaFileName)[1]
-            compoundId = references.CompoundReferenceId.compose(
-                referenceSetId=referenceSetId, rId=filename.split(".")[0])
-            self.id = str(compoundId)
             self.fastaFile = pysam.FastaFile(fastaFileName)
             self.bases = self.fastaFile.fetch(self.fastaFile.references[0])
 
     def __init__(self, referenceSetId, baseDir):
-        super(ReferenceSetTest, self).__init__(referenceSetId, baseDir)
+        super(ReferenceSetTest, self).__init__(None, referenceSetId, baseDir)
         self._referenceInfos = {}
         for fastaFileName in glob.glob(
                 os.path.join(self._dataDir, "*.fa.gz")):
@@ -56,7 +52,11 @@ class ReferenceSetTest(datadriven.DataDrivenTest):
         self._referenceInfos[fastaFileName] = referenceInfo
 
     def getDataModelClass(self):
-        return references.HtslibReferenceSet
+        class HtslibReferenceSetWrapper(references.HtslibReferenceSet):
+            def __init__(self, parentContainer, localId, dataDir):
+                super(HtslibReferenceSetWrapper, self).__init__(
+                    localId, dataDir)
+        return HtslibReferenceSetWrapper
 
     def getProtocolClass(self):
         return protocol.ReferenceSet

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -10,9 +10,10 @@ import glob
 
 import vcf
 
-import ga4gh.protocol as protocol
 import ga4gh.datamodel as datamodel
+import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.variants as variants
+import ga4gh.protocol as protocol
 import tests.datadriven as datadriven
 import tests.utils as utils
 
@@ -30,10 +31,8 @@ class VariantSetTest(datadriven.DataDrivenTest):
     built by the variants.VariantSet object.
     """
     def __init__(self, variantSetId, baseDir):
-        compoundId = variants.CompoundVariantSetId.compose(
-            datasetId='dataset1', vsId=variantSetId)
-        super(VariantSetTest, self).__init__(
-            variantSetId, baseDir, str(compoundId))
+        dataset = datasets.AbstractDataset("ds")
+        super(VariantSetTest, self).__init__(dataset, variantSetId, baseDir)
         self._variantRecords = []
         self._referenceNames = set()
         # Read in all the VCF files in datadir and store each variant.
@@ -167,12 +166,11 @@ class VariantSetTest(datadriven.DataDrivenTest):
         leaving searchSampleIds will get all samples.
         """
         gaCallSetVariants = []
-        gaId = self._gaObject.getId()
         for referenceName in self._referenceNames:
             end = datamodel.PysamDatamodelMixin.vcfMax
             gaSearchIds = [
-                str(variants.CompoundCallsetId.compose(
-                    variantSetId=gaId, csId=sampleId))
+                str(datamodel.CallSetCompoundId(
+                    self._gaObject.getCompoundId(), sampleId))
                 for sampleId in searchsampleIds]
             gaVariants = list(self._gaObject.getVariants(
                 referenceName, 0, end, searchVariants, gaSearchIds))

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -15,8 +15,6 @@ from __future__ import unicode_literals
 import server_test
 import client
 
-import ga4gh.datamodel.references as references
-
 
 class TestGestalt(server_test.ServerTest):
     """
@@ -85,8 +83,7 @@ class TestGestalt(server_test.ServerTest):
 
     def runReferencesRequest(self):
         referenceSetId = 'referenceSet0'
-        referenceId = references.CompoundReferenceId.compose(
-            referenceSetId=referenceSetId, rId='srs0')
+        referenceId = referenceSetId + ":srs0"
         cmd = "referencesets-search"
         self.runClientCmd(self.client, cmd)
         cmd = "references-search"

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -211,10 +211,11 @@ class TestFileSystemBackend(TestAbstractBackend):
         self.assertEqual(len(variantSets), len(self._vcfs))
         ids = set(variantSet.id for variantSet in variantSets)
         datasetId = self._backend.getDatasetIds()[0]
-        vcfKeys = set(
-            str(variants.CompoundVariantSetId.compose(
-                datasetId=datasetId, vsId=vsId))
-            for vsId in self._vcfs.keys())
+        dataset = self._backend.getDataset(datasetId)
+        vcfKeys = set()
+        for localId in self._vcfs.keys():
+            tmpVariantSet = variants.AbstractVariantSet(dataset, localId)
+            vcfKeys.add(tmpVariantSet.getId())
         self.assertEqual(ids, vcfKeys)
 
     def testRunListReferenceBases(self):

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -9,6 +9,7 @@ import unittest
 
 import ga4gh.datamodel as datamodel
 import ga4gh.exceptions as exceptions
+import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.variants as variants
 import ga4gh.datamodel.references as references
 import ga4gh.datamodel.reads as reads
@@ -17,84 +18,245 @@ import ga4gh.datamodel.reads as reads
 class ExampleCompoundId(datamodel.CompoundId):
     separator = ';'
     fields = ['foo', 'bar', 'baz']
-    comboFields = {
-        'bazfoo': [2, 0],
-    }
+    containerIds = [('foobar', 1), ('foobarbaz', 2)]
 
 
 class TestCompoundIds(unittest.TestCase):
     """
     Test the compound ids
     """
-    def testBadInit(self):
-        with self.assertRaises(exceptions.BadIdentifierException):
-            ExampleCompoundId(5)
-        with self.assertRaises(exceptions.BadIdentifierException):
-            ExampleCompoundId(None)
-        with self.assertRaises(exceptions.BadIdentifierException):
-            ExampleCompoundId('a;b')
+    def testBadParse(self):
+        for badId in [5, None, 'a;b', 'a;b;c;d', 'a;b;', ';;;', ';;;;']:
+            with self.assertRaises(exceptions.BadIdentifierException):
+                ExampleCompoundId.parse(badId)
+
+    def verifyParseFailure(self, idStr, compoundIdClass):
+        """
+        Verifies that substrings and superstrings of the specified parsing
+        ID string correctly raise parse failures.
+        """
+        # first, check if we really can parse the string
+        cid = compoundIdClass.parse(idStr)
+        self.assertIsNotNone(cid)
+        # Now, check for substrings
+        for j in range(len(idStr)):
+            self.assertRaises(
+                exceptions.BadIdentifierException, compoundIdClass.parse,
+                idStr[:j])
+            self.assertRaises(
+                exceptions.BadIdentifierException, compoundIdClass.parse,
+                idStr[j + 1:])
+        # Adding on an extra field should also provoke a parse error.
+        self.assertRaises(
+            exceptions.BadIdentifierException, compoundIdClass.parse,
+            idStr + ":b")
 
     def testAttrs(self):
-        compoundId = ExampleCompoundId('a;b;c')
+        compoundId = ExampleCompoundId.parse('a;b;c')
         self.assertEqual(compoundId.foo, 'a')
         self.assertEqual(compoundId.bar, 'b')
         self.assertEqual(compoundId.baz, 'c')
-        self.assertEqual(compoundId.bazfoo, 'c;a')
+        self.assertEqual(compoundId.foobar, 'a;b')
+        self.assertEqual(compoundId.foobarbaz, 'a;b;c')
 
-    def testCompose(self):
-        compoundId = ExampleCompoundId.compose(bar=5, bazfoo='c;a')
+    def testInstantiate(self):
+        compoundId = ExampleCompoundId(None, "a", "5", "c")
         compoundIdStr = str(compoundId)
         self.assertEqual(compoundIdStr, 'a;5;c')
         self.assertEqual(compoundId.__class__, ExampleCompoundId)
 
-    def testComposeFail(self):
-        with self.assertRaises(ValueError):
-            ExampleCompoundId.compose(notValid='invalidKey')
-        with self.assertRaises(ValueError):
-            ExampleCompoundId.compose(bazfoo='too;many;entries')
+    def getDataset(self):
+        return datasets.AbstractDataset("dataset")
 
-    def testCompoundVariantId(self):
-        compoundId = variants.CompoundVariantId('a:b:c:d')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.vsId, 'b')
-        self.assertEqual(compoundId.referenceName, 'c')
-        self.assertEqual(compoundId.start, 'd')
-        self.assertEqual(compoundId.variantSetId, 'a:b')
-        self.assertEqual(compoundId.variantId, 'c:d')
+    def getReferenceSet(self):
+        return references.AbstractReferenceSet("referenceSet")
 
-    def testCompoundVariantSetId(self):
-        compoundId = variants.CompoundVariantSetId('a:b')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.vsId, 'b')
+    def getVariantSet(self):
+        return variants.AbstractVariantSet(self.getDataset(), "variantSet")
 
-    def testCompoundCallsetId(self):
-        compoundId = variants.CompoundCallsetId('a:b:c')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.vsId, 'b')
-        self.assertEqual(compoundId.csId, 'c')
+    def getReadGroupSet(self):
+        return reads.AbstractReadGroupSet(self.getDataset(), "readGroupSet")
 
-    def testCompoundReadGroupSetId(self):
-        compoundId = reads.CompoundReadGroupSetId('a:b')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.rgsId, 'b')
+    def getReadGroup(self):
+        return reads.AbstractReadGroup(self.getReadGroupSet(), "readGroup")
 
-    def testCompoundReadGroupId(self):
-        compoundId = reads.CompoundReadGroupId('a:b:c')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.rgsId, 'b')
-        self.assertEqual(compoundId.rgId, 'c')
-        self.assertEqual(compoundId.readGroupSetId, 'a:b')
+    def testDataset(self):
+        localId = "dataset"
+        cid = datamodel.DatasetCompoundId(None, localId)
+        self.assertRaises(
+            ValueError, datamodel.DatasetCompoundId, None)
+        self.assertEqual(cid.dataset, localId)
 
-    def testCompoundReadAlignmentId(self):
-        compoundId = reads.CompoundReadAlignmentId('a:b:c:d')
-        self.assertEqual(compoundId.datasetId, 'a')
-        self.assertEqual(compoundId.rgsId, 'b')
-        self.assertEqual(compoundId.rgId, 'c')
-        self.assertEqual(compoundId.raId, 'd')
-        self.assertEqual(compoundId.readGroupSetId, 'a:b')
-        self.assertEqual(compoundId.readGroupId, 'a:b:c')
+    def testDatasetParse(self):
+        idStr = "a"
+        cid = datamodel.DatasetCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.verifyParseFailure(idStr, datamodel.DatasetCompoundId)
 
-    def testCompoundReferenceId(self):
-        compoundId = references.CompoundReferenceId('a:b')
-        self.assertEqual(compoundId.referenceSetId, 'a')
-        self.assertEqual(compoundId.rId, 'b')
+    def testVariantSet(self):
+        dataset = self.getDataset()
+        localId = "variantSet"
+        cid = datamodel.VariantSetCompoundId(dataset.getCompoundId(), localId)
+        self.assertRaises(
+            ValueError, datamodel.VariantCompoundId, dataset.getCompoundId())
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.variantSet, localId)
+        self.assertEqual(cid.datasetId, dataset.getId())
+
+    def testVariantSetParse(self):
+        idStr = "a:b"
+        cid = datamodel.VariantSetCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.variantSet, "b")
+        self.verifyParseFailure(idStr, datamodel.VariantSetCompoundId)
+
+    def testCallSet(self):
+        name = "sampleName"
+        variantSet = self.getVariantSet()
+        dataset = variantSet.getParentContainer()
+        cid = datamodel.CallSetCompoundId(variantSet.getCompoundId(), name)
+        self.assertRaises(
+            ValueError, datamodel.CallSetCompoundId,
+            variantSet.getCompoundId())
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.variantSet, variantSet.getLocalId())
+        self.assertEqual(cid.name, name)
+        self.assertEqual(cid.datasetId, dataset.getId())
+        self.assertEqual(cid.variantSetId, variantSet.getId())
+
+    def testCallSetParse(self):
+        idStr = "a:b:c"
+        cid = datamodel.CallSetCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.variantSet, "b")
+        self.assertEqual(cid.name, "c")
+        self.verifyParseFailure(idStr, datamodel.CallSetCompoundId)
+
+    def testVariant(self):
+        referenceName = "referenceName"
+        start = "start"
+        variantSet = self.getVariantSet()
+        dataset = variantSet.getParentContainer()
+        cid = datamodel.VariantCompoundId(
+            variantSet.getCompoundId(), referenceName, start)
+        self.assertRaises(
+            ValueError, datamodel.VariantCompoundId,
+            variantSet.getCompoundId())
+        self.assertRaises(
+            ValueError, datamodel.VariantCompoundId,
+            variantSet.getCompoundId(), referenceName)
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.variantSet, variantSet.getLocalId())
+        self.assertEqual(cid.referenceName, referenceName)
+        self.assertEqual(cid.start, start)
+        self.assertEqual(cid.datasetId, dataset.getId())
+        self.assertEqual(cid.variantSetId, variantSet.getId())
+
+    def testVariantParse(self):
+        idStr = "a:b:c:d"
+        cid = datamodel.VariantCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.variantSet, "b")
+        self.assertEqual(cid.referenceName, "c")
+        self.assertEqual(cid.start, "d")
+        self.verifyParseFailure(idStr, datamodel.VariantCompoundId)
+
+    def testReferenceSet(self):
+        localId = "referenceSet"
+        cid = datamodel.ReferenceSetCompoundId(None, localId)
+        self.assertRaises(
+            ValueError, datamodel.ReferenceSetCompoundId, None)
+        self.assertEqual(cid.referenceSet, localId)
+
+    def testReferenceSetParse(self):
+        idStr = "a"
+        cid = datamodel.ReferenceSetCompoundId.parse(idStr)
+        self.assertEqual(cid.referenceSet, "a")
+        self.verifyParseFailure(idStr, datamodel.ReferenceSetCompoundId)
+
+    def testReference(self):
+        referenceSet = self.getReferenceSet()
+        localId = "reference"
+        cid = datamodel.ReferenceCompoundId(
+            referenceSet.getCompoundId(), localId)
+        self.assertRaises(
+            ValueError, datamodel.ReferenceCompoundId,
+            referenceSet.getCompoundId())
+        self.assertEqual(cid.referenceSet, referenceSet.getLocalId())
+        self.assertEqual(cid.reference, localId)
+        self.assertEqual(cid.referenceSetId, referenceSet.getId())
+
+    def testReferenceParse(self):
+        idStr = "a:b"
+        cid = datamodel.ReferenceCompoundId.parse(idStr)
+        self.assertEqual(cid.referenceSet, "a")
+        self.assertEqual(cid.reference, "b")
+        self.verifyParseFailure(idStr, datamodel.ReferenceCompoundId)
+
+    def testReadGroupSet(self):
+        dataset = self.getDataset()
+        localId = "readGroupSet"
+        cid = datamodel.ReadGroupSetCompoundId(
+            dataset.getCompoundId(), localId)
+        self.assertRaises(
+            ValueError, datamodel.ReadGroupSetCompoundId,
+            dataset.getCompoundId())
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.readGroupSet, localId)
+
+    def testReadGroupSetParse(self):
+        idStr = "a:b"
+        cid = datamodel.ReadGroupSetCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.readGroupSet, "b")
+        self.verifyParseFailure(idStr, datamodel.ReadGroupSetCompoundId)
+
+    def testReadGroup(self):
+        readGroupSet = self.getReadGroupSet()
+        dataset = readGroupSet.getParentContainer()
+        localId = "readGroup"
+        cid = datamodel.ReadGroupCompoundId(
+            readGroupSet.getCompoundId(), localId)
+        self.assertRaises(
+            ValueError, datamodel.ReadGroupCompoundId,
+            readGroupSet.getCompoundId())
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.readGroupSet, readGroupSet.getLocalId())
+        self.assertEqual(cid.readGroup, localId)
+        self.assertEqual(cid.datasetId, dataset.getId())
+        self.assertEqual(cid.readGroupSetId, readGroupSet.getId())
+
+    def testReadGroupParse(self):
+        idStr = "a:b:c"
+        cid = datamodel.ReadGroupCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.readGroupSet, "b")
+        self.assertEqual(cid.readGroup, "c")
+        self.verifyParseFailure(idStr, datamodel.ReadGroupCompoundId)
+
+    def testReadAlignment(self):
+        readGroup = self.getReadGroup()
+        readGroupSet = readGroup.getParentContainer()
+        dataset = readGroupSet.getParentContainer()
+        localId = "alignment"
+        cid = datamodel.ReadAlignmentCompoundId(
+            readGroup.getCompoundId(), localId)
+        self.assertRaises(
+            ValueError, datamodel.ReadAlignmentCompoundId,
+            dataset.getCompoundId())
+        self.assertEqual(cid.dataset, dataset.getLocalId())
+        self.assertEqual(cid.readGroupSet, readGroupSet.getLocalId())
+        self.assertEqual(cid.readGroup, readGroup.getLocalId())
+        self.assertEqual(cid.readAlignment, localId)
+        self.assertEqual(cid.datasetId, dataset.getId())
+        self.assertEqual(cid.readGroupSetId, readGroupSet.getId())
+        self.assertEqual(cid.readGroupId, readGroup.getId())
+
+    def testReadAlignmentParse(self):
+        idStr = "a:b:c:d"
+        cid = datamodel.ReadAlignmentCompoundId.parse(idStr)
+        self.assertEqual(cid.dataset, "a")
+        self.assertEqual(cid.readGroupSet, "b")
+        self.assertEqual(cid.readGroup, "c")
+        self.assertEqual(cid.readAlignment, "d")
+        self.verifyParseFailure(idStr, datamodel.ReadAlignmentCompoundId)

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -8,8 +8,9 @@ from __future__ import unicode_literals
 import os
 import unittest
 
-import ga4gh.datamodel.variants as variants
+import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.references as references
+import ga4gh.datamodel.variants as variants
 import ga4gh.exceptions as exceptions
 import ga4gh.protocol as protocol
 
@@ -17,68 +18,62 @@ import ga4gh.protocol as protocol
 class FaultyVariantDataTest(unittest.TestCase):
     def setUp(self):
         self.testDataDir = "tests/faultydata/variants"
-        self.datasetId = 'dataset1'
+        self.dataset = datasets.AbstractDataset('dataset1')
 
-    def getFullPath(self, variantSetId):
-        return os.path.join(self.testDataDir, variantSetId)
+    def getFullPath(self, localId):
+        return os.path.join(self.testDataDir, localId)
 
 
 class TestVariantSetNoIndexedVcf(FaultyVariantDataTest):
     setIds = ["no_indexed_vcf"]
 
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             self.assertRaises(
                 exceptions.NotIndexedException,
-                variants.HtslibVariantSet, variantSetId, path)
+                variants.HtslibVariantSet, self.dataset, localId, path)
 
 
 class TestInconsistentMetaData(FaultyVariantDataTest):
     setIds = ["inconsist_meta"]
 
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
-            compoundId = variants.CompoundVariantSetId.compose(
-                datasetId=self.datasetId, vsId=variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             with self.assertRaises(exceptions.InconsistentMetaDataException):
-                variants.HtslibVariantSet(str(compoundId), path)
+                variants.HtslibVariantSet(self.dataset, localId, path)
 
 
 class TestInconsistentCallSetId(FaultyVariantDataTest):
     setIds = ["inconsist_sampleid", "inconsist_sampleid2"]
 
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
-            compoundId = variants.CompoundVariantSetId.compose(
-                datasetId=self.datasetId, vsId=variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             with self.assertRaises(exceptions.InconsistentCallSetIdException):
-                variants.HtslibVariantSet(str(compoundId), path)
+                variants.HtslibVariantSet(self.dataset, localId, path)
 
 
 class TestOverlappingVcfVariants(FaultyVariantDataTest):
     setIds = ["overlapping_vcf"]
 
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
-            compoundId = variants.CompoundVariantSetId.compose(
-                datasetId=self.datasetId, vsId=variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             with self.assertRaises(exceptions.OverlappingVcfException):
-                variants.HtslibVariantSet(str(compoundId), path)
+                variants.HtslibVariantSet(self.dataset, localId, path)
 
 
 class TestEmptyDirException(FaultyVariantDataTest):
     setIds = ["empty_dir"]
 
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             self.assertRaises(
                 exceptions.EmptyDirException,
-                variants.HtslibVariantSet, variantSetId, path)
+                variants.HtslibVariantSet, self.dataset, localId, path)
 
 
 class TestDuplicateCallSetId(FaultyVariantDataTest):
@@ -98,11 +93,11 @@ class TestDuplicateCallSetId(FaultyVariantDataTest):
 
     @unittest.skipIf(protocol.version.startswith("0.6"), "")
     def testInstantiation(self):
-        for variantSetId in self.setIds:
-            path = self.getFullPath(variantSetId)
+        for localId in self.setIds:
+            path = self.getFullPath(localId)
             self.assertRaises(
                 exceptions.DuplicateCallSetIdException,
-                variants.HtslibVariantSet, variantSetId, path)
+                variants.HtslibVariantSet, self.dataset, localId, path)
 
 
 class FaultyReferenceDataTest(unittest.TestCase):

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -11,6 +11,7 @@ import unittest
 import hashlib
 import logging
 
+import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.variants as variants
 import ga4gh.frontend as frontend
 import ga4gh.protocol as protocol
@@ -102,11 +103,10 @@ class TestSimulatedStack(unittest.TestCase):
             self.assertEqual(200, response.status_code)
             responseObject = protocol.VariantSet.fromJsonString(response.data)
             self.assertEqual(responseObject.id, variantSetId)
-        datasetId = 'dataset1'
-        for badId in ["", "terribly bad ID value", "x" * 1000]:
-            compoundId = variants.CompoundVariantSetId.compose(
-                datasetId=datasetId, vsId=badId)
-            response = self.sendObjectGetRequest(path, str(compoundId))
+        dataset = datasets.AbstractDataset("dataset1")
+        for badId in ["terribly bad ID value", "x" * 1000]:
+            variantSet = variants.AbstractVariantSet(dataset, badId)
+            response = self.sendObjectGetRequest(path, variantSet.getId())
             self.assertEqual(404, response.status_code)
 
     def testVariantsSearch(self):

--- a/tests/unit/test_simulator.py
+++ b/tests/unit/test_simulator.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 
 import unittest
 
+import ga4gh.datamodel as datamodel
+import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.reads as reads
 import ga4gh.datamodel.variants as variants
 
@@ -20,10 +22,6 @@ class TestSimulatedVariantSet(unittest.TestCase):
         self.numCalls = 2
         # ensure variantDensity is >= 1 so we get deterministic behavoir
         self.variantDensity = 1
-        self.datasetId = 'dataset1'
-        compoundId = variants.CompoundVariantSetId.compose(
-            datasetId=self.datasetId, vsId=3)
-        self.variantSetId = str(compoundId)
         self.simulatedVariantSet = self._getSimulatedVariantSet()
         self.referenceName = 'ref'
         self.startPosition = 100
@@ -33,9 +31,10 @@ class TestSimulatedVariantSet(unittest.TestCase):
         self.bases = ["A", "C", "G", "T"]
 
     def _getSimulatedVariantSet(self):
+        dataset = datasets.AbstractDataset('dataset1')
         simulatedVariantSet = variants.SimulatedVariantSet(
-            self.randomSeed, self.numCalls,
-            self.variantDensity, self.variantSetId)
+            dataset, 'variantSet1', self.randomSeed, self.numCalls,
+            self.variantDensity)
         return simulatedVariantSet
 
     def _getSimulatedVariantsList(self, simulatedVariantSet=None):
@@ -56,8 +55,6 @@ class TestSimulatedVariantSet(unittest.TestCase):
         self.assertEqual(
             self.variantDensity, self.simulatedVariantSet._variantDensity)
         self.assertEqual(
-            self.variantSetId, self.simulatedVariantSet._id)
-        self.assertEqual(
             self.simulatedVariantSet.getCreationTime(),
             self.simulatedVariantSet.getUpdatedTime())
 
@@ -66,19 +63,34 @@ class TestSimulatedVariantSet(unittest.TestCase):
         variantList = self._getSimulatedVariantsList()
         self.assertEqual(
             len(variantList), self.endPosition - self.startPosition)
-        simulatedVariant = variantList[0]
-        self.assertIn(str(self.variantSetId), simulatedVariant.id)
-        self.assertIn(self.referenceName, simulatedVariant.id)
-        self.assertIn(str(self.startPosition), simulatedVariant.id)
-        self.assertEqual(simulatedVariant.variantSetId, self.variantSetId)
-        self.assertEqual(simulatedVariant.referenceName, self.referenceName)
-        self.assertEqual(simulatedVariant.created, simulatedVariant.updated)
-        self.assertEqual(simulatedVariant.start, self.startPosition)
-        self.assertEqual(simulatedVariant.end, self.startPosition + 1)
-        self.assertIn(simulatedVariant.referenceBases, self.bases)
-        self.assertIn(
-            simulatedVariant.alternateBases[0], self.bases)
-        self.assertEqual(len(simulatedVariant.calls), self.numCalls)
+        for offset, simulatedVariant in enumerate(variantList):
+            start = self.startPosition + offset
+            variantSetCompoundId = self.simulatedVariantSet.getCompoundId()
+            variantCompoundId = datamodel.VariantCompoundId.parse(
+                simulatedVariant.id)
+            self.assertEqual(
+                variantSetCompoundId.variantSetId,
+                self.simulatedVariantSet.getId())
+            self.assertEqual(
+                variantSetCompoundId.variantSetId,
+                variantCompoundId.variantSetId)
+            self.assertEqual(
+                variantCompoundId.referenceName, self.referenceName)
+            self.assertEqual(
+                variantCompoundId.start, str(simulatedVariant.start))
+            self.assertEqual(
+                simulatedVariant.variantSetId,
+                self.simulatedVariantSet.getId())
+            self.assertEqual(
+                simulatedVariant.referenceName, self.referenceName)
+            self.assertEqual(
+                simulatedVariant.created, simulatedVariant.updated)
+            self.assertEqual(simulatedVariant.start, start)
+            self.assertEqual(simulatedVariant.end, start + 1)
+            self.assertIn(simulatedVariant.referenceBases, self.bases)
+            self.assertIn(
+                simulatedVariant.alternateBases[0], self.bases)
+            self.assertEqual(len(simulatedVariant.calls), self.numCalls)
 
     def testConsistency(self):
         # two SimulatedBackend objects given the same parameters
@@ -112,9 +124,10 @@ class TestSimulatedReadGroupSet(unittest.TestCase):
     Test properties of the simulated ReadGroupSet
     """
     def testCreation(self):
-        compoundId = reads.CompoundReadGroupSetId("dataset1:readGroupSetId")
+        dataset = datasets.AbstractDataset('dataset1')
+        localId = "readGroupSetId"
         simulatedReadGroupSet = reads.SimulatedReadGroupSet(
-            str(compoundId))
+                dataset, localId)
         for readGroup in simulatedReadGroupSet.getReadGroups():
             alignments = list(readGroup.getReadAlignments())
             self.assertGreater(len(alignments), 0)

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import unittest
 import logging
 
-import ga4gh.datamodel.variants as variants
+import ga4gh.datamodel as datamodel
 import ga4gh.frontend as frontend
 import ga4gh.protocol as protocol
 import tests.utils as utils
@@ -286,7 +286,7 @@ class TestFrontend(unittest.TestCase):
         variantSetId = responseData.variantSets[0].id
         response = self.sendGetVariantSet(variantSetId)
         self.assertEqual(200, response.status_code)
-        compoundId = variants.CompoundVariantSetId("notValid:notValid")
+        compoundId = datamodel.VariantSetCompoundId.parse("notValid:notValid")
         response = self.sendGetVariantSet(str(compoundId))
         self.assertEqual(404, response.status_code)
 


### PR DESCRIPTION
This is a fairly widespread refactoring of the datamodel code. Changes:

1. All of the datamodel objects actually inherit from datamodel.DatamodelObject now. Each one has a CompoundId and a localId. 
2. Refactored the CompoundId concept a bit to fit into this.

The aim of this is to get a proper, linked up model in memory of our data tree. This should make issues like #535 simple to fix (should be fixed already, in fact; it would be better to verify this and add some test cases in a follow up PR though).

There's still some tests to fix, but I ran out of time. Hopefully I'll finish this PR later.

Comments/feedback?