### PR TITLE
Keep PyCharm/IntelliJ module files out of the repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ target/
 
 # Pycharm
 .idea/
+*.iml
 
 # Unused parts of the OIDC provider
 oidc-provider/simple_op/src/provider/server/static/jwks.json


### PR DESCRIPTION
The PyCharm/IntelliJ IDEA IDE creates *.iml files to describe projects in the same way it uses the .idea directory, which is already listed in the .gitignore.
