### PR TITLE
Complete refactor to explicit getter methods.

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -104,6 +104,15 @@ class AbstractDataset(datamodel.DatamodelObject):
             raise exceptions.ReadGroupNotFoundException(id_)
         return self._readGroupSetIdMap[id_]
 
+    def getVariantSet(self, id_):
+        """
+        Returns the VariantSet with the specified name, or raises a
+        VariantSetNotFoundException otherwise.
+        """
+        if id_ not in self._variantSetIdMap:
+            raise exceptions.VariantSetNotFoundException(id_)
+        return self._variantSetIdMap[id_]
+
 
 class SimulatedDataset(AbstractDataset):
     """

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -98,6 +98,15 @@ class AbstractReadGroupSet(datamodel.DatamodelObject):
         """
         return [self._readGroupIdMap[id_] for id_ in self._readGroupIds]
 
+    def getReadGroup(self, id_):
+        """
+        Returns the ReadGroup with the specified id if it exists in this
+        ReadGroupSet, or raises a ReadGroupNotFoundException otherwise.
+        """
+        if id_ not in self._readGroupIdMap:
+            raise exceptions.ReadGroupNotFoundException(id_)
+        return self._readGroupIdMap[id_]
+
     def toProtocolElement(self):
         """
         Returns the GA4GH protocol representation of this ReadGroupSet.

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -141,6 +141,15 @@ class AbstractVariantSet(datamodel.DatamodelObject):
             raise exceptions.CallSetNameNotFoundException(name)
         return self._callSetNameMap[name]
 
+    def getCallSet(self, id_):
+        """
+        Returns a CallSet with the specified id, or raises a
+        CallSetNotFoundException if it does not exist.
+        """
+        if id_ not in self._callSetIdMap:
+            raise exceptions.CallSetNotFoundException(id_)
+        return self._callSetIdMap[id_]
+
     def toProtocolElement(self):
         """
         Converts this VariantSet into its GA4GH protocol equivalent.

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -186,6 +186,12 @@ class VariantSetNotFoundException(NotFoundException):
             variantSetId)
 
 
+class CallSetNotFoundException(NotFoundException):
+    def __init__(self, callSetId):
+        self.message = "The requested CallSet '{}' was not found".format(
+            callSetId)
+
+
 class DatasetNotFoundException(NotFoundException):
     def __init__(self, datasetId):
         self.message = "The requested dataset '{}' was not found".format(

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -13,7 +13,6 @@ import unittest
 import ga4gh.exceptions as exceptions
 import ga4gh.backend as backend
 import ga4gh.protocol as protocol
-import ga4gh.datamodel.references as references
 
 
 class BackendForTesting(backend.AbstractBackend):
@@ -116,10 +115,8 @@ class TestAbstractBackend(unittest.TestCase):
             isinstance(response, protocol.SearchVariantSetsResponse))
 
     def testRunGetRequest(self):
-        id_ = "anId"
-        obj = references.SimulatedReferenceSet(id_)
-        idMap = {id_: obj}
-        responseStr = self._backend.runGetRequest(idMap, id_)
+        referenceSet = self._backend.getReferenceSets()[0]
+        responseStr = self._backend.runGetReferenceSet(referenceSet.getId())
         class_ = protocol.ReferenceSet
         response = class_.fromJsonString(responseStr)
         self.assertTrue(isinstance(response, class_))
@@ -246,25 +243,3 @@ class TestPrivateBackendMethods(unittest.TestCase):
         goodPageToken = "12:34:567:8:9000"
         parsedToken = backend._parsePageToken(goodPageToken, 5)
         self.assertEqual(parsedToken[2], 567)
-
-    def testSafeMapQuery(self):
-        # test map
-        key = 'a'
-        value = 'b'
-        idMap = {key: value}
-        result = backend._safeMapQuery(idMap, key)
-        self.assertEqual(result, value)
-
-        # test array
-        arr = [value]
-        result = backend._safeMapQuery(arr, 0)
-        self.assertEqual(result, value)
-
-        # test exception with custom class
-        exceptionClass = exceptions.FileOpenFailedException
-        with self.assertRaises(exceptionClass):
-            backend._safeMapQuery(idMap, 'notFound', exceptionClass)
-
-        # test exception with custom id string
-        with self.assertRaises(exceptions.ObjectWithIdNotFoundException):
-            backend._safeMapQuery(idMap, 'notFound', idErrorString='msg')


### PR DESCRIPTION
This PR completes the process of refactoring client-facing getter methods to within their actual containers. This is safer than passing around maps, as there is a single location where we must raise the correct exception. This also gives a better interface, as we can change the internal indexing structures without affecting client code.