### PR TITLE
Search by name support in readGroupSets + refactor.

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -6,12 +6,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import random
 
-import ga4gh.protocol as protocol
 import ga4gh.datamodel as datamodel
-import ga4gh.datamodel.variants as variants
 import ga4gh.datamodel.reads as reads
+import ga4gh.datamodel.variants as variants
+import ga4gh.exceptions as exceptions
+import ga4gh.protocol as protocol
 
 
 class AbstractDataset(datamodel.DatamodelObject):
@@ -26,8 +26,24 @@ class AbstractDataset(datamodel.DatamodelObject):
         self._variantSetIdMap = {}
         self._readGroupSetIds = []
         self._readGroupSetIdMap = {}
-        self._readGroupIds = []
-        self._readGroupIdMap = {}
+        self._readGroupSetNameMap = {}
+
+    def addVariantSet(self, variantSet):
+        """
+        Adds the specified variantSet to this dataset.
+        """
+        id_ = variantSet.getId()
+        self._variantSetIdMap[id_] = variantSet
+        self._variantSetIds.append(id_)
+
+    def addReadGroupSet(self, readGroupSet):
+        """
+        Adds the specified readGroupSet to this dataset.
+        """
+        id_ = readGroupSet.getId()
+        self._readGroupSetIdMap[id_] = readGroupSet
+        self._readGroupSetNameMap[readGroupSet.getLocalId()] = readGroupSet
+        self._readGroupSetIds.append(id_)
 
     def toProtocolElement(self):
         dataset = protocol.Dataset()
@@ -64,23 +80,29 @@ class AbstractDataset(datamodel.DatamodelObject):
         """
         return self._readGroupSetIdMap
 
-    def getReadGroupIds(self):
-        """
-        Return a list of ids of read groups that this dataset has
-        """
-        return self._readGroupIds
-
-    def getReadGroupIdMap(self):
-        """
-        Return a map of the dataset's read group ids to read groups
-        """
-        return self._readGroupIdMap
-
     def getReadGroupSets(self):
         """
         Returns the list of ReadGroupSets in this dataset
         """
         return self._readGroupSetIdMap.values()
+
+    def getReadGroupSetByName(self, name):
+        """
+        Returns a ReadGroupSet with the specified name, or raises a
+        ReadGroupSetNameNotFoundException if it does not exist.
+        """
+        if name not in self._readGroupSetNameMap:
+            raise exceptions.ReadGroupSetNameNotFoundException(name)
+        return self._readGroupSetNameMap[name]
+
+    def getReadGroupSet(self, id_):
+        """
+        Returns the ReadGroupSet with the specified name, or raises
+        a ReadGroupSetNotFoundException otherwise.
+        """
+        if id_ not in self._readGroupSetIdMap:
+            raise exceptions.ReadGroupNotFoundException(id_)
+        return self._readGroupSetIdMap[id_]
 
 
 class SimulatedDataset(AbstractDataset):
@@ -88,31 +110,26 @@ class SimulatedDataset(AbstractDataset):
     A simulated dataset
     """
     def __init__(
-            self, localId, randomSeed=1, numCalls=1,
-            variantDensity=1, numVariantSets=1, numAlignments=1):
+            self, localId, randomSeed=0,
+            numVariantSets=1, numCalls=1, variantDensity=0.5,
+            numReadGroupSets=1, numReadGroupsPerReadGroupSet=1,
+            numAlignments=1):
         super(SimulatedDataset, self).__init__(localId)
-        self._randomSeed = randomSeed
-        self._randomGenerator = random.Random()
-        self._randomGenerator.seed(self._randomSeed)
-
         # Variants
         for i in range(numVariantSets):
             localId = "simVs{}".format(i)
-            seed = self._randomGenerator.randint(0, 2**32 - 1)
+            seed = randomSeed + i
             variantSet = variants.SimulatedVariantSet(
                 self, localId, seed, numCalls, variantDensity)
-            self._variantSetIdMap[variantSet.getId()] = variantSet
-        self._variantSetIds = sorted(self._variantSetIdMap.keys())
-
+            self.addVariantSet(variantSet)
         # Reads
-        localId = 'aReadGroupSet'
-        readGroupSet = reads.SimulatedReadGroupSet(
-            self, localId, numAlignments)
-        self._readGroupSetIdMap[readGroupSet.getId()] = readGroupSet
-        for readGroup in readGroupSet.getReadGroups():
-            self._readGroupIdMap[readGroup.getId()] = readGroup
-        self._readGroupSetIds = sorted(self._readGroupSetIdMap.keys())
-        self._readGroupIds = sorted(self._readGroupIdMap.keys())
+        for i in range(numReadGroupSets):
+            localId = 'simRgs{}'.format(i)
+            seed = randomSeed + i
+            readGroupSet = reads.SimulatedReadGroupSet(
+                self, localId, seed, numReadGroupsPerReadGroupSet,
+                numAlignments)
+            self.addReadGroupSet(readGroupSet)
 
 
 class FileSystemDataset(AbstractDataset):
@@ -130,9 +147,7 @@ class FileSystemDataset(AbstractDataset):
             if os.path.isdir(relativePath):
                 variantSet = variants.HtslibVariantSet(
                     self, localId, relativePath)
-                self._variantSetIdMap[variantSet.getId()] = variantSet
-        self._variantSetIds = sorted(self._variantSetIdMap.keys())
-
+                self.addVariantSet(variantSet)
         # Reads
         readGroupSetDir = os.path.join(dataDir, "reads")
         for localId in os.listdir(readGroupSetDir):
@@ -140,8 +155,4 @@ class FileSystemDataset(AbstractDataset):
             if os.path.isdir(relativePath):
                 readGroupSet = reads.HtslibReadGroupSet(
                     self, localId, relativePath)
-                self._readGroupSetIdMap[readGroupSet.getId()] = readGroupSet
-                for readGroup in readGroupSet.getReadGroups():
-                    self._readGroupIdMap[readGroup.getId()] = readGroup
-        self._readGroupSetIds = sorted(self._readGroupSetIdMap.keys())
-        self._readGroupIds = sorted(self._readGroupIdMap.keys())
+                self.addReadGroupSet(readGroupSet)

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -192,6 +192,11 @@ class DatasetNotFoundException(NotFoundException):
             datasetId)
 
 
+class ReadGroupSetNotFoundException(ObjectNotFoundException):
+    def __init__(self, readGroupSetId):
+        self.message = "readGroupSetId '{}' not found".format(readGroupSetId)
+
+
 class ReadGroupNotFoundException(ObjectNotFoundException):
     def __init__(self, readGroupId):
         self.message = "readGroupId '{}' not found".format(readGroupId)
@@ -270,8 +275,17 @@ class CallSetNameNotFoundException(NotFoundException):
     Indicates a request was made for a callSet with a name that
     does not exist.
     """
-    def __init__(self, callSetName):
-        self.message = "callSet with name '{0}' not found".format(callSetName)
+    def __init__(self, name):
+        self.message = "CallSet with name '{0}' not found".format(name)
+
+
+class ReadGroupSetNameNotFoundException(NotFoundException):
+    """
+    Indicates a request was made for a ReadGroupSet with a name that
+    does not exist.
+    """
+    def __init__(self, name):
+        self.message = "ReadGroupSet with name '{0}' not found".format(name)
 
 
 class DataException(BaseServerException):

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -234,8 +234,11 @@ def configure(configFile=None, baseConfig="ProductionConfig",
         numAlignments = app.config[
             "SIMULATED_BACKEND_NUM_ALIGNMENTS_PER_READ_GROUP"]
         theBackend = backend.SimulatedBackend(
-            randomSeed, numCalls, variantDensity, numVariantSets,
-            numReferenceSets, numReferencesPerReferenceSet, numAlignments)
+            randomSeed=randomSeed, numCalls=numCalls,
+            variantDensity=variantDensity, numVariantSets=numVariantSets,
+            numReferenceSets=numReferenceSets,
+            numReferencesPerReferenceSet=numReferencesPerReferenceSet,
+            numAlignments=numAlignments)
     elif dataSource == "__EMPTY__":
         theBackend = backend.EmptyBackend()
     else:

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -21,8 +21,8 @@ class TestGestalt(server_test.ServerTest):
     An end-to-end test of the client and server
     """
     def testEndToEnd(self):
-        self.simulatedVariantSetId = "simulatedDataset1:simVs0"
-        self.simulatedReadGroupId = "simulatedDataset1:aReadGroupSet:one"
+        self.simulatedVariantSetId = "simulatedDataset0:simVs0"
+        self.simulatedReadGroupId = "simulatedDataset0:simRgs0:rg0"
         self.simulatedReferenceSetId = "referenceSet0"
         self.simulatedReferenceId = "referenceSet0:srs0"
         self.client = client.ClientForTesting(self.server.getUrl())
@@ -101,6 +101,6 @@ class TestGestalt(server_test.ServerTest):
         self.runClientCmd(self.client, cmd)
 
     def runVariantSetsRequestDatasetTwo(self):
-        datasetId = "simulatedDataset2"
+        datasetId = "simulatedDataset1"
         cmd = "variantsets-search --datasetId {}".format(datasetId)
         self.runClientCmd(self.client, cmd)

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -39,7 +39,6 @@ class TestVariantsGenerator(unittest.TestCase):
         self.request = protocol.SearchVariantsRequest()
         self.backend = backend.SimulatedBackend()
         self.dataset = self.backend.getDatasets()[0]
-        self.variantSetLocalId = 'variantSet'
 
     def testNonexistantVariantSet(self):
         # a request for a variant set that doesn't exist should throw an error
@@ -79,8 +78,8 @@ class TestVariantsGenerator(unittest.TestCase):
 
     def _initVariantSet(self, numVariants):
         variantSet = MockVariantSet(
-            self.dataset, self.variantSetLocalId, numVariants)
-        self.dataset._variantSetIdMap = {variantSet.getId(): variantSet}
+            self.dataset, "mockvs", numVariants)
+        self.dataset.addVariantSet(variantSet)
         self.request.variantSetId = variantSet.getId()
 
 
@@ -112,12 +111,9 @@ class TestReadsGenerator(unittest.TestCase):
     def setUp(self):
         self.request = protocol.SearchReadsRequest()
         self.request.referenceId = "chr1"
-        self.backend = backend.SimulatedBackend()
+        self.backend = backend.SimulatedBackend(numAlignments=0)
         self.dataset = self.backend.getDatasets()[0]
-        self.readGroupSetLocalId = "aReadGroupSet"
-        self.readGroupLocalId = "aReadGroup"
-        self.readGroupSet = reads.AbstractReadGroupSet(
-            self.dataset, self.readGroupSetLocalId)
+        self.readGroupSet = self.dataset.getReadGroupSets()[0]
 
     def testNoReadGroupsNotSupported(self):
         # a request for no read groups should throw an exception
@@ -168,8 +164,8 @@ class TestReadsGenerator(unittest.TestCase):
 
     def _initReadGroup(self, numAlignments):
         readGroup = MockReadGroup(
-            self.readGroupSet, self.readGroupLocalId, numAlignments)
-        self.dataset._readGroupIdMap = {readGroup.getId(): readGroup}
+            self.readGroupSet, "mockrg", numAlignments)
+        self.readGroupSet.addReadGroup(readGroup)
         self.request.readGroupIds = [readGroup.getId()]
 
 

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -222,6 +222,20 @@ class TestSimulatedStack(unittest.TestCase):
             self.verifySearchMethod(
                 request, path, protocol.SearchReadGroupSetsResponse,
                 readGroupSets, self.verifyReadGroupSetsEqual)
+            # Check if we can search for the readGroupSet with a good name.
+            for readGroupSet in readGroupSets:
+                request = protocol.SearchReadGroupSetsRequest()
+                request.datasetId = dataset.getId()
+                request.name = readGroupSet.getLocalId()
+                self.verifySearchMethod(
+                    request, path, protocol.SearchReadGroupSetsResponse,
+                    [readGroupSet], self.verifyReadGroupSetsEqual)
+            # Check if we can search for the callset with a bad name.
+            for badId in self.getBadIds():
+                request = protocol.SearchReadGroupSetsRequest()
+                request.datasetId = dataset.getId()
+                request.name = badId
+                self.verifySearchMethodFails(request, path)
         for badId in self.getBadIds():
             request = protocol.SearchReadGroupSetsRequest()
             request.datasetId = badId

--- a/tests/unit/test_simulator.py
+++ b/tests/unit/test_simulator.py
@@ -33,8 +33,8 @@ class TestSimulatedVariantSet(unittest.TestCase):
     def _getSimulatedVariantSet(self):
         dataset = datasets.AbstractDataset('dataset1')
         simulatedVariantSet = variants.SimulatedVariantSet(
-            dataset, 'variantSet1', self.randomSeed, self.numCalls,
-            self.variantDensity)
+            dataset, 'variantSet1', randomSeed=self.randomSeed,
+            numCalls=self.numCalls, variantDensity=self.variantDensity)
         return simulatedVariantSet
 
     def _getSimulatedVariantsList(self, simulatedVariantSet=None):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -47,6 +47,8 @@ class TestFrontend(unittest.TestCase):
         cls.datasetId = cls.dataset.getId()
         cls.variantSet = cls.dataset.getVariantSets()[0]
         cls.variantSetId = cls.variantSet.getId()
+        gaVariant = cls.variantSet.getVariants("1", 0, 2**32).next()
+        cls.variantId = gaVariant.id
         cls.callSet = cls.variantSet.getCallSets()[0]
         cls.callSetId = cls.callSet.getId()
         cls.readGroupSet = cls.dataset.getReadGroupSets()[0]
@@ -122,9 +124,7 @@ class TestFrontend(unittest.TestCase):
 
     def sendGetVariant(self, id_=None):
         if id_ is None:
-            compoundId = datamodel.VariantCompoundId.parse(
-                'simulatedDataset1:simVs0:referenceName:5:md5')
-            id_ = str(compoundId)
+            id_ = self.variantId
         path = "/variants/{}".format(id_)
         response = self.sendGetRequest(path)
         return response
@@ -359,9 +359,6 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(
             responseData.alignments[0].id,
             self.readAlignmentId)
-        self.assertEqual(
-            responseData.alignments[1].id,
-            "simulatedDataset1:aReadGroupSet:one:simulated1")
 
     def testDatasetsSearch(self):
         response = self.sendDatasetsSearch()


### PR DESCRIPTION
- Refactored to make ID search fully hierarchical
- Added support for searching ReadGroupSets by name (issue #534)
- Generalised the simulator initialisation structures
- Removed multiple locations for initialising internal maps, preferring
  the use of addDataset, addVariantSet, etc.
- Fixed up some test cases that depended on brittle interfaces.