### PR TITLE
Search filters

### DIFF
--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -169,14 +169,17 @@ class CompoundId(object):
         """
         Parses the specified compoundId string and returns an instance
         of this CompoundId class.
+
+        :raises: An ObjectWithIdNotFoundException if parsing fails. This is
+        because this method is a client-facing method, and if a malformed
+        identifier (under our internal rules) is provided, the response should
+        be that the identifier does not exist.
         """
         if not isinstance(compoundIdStr, basestring):
             raise exceptions.BadIdentifierException(compoundIdStr)
         splits = compoundIdStr.split(cls.separator)
         if len(splits) != len(cls.fields):
-            idFormat = cls.separator.join(cls.fields)
-            msg = "(id must be in format {})".format(idFormat)
-            raise exceptions.BadIdentifierException(compoundIdStr, msg)
+            raise exceptions.ObjectWithIdNotFoundException(compoundIdStr)
         return cls(None, *splits)
 
 

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -66,6 +66,7 @@ class CallSet(datamodel.DatamodelObject):
         gaCallSet.id = self.getId()
         gaCallSet.name = self.getLocalId()
         gaCallSet.sampleId = self.getLocalId()
+        gaCallSet.variantSetIds = [variantSet.getId()]
         return gaCallSet
 
     def getSampleName(self):
@@ -125,9 +126,9 @@ class AbstractVariantSet(datamodel.DatamodelObject):
 
     def getCallSets(self):
         """
-        Returns an iterator over the CallSets for this VariantSet.
+        Returns the list of CallSets in this VariantSet.
         """
-        return self._callSetIdMap.values()
+        return [self._callSetIdMap[id_] for id_ in self._callSetIds]
 
     def toProtocolElement(self):
         """

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -85,6 +85,7 @@ class AbstractVariantSet(datamodel.DatamodelObject):
     def __init__(self, parentContainer, localId):
         super(AbstractVariantSet, self).__init__(parentContainer, localId)
         self._callSetIdMap = {}
+        self._callSetNameMap = {}
         self._callSetIds = []
         self._creationTime = None
         self._updatedTime = None
@@ -109,6 +110,7 @@ class AbstractVariantSet(datamodel.DatamodelObject):
         callSet = CallSet(self, sampleName)
         callSetId = callSet.getId()
         self._callSetIdMap[callSetId] = callSet
+        self._callSetNameMap[sampleName] = callSet
         self._callSetIds.append(callSetId)
 
     def getCallSetIdMap(self):
@@ -129,6 +131,15 @@ class AbstractVariantSet(datamodel.DatamodelObject):
         Returns the list of CallSets in this VariantSet.
         """
         return [self._callSetIdMap[id_] for id_ in self._callSetIds]
+
+    def getCallSetByName(self, name):
+        """
+        Returns a CallSet with the specified name, or raises a
+        CallSetNameNotFoundException if it does not exist.
+        """
+        if name not in self._callSetNameMap:
+            raise exceptions.CallSetNameNotFoundException(name)
+        return self._callSetNameMap[name]
 
     def toProtocolElement(self):
         """

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -265,6 +265,15 @@ class CallSetNotInVariantSetException(NotFoundException):
             callSetId, variantSetId)
 
 
+class CallSetNameNotFoundException(NotFoundException):
+    """
+    Indicates a request was made for a callSet with a name that
+    does not exist.
+    """
+    def __init__(self, callSetName):
+        self.message = "callSet with name '{0}' not found".format(callSetName)
+
+
 class DataException(BaseServerException):
     """
     Exceptions thrown during the server startup, and processing faulty VCFs

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -26,9 +26,12 @@ class TestCompoundIds(unittest.TestCase):
     Test the compound ids
     """
     def testBadParse(self):
-        for badId in [5, None, 'a;b', 'a;b;c;d', 'a;b;sd;', ';;;;']:
-            with self.assertRaises(exceptions.BadIdentifierException):
+        for badId in ['a;b', 'a;b;c;d', 'a;b;sd;', ';;;;']:
+            with self.assertRaises(exceptions.ObjectWithIdNotFoundException):
                 ExampleCompoundId.parse(badId)
+        for badType in [0, None, []]:
+            with self.assertRaises(exceptions.BadIdentifierException):
+                ExampleCompoundId.parse(badType)
 
     def verifyParseFailure(self, idStr, compoundIdClass):
         """
@@ -41,11 +44,11 @@ class TestCompoundIds(unittest.TestCase):
         # Now, check for substrings
         for j in range(len(idStr) - 1):
             self.assertRaises(
-                exceptions.BadIdentifierException, compoundIdClass.parse,
-                idStr[:j])
+                exceptions.ObjectWithIdNotFoundException,
+                compoundIdClass.parse, idStr[:j])
         # Adding on an extra field should also provoke a parse error.
         self.assertRaises(
-            exceptions.BadIdentifierException, compoundIdClass.parse,
+            exceptions.ObjectWithIdNotFoundException, compoundIdClass.parse,
             idStr + ":b")
 
     def testAttrs(self):


### PR DESCRIPTION
This PR fixes some miscellaneous issues relating to CallSets, and updates the top level object search code so that we always 404 when a missing ID is provided as an argument.

See the commit messages for the issues involved. I've left it as two commits as these deal with different issues.