### PR TITLE
Refactor reference handling and some tests.

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -103,6 +103,7 @@ class RequestFactory(object):
         request = protocol.SearchReferencesRequest()
         setCommaSeparatedAttribute(request, self.args, 'accessions')
         setCommaSeparatedAttribute(request, self.args, 'md5checksums')
+        request.referenceSetId = self.args.referenceSetId
         return request
 
     def createSearchReadGroupSetsRequest(self):
@@ -678,6 +679,12 @@ def addDatasetIdArgument(parser):
         help="The datasetId to search over")
 
 
+def addReferenceSetIdArgument(parser):
+    parser.add_argument(
+        "--referenceSetId", default=None,
+        help="The referenceSet to search over")
+
+
 def addNameArgument(parser):
     parser.add_argument(
         "--name", default=None,
@@ -764,6 +771,7 @@ def addReferencesSearchParser(subparsers):
     addPageSizeArgument(parser)
     addAccessionsArgument(parser)
     addMd5ChecksumsArgument(parser)
+    addReferenceSetIdArgument(parser)
     return parser
 
 

--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -177,10 +177,6 @@ class CompoundId(object):
             idFormat = cls.separator.join(cls.fields)
             msg = "(id must be in format {})".format(idFormat)
             raise exceptions.BadIdentifierException(compoundIdStr, msg)
-        for identifier in splits:
-            msg = "Cannot have empty sections within identifier."
-            if len(identifier) == 0:
-                raise exceptions.BadIdentifierException(compoundIdStr, msg)
         return cls(None, *splits)
 
 

--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -50,7 +50,7 @@ class AbstractDataset(datamodel.DatamodelObject):
         """
         Returns the list of VariantSets in this dataset
         """
-        return self._variantSetIdMap.values()
+        return [self._variantSetIdMap[id_] for id_ in self._variantSetIds]
 
     def getReadGroupSetIds(self):
         """

--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -34,7 +34,13 @@ class AbstractReferenceSet(datamodel.DatamodelObject):
         """
         Returns the References in this ReferenceSet.
         """
-        return self._referenceIdMap.values()
+        return [self._referenceIdMap[id_] for id_ in self._referenceIds]
+
+    def getReferenceIdMap(self):
+        return self._referenceIdMap
+
+    def getReferenceIds(self):
+        return self._referenceIds
 
     def toProtocolElement(self):
         """

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -197,6 +197,11 @@ class ReadGroupNotFoundException(ObjectNotFoundException):
         self.message = "readGroupId '{}' not found".format(readGroupId)
 
 
+class ReferenceSetNotFoundException(ObjectNotFoundException):
+    def __init__(self, referenceSetId):
+        self.message = "referenceSetId '{}' not found".format(referenceSetId)
+
+
 class ReferenceNotFoundException(ObjectNotFoundException):
     def __init__(self, readGroupId, referenceId, validRefs):
         self.message = (

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -163,11 +163,11 @@ class ServerStatus(object):
         app.urls.sort()
         return app.urls
 
-    def getDatasetIds(self):
+    def getDatasets(self):
         """
         Returns the list of datasetIds for this backend
         """
-        return app.backend.getDatasetIds()
+        return app.backend.getDatasets()
 
     def getVariantSets(self, datasetId):
         """

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -60,11 +60,11 @@
             </table>
 
             <h4>DataSets</h4>
-            {% for datasetId in info.getDatasetIds() %}
-                <h5>{{ datasetId }}</h5>
+            {% for dataset in info.getDatasets() %}
+                <h5>{{ dataset.getId() }}</h5>
                 <h6>VariantSets</h6>
                 <table>
-                    {% for variantSet in info.getVariantSets(datasetId) %}
+                    {% for variantSet in info.getVariantSets(dataset.getId()) %}
                     <tr>
                         <td>{{ variantSet.getId() }}</td>
                     </tr>
@@ -72,7 +72,7 @@
                 </table>
                 <h6>ReadGroupSets</h6>
                 <table>
-                    {% for readGroupSet in info.getReadGroupSets(datasetId) %}
+                    {% for readGroupSet in info.getReadGroupSets(dataset.getId())%}
                     <tr>
                         <td>{{ readGroupSet.getId() }}</td>
                         <td></td>

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -86,7 +86,7 @@ class TestGestalt(server_test.ServerTest):
         referenceId = referenceSetId + ":srs0"
         cmd = "referencesets-search"
         self.runClientCmd(self.client, cmd)
-        cmd = "references-search"
+        cmd = "references-search --referenceSetId={}".format(referenceSetId)
         self.runClientCmd(self.client, cmd)
         cmd = "referencesets-get {}".format(referenceSetId)
         self.runClientCmd(self.client, cmd)

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -36,6 +36,9 @@ class TestAbstractBackend(unittest.TestCase):
             numCalls=100, numVariantSets=10)
         # TODO arbitrary values, pepper to taste
 
+    def getDataset(self):
+        return self._backend.getDatasets()[0]
+
     def resultIterator(
             self, request, pageSize, searchMethod, ResponseClass, listMember):
         """
@@ -62,7 +65,7 @@ class TestAbstractBackend(unittest.TestCase):
         the details of the pageSize.
         """
         request = protocol.SearchVariantSetsRequest()
-        request.datasetId = self._backend.getDatasetIds()[0]
+        request.datasetId = self.getDataset().getId()
         return self.resultIterator(
             request, pageSize, self._backend.runSearchVariantSets,
             protocol.SearchVariantSetsResponse, "variantSets")
@@ -96,7 +99,7 @@ class TestAbstractBackend(unittest.TestCase):
             protocol.SearchCallSetsResponse, "callSets")
 
     def testGetVariantSets(self):
-        datasetId = self._backend.getDatasetIds()[0]
+        datasetId = self.getDataset().getId()
         sortedVariantSetsFromGetter = sorted(
             self._backend.getDataset(datasetId).getVariantSets())
         sortedVariantSetMapValues = sorted(
@@ -106,7 +109,7 @@ class TestAbstractBackend(unittest.TestCase):
 
     def testRunSearchRequest(self):
         request = protocol.SearchVariantSetsRequest()
-        request.datasetId = self._backend.getDatasetIds()[0]
+        request.datasetId = self.getDataset().getId()
         responseStr = self._backend.runSearchRequest(
             request.toJsonString(), protocol.SearchVariantSetsRequest,
             protocol.SearchVariantSetsResponse,
@@ -131,7 +134,7 @@ class TestAbstractBackend(unittest.TestCase):
 
     def testSearchVariantSets(self):
         request = protocol.SearchVariantSetsRequest()
-        request.datasetId = self._backend.getDatasetIds()[0]
+        request.datasetId = self.getDataset().getId()
         responseStr = self._backend.runSearchVariantSets(
             request.toJsonString())
         response = protocol.SearchVariantSetsResponse.fromJsonString(
@@ -210,8 +213,7 @@ class TestFileSystemBackend(TestAbstractBackend):
         variantSets = [variantSet for variantSet in self.getVariantSets()]
         self.assertEqual(len(variantSets), len(self._vcfs))
         ids = set(variantSet.id for variantSet in variantSets)
-        datasetId = self._backend.getDatasetIds()[0]
-        dataset = self._backend.getDataset(datasetId)
+        dataset = self.getDataset()
         vcfKeys = set()
         for localId in self._vcfs.keys():
             tmpVariantSet = variants.AbstractVariantSet(dataset, localId)

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -26,7 +26,7 @@ class TestCompoundIds(unittest.TestCase):
     Test the compound ids
     """
     def testBadParse(self):
-        for badId in [5, None, 'a;b', 'a;b;c;d', 'a;b;', ';;;', ';;;;']:
+        for badId in [5, None, 'a;b', 'a;b;c;d', 'a;b;sd;', ';;;;']:
             with self.assertRaises(exceptions.BadIdentifierException):
                 ExampleCompoundId.parse(badId)
 
@@ -39,13 +39,10 @@ class TestCompoundIds(unittest.TestCase):
         cid = compoundIdClass.parse(idStr)
         self.assertIsNotNone(cid)
         # Now, check for substrings
-        for j in range(len(idStr)):
+        for j in range(len(idStr) - 1):
             self.assertRaises(
                 exceptions.BadIdentifierException, compoundIdClass.parse,
                 idStr[:j])
-            self.assertRaises(
-                exceptions.BadIdentifierException, compoundIdClass.parse,
-                idStr[j + 1:])
         # Adding on an extra field should also provoke a parse error.
         self.assertRaises(
             exceptions.BadIdentifierException, compoundIdClass.parse,

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -38,8 +38,7 @@ class TestVariantsGenerator(unittest.TestCase):
     def setUp(self):
         self.request = protocol.SearchVariantsRequest()
         self.backend = backend.SimulatedBackend()
-        self.datasetId = self.backend.getDatasetIds()[0]
-        self.dataset = self.backend.getDataset(self.datasetId)
+        self.dataset = self.backend.getDatasets()[0]
         self.variantSetLocalId = 'variantSet'
 
     def testNonexistantVariantSet(self):
@@ -81,8 +80,7 @@ class TestVariantsGenerator(unittest.TestCase):
     def _initVariantSet(self, numVariants):
         variantSet = MockVariantSet(
             self.dataset, self.variantSetLocalId, numVariants)
-        self.backend.getDataset(self.datasetId)._variantSetIdMap = {
-            variantSet.getId(): variantSet}
+        self.dataset._variantSetIdMap = {variantSet.getId(): variantSet}
         self.request.variantSetId = variantSet.getId()
 
 
@@ -115,8 +113,7 @@ class TestReadsGenerator(unittest.TestCase):
         self.request = protocol.SearchReadsRequest()
         self.request.referenceId = "chr1"
         self.backend = backend.SimulatedBackend()
-        self.datasetId = self.backend.getDatasetIds()[0]
-        self.dataset = self.backend.getDataset(self.datasetId)
+        self.dataset = self.backend.getDatasets()[0]
         self.readGroupSetLocalId = "aReadGroupSet"
         self.readGroupLocalId = "aReadGroup"
         self.readGroupSet = reads.AbstractReadGroupSet(


### PR DESCRIPTION
- This changes reference handling to be symmetrical with the way datasets
are managed (fully hierarchical).

- Fixed a missing part of the CLI and API where referenceSets were not
  correctly passed to searchReferences.

- Provide getters for all datamodel objects from the backend so that
tests can access the data through a uniform interface.

- Revert a recent change to make the empty string a valid identifier
again (so we correctly 404 when someone provides a non-existant ID as a
parameter, not a different error).

Also, verifies that issues #531 and #535 have been resolved.