### PR TITLE
ID obfuscation via base64 encoding.

### DIFF
--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -97,7 +97,6 @@ class VariantSetTest(datadriven.DataDrivenTest):
         genotype, phaseset = variants.convertVCFGenotype(
             pyvcfCall.data.GT, pyvcfCall.phased)
         # callSetId information is not available in pyvcf.model._Call
-        self.assertIn(pyvcfCall.sample, gaCall.callSetId)
         self.assertEqual(gaCall.callSetName, pyvcfCall.sample)
         self.assertEqual(gaCall.genotype, genotype)
         phaseset = None

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -21,10 +21,11 @@ class TestGestalt(server_test.ServerTest):
     An end-to-end test of the client and server
     """
     def testEndToEnd(self):
-        self.simulatedVariantSetId = "simulatedDataset0:simVs0"
-        self.simulatedReadGroupId = "simulatedDataset0:simRgs0:rg0"
-        self.simulatedReferenceSetId = "referenceSet0"
-        self.simulatedReferenceId = "referenceSet0:srs0"
+        self.simulatedDatasetId = "c2ltdWxhdGVkRGF0YXNldDA="
+        self.simulatedVariantSetId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltVnMw"
+        self.simulatedReadGroupId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltUmdzMDpyZzA="
+        self.simulatedReferenceSetId = "cmVmZXJlbmNlU2V0MA=="
+        self.simulatedReferenceId = "cmVmZXJlbmNlU2V0MDpzcnMw"
         self.client = client.ClientForTesting(self.server.getUrl())
         self.runVariantsRequest()
         self.assertLogsWritten()
@@ -101,6 +102,6 @@ class TestGestalt(server_test.ServerTest):
         self.runClientCmd(self.client, cmd)
 
     def runVariantSetsRequestDatasetTwo(self):
-        datasetId = "simulatedDataset1"
+        datasetId = self.simulatedDatasetId
         cmd = "variantsets-search --datasetId {}".format(datasetId)
         self.runClientCmd(self.client, cmd)

--- a/tests/end_to_end/test_oidc.py
+++ b/tests/end_to_end/test_oidc.py
@@ -52,7 +52,7 @@ class TestOidc(server_test.ServerTestClass):
     """
     @classmethod
     def otherSetup(cls):
-        cls.simulatedVariantSetId = "simulatedDataset1:simVs0"
+        cls.simulatedVariantSetId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltVnMw"
         requests.packages.urllib3.disable_warnings()
         cls.opServer = server.OidcOpServerForTesting()
         cls.opServer.start()

--- a/tests/end_to_end/test_remote_fetch.py
+++ b/tests/end_to_end/test_remote_fetch.py
@@ -29,8 +29,8 @@ class TestRemoteFetchReads(RemoteServerTestReads):
     def testBamFetch(self):
         self.client = client.ClientForTesting(self.server.getUrl())
         self.readGroupIds = (
-            'dataset1:remoteTest:'
-            'wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample')
+            'ZGF0YXNldDE6cmVtb3RlVGVzdDp3Z0VuY29kZVV3UmVwbGlTZXFCZzAy'
+            'ZXNHMWJBbG5SZXAxX3NhbXBsZQ==')
         self.runClientCmd(
             self.client,
             "reads-search --readGroupIds '{}' "
@@ -63,7 +63,7 @@ class TestRemoteFetchVariants(RemoteServerTestVariants):
         self.client = client.ClientForTesting(self.server.getUrl())
         self.runClientCmd(
             self.client,
-            "variants-search -V dataset1:remoteTest")
+            "variants-search -V ZGF0YXNldDE6cmVtb3RlVGVzdA==")
         self._assertLogsWritten()
         self.client.cleanup()
 

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -27,8 +27,13 @@ class TestCompoundIds(unittest.TestCase):
     """
     def testBadParse(self):
         for badId in ['a;b', 'a;b;c;d', 'a;b;sd;', ';;;;']:
+            obfuscated = datamodel.CompoundId.obfuscate(badId)
+            self.assertEqual(
+                badId, datamodel.CompoundId.deobfuscate(obfuscated))
             with self.assertRaises(exceptions.ObjectWithIdNotFoundException):
                 ExampleCompoundId.parse(badId)
+            with self.assertRaises(exceptions.ObjectWithIdNotFoundException):
+                ExampleCompoundId.parse(obfuscated)
         for badType in [0, None, []]:
             with self.assertRaises(exceptions.BadIdentifierException):
                 ExampleCompoundId.parse(badType)
@@ -39,30 +44,39 @@ class TestCompoundIds(unittest.TestCase):
         ID string correctly raise parse failures.
         """
         # first, check if we really can parse the string
-        cid = compoundIdClass.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = compoundIdClass.parse(obfuscated)
         self.assertIsNotNone(cid)
         # Now, check for substrings
         for j in range(len(idStr) - 1):
+            badId = idStr[:j]
+            obfuscated = datamodel.CompoundId.obfuscate(badId)
             self.assertRaises(
                 exceptions.ObjectWithIdNotFoundException,
-                compoundIdClass.parse, idStr[:j])
+                compoundIdClass.parse, obfuscated)
         # Adding on an extra field should also provoke a parse error.
+        badId = idStr + ":b"
+        obfuscated = datamodel.CompoundId.obfuscate(badId)
         self.assertRaises(
             exceptions.ObjectWithIdNotFoundException, compoundIdClass.parse,
-            idStr + ":b")
+            obfuscated)
 
     def testAttrs(self):
-        compoundId = ExampleCompoundId.parse('a;b;c')
+        obfuscated = datamodel.CompoundId.obfuscate('a;b;c')
+        compoundId = ExampleCompoundId.parse(obfuscated)
         self.assertEqual(compoundId.foo, 'a')
         self.assertEqual(compoundId.bar, 'b')
         self.assertEqual(compoundId.baz, 'c')
-        self.assertEqual(compoundId.foobar, 'a;b')
-        self.assertEqual(compoundId.foobarbaz, 'a;b;c')
+        obfuscated = datamodel.CompoundId.obfuscate("a;b")
+        self.assertEqual(compoundId.foobar, obfuscated)
+        obfuscated = datamodel.CompoundId.obfuscate("a;b;c")
+        self.assertEqual(compoundId.foobarbaz, obfuscated)
 
     def testInstantiate(self):
         compoundId = ExampleCompoundId(None, "a", "5", "c")
+        obfuscated = datamodel.CompoundId.obfuscate("a;5;c")
         compoundIdStr = str(compoundId)
-        self.assertEqual(compoundIdStr, 'a;5;c')
+        self.assertEqual(compoundIdStr, obfuscated)
         self.assertEqual(compoundId.__class__, ExampleCompoundId)
 
     def getDataset(self):
@@ -89,7 +103,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testDatasetParse(self):
         idStr = "a"
-        cid = datamodel.DatasetCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.DatasetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.verifyParseFailure(idStr, datamodel.DatasetCompoundId)
 
@@ -105,7 +120,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testVariantSetParse(self):
         idStr = "a:b"
-        cid = datamodel.VariantSetCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.VariantSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.variantSet, "b")
         self.verifyParseFailure(idStr, datamodel.VariantSetCompoundId)
@@ -126,7 +142,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testCallSetParse(self):
         idStr = "a:b:c"
-        cid = datamodel.CallSetCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.CallSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.variantSet, "b")
         self.assertEqual(cid.name, "c")
@@ -156,7 +173,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testVariantParse(self):
         idStr = "a:b:c:d:e"
-        cid = datamodel.VariantCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.VariantCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.variantSet, "b")
         self.assertEqual(cid.referenceName, "c")
@@ -173,7 +191,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testReferenceSetParse(self):
         idStr = "a"
-        cid = datamodel.ReferenceSetCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.ReferenceSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.referenceSet, "a")
         self.verifyParseFailure(idStr, datamodel.ReferenceSetCompoundId)
 
@@ -191,7 +210,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testReferenceParse(self):
         idStr = "a:b"
-        cid = datamodel.ReferenceCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.ReferenceCompoundId.parse(obfuscated)
         self.assertEqual(cid.referenceSet, "a")
         self.assertEqual(cid.reference, "b")
         self.verifyParseFailure(idStr, datamodel.ReferenceCompoundId)
@@ -209,7 +229,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testReadGroupSetParse(self):
         idStr = "a:b"
-        cid = datamodel.ReadGroupSetCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.ReadGroupSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.readGroupSet, "b")
         self.verifyParseFailure(idStr, datamodel.ReadGroupSetCompoundId)
@@ -231,7 +252,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testReadGroupParse(self):
         idStr = "a:b:c"
-        cid = datamodel.ReadGroupCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.ReadGroupCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.readGroupSet, "b")
         self.assertEqual(cid.readGroup, "c")
@@ -257,7 +279,8 @@ class TestCompoundIds(unittest.TestCase):
 
     def testReadAlignmentParse(self):
         idStr = "a:b:c:d"
-        cid = datamodel.ReadAlignmentCompoundId.parse(idStr)
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
+        cid = datamodel.ReadAlignmentCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
         self.assertEqual(cid.readGroupSet, "b")
         self.assertEqual(cid.readGroup, "c")

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -311,7 +311,8 @@ class TestFrontend(unittest.TestCase):
         variantSetId = responseData.variantSets[0].id
         response = self.sendGetVariantSet(variantSetId)
         self.assertEqual(200, response.status_code)
-        compoundId = datamodel.VariantSetCompoundId.parse("notValid:notValid")
+        obfuscated = datamodel.CompoundId.obfuscate("notValid:notValid")
+        compoundId = datamodel.VariantSetCompoundId.parse(obfuscated)
         response = self.sendGetVariantSet(str(compoundId))
         self.assertEqual(404, response.status_code)
 


### PR DESCRIPTION
This obfuscates our hierarchical breadcrumb-trail ID format from clients. Clients should not depend on our internal ID values, which are private to a given server instance.  This discourages them from doing so. 

