### PR TITLE
install libxslt1-dev and libffi-dev for docker

### DIFF
--- a/.whiskey/action_hooks/pre-build
+++ b/.whiskey/action_hooks/pre-build
@@ -12,3 +12,9 @@ echo "-e ." >> /app/requirements.txt
 
 # Copy application.wsgi into the location mod-wsgi_docker expects it
 cp /app/deploy/application.wsgi /app/ga4gh/
+
+echo " -----> Installing extra libs"
+apt-get update && \
+	apt-get install -y --no-install-recommends \
+	libffi-dev \
+	libxslt1-dev


### PR DESCRIPTION
It might make sense to maintain a fork of the mod_wsgi image if we need more changes like this, but this builds nicely.  I would prefer to deprecate the ubuntu/centos images. Resolves #484 and #505. https://hub.docker.com/r/afirth/ga4gh_server_apache/builds/bmgjxowqrgrsjqugf4ncuen/