### PR TITLE
Remove external map access

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -50,35 +50,38 @@ class AbstractDataset(datamodel.DatamodelObject):
         dataset.id = self.getId()
         return dataset
 
-    def getVariantSetIds(self):
-        """
-        Return a list of ids of variant sets that this dataset has
-        """
-        return self._variantSetIds
-
-    def getVariantSetIdMap(self):
-        """
-        Return a map of the dataset's variant set ids to variant sets
-        """
-        return self._variantSetIdMap
-
     def getVariantSets(self):
         """
         Returns the list of VariantSets in this dataset
         """
         return [self._variantSetIdMap[id_] for id_ in self._variantSetIds]
 
-    def getReadGroupSetIds(self):
+    def getNumVariantSets(self):
         """
-        Return a list of ids of read group sets that this dataset has
+        Returns the number of variant sets in this dataset.
         """
-        return self._readGroupSetIds
+        return len(self._variantSetIds)
 
-    def getReadGroupSetIdMap(self):
+    def getVariantSet(self, id_):
         """
-        Return a map of the dataset's read group set ids to read group sets
+        Returns the VariantSet with the specified name, or raises a
+        VariantSetNotFoundException otherwise.
         """
-        return self._readGroupSetIdMap
+        if id_ not in self._variantSetIdMap:
+            raise exceptions.VariantSetNotFoundException(id_)
+        return self._variantSetIdMap[id_]
+
+    def getVariantSetByIndex(self, index):
+        """
+        Returns the variant set at the specified index in this dataset.
+        """
+        return self._variantSetIdMap[self._variantSetIds[index]]
+
+    def getNumReadGroupSets(self):
+        """
+        Returns the number of readgroup sets in this dataset.
+        """
+        return len(self._readGroupSetIds)
 
     def getReadGroupSets(self):
         """
@@ -95,6 +98,12 @@ class AbstractDataset(datamodel.DatamodelObject):
             raise exceptions.ReadGroupSetNameNotFoundException(name)
         return self._readGroupSetNameMap[name]
 
+    def getReadGroupSetByIndex(self, index):
+        """
+        Returns the readgroup set at the specified index in this dataset.
+        """
+        return self._readGroupSetIdMap[self._readGroupSetIds[index]]
+
     def getReadGroupSet(self, id_):
         """
         Returns the ReadGroupSet with the specified name, or raises
@@ -103,15 +112,6 @@ class AbstractDataset(datamodel.DatamodelObject):
         if id_ not in self._readGroupSetIdMap:
             raise exceptions.ReadGroupNotFoundException(id_)
         return self._readGroupSetIdMap[id_]
-
-    def getVariantSet(self, id_):
-        """
-        Returns the VariantSet with the specified name, or raises a
-        VariantSetNotFoundException otherwise.
-        """
-        if id_ not in self._variantSetIdMap:
-            raise exceptions.VariantSetNotFoundException(id_)
-        return self._variantSetIdMap[id_]
 
 
 class SimulatedDataset(AbstractDataset):

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -86,12 +86,6 @@ class AbstractReadGroupSet(datamodel.DatamodelObject):
         self._readGroupIdMap[id_] = readGroup
         self._readGroupIds.append(id_)
 
-    def getReadGroupIdMap(self):
-        return self._readGroupIdMap
-
-    def getReadGroupIds(self):
-        return self._readGroupIds
-
     def getReadGroups(self):
         """
         Returns the list of ReadGroups in this ReadGroupSet.

--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -50,6 +50,18 @@ class AbstractReferenceSet(datamodel.DatamodelObject):
         """
         return [self._referenceIdMap[id_] for id_ in self._referenceIds]
 
+    def getNumReferences(self):
+        """
+        Returns the number of references in this ReferenceSet.
+        """
+        return len(self._referenceIds)
+
+    def getReferenceByIndex(self, index):
+        """
+        Returns the reference at the specified index in this ReferenceSet.
+        """
+        return self._referenceIdMap[self._referenceIds[index]]
+
     def getReference(self, id_):
         """
         Returns the Reference with the specified ID or raises a
@@ -58,12 +70,6 @@ class AbstractReferenceSet(datamodel.DatamodelObject):
         if id_ not in self._referenceIdMap:
             raise exceptions.ReferenceNotFoundException(id_)
         return self._referenceIdMap[id_]
-
-    def getReferenceIdMap(self):
-        return self._referenceIdMap
-
-    def getReferenceIds(self):
-        return self._referenceIds
 
     def getMd5Checksum(self):
         """

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -113,24 +113,17 @@ class AbstractVariantSet(datamodel.DatamodelObject):
         self._callSetNameMap[sampleName] = callSet
         self._callSetIds.append(callSetId)
 
-    def getCallSetIdMap(self):
-        """
-        Returns the map of callSetIds to CallSet objects in this
-        VariantSet.
-        """
-        return self._callSetIdMap
-
-    def getCallSetIds(self):
-        """
-        Returns the list of callSetIds in this VariantSet.
-        """
-        return self._callSetIds
-
     def getCallSets(self):
         """
         Returns the list of CallSets in this VariantSet.
         """
         return [self._callSetIdMap[id_] for id_ in self._callSetIds]
+
+    def getNumCallSets(self):
+        """
+        Returns the number of CallSets in this variant set.
+        """
+        return len(self._callSetIds)
 
     def getCallSetByName(self, name):
         """
@@ -140,6 +133,12 @@ class AbstractVariantSet(datamodel.DatamodelObject):
         if name not in self._callSetNameMap:
             raise exceptions.CallSetNameNotFoundException(name)
         return self._callSetNameMap[name]
+
+    def getCallSetByIndex(self, index):
+        """
+        Returns the CallSet at the specfied index in this VariantSet.
+        """
+        return self._callSetIdMap[self._callSetIds[index]]
 
     def getCallSet(self, id_):
         """

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -349,7 +349,7 @@ class VariantSetTest(datadriven.DataDrivenTest):
         variantSet = self._gaObject
         start = 0
         end = datamodel.PysamDatamodelMixin.vcfMax
-        callSetIds = variantSet.getCallSetIds()
+        callSetIds = [callSet.getId() for callSet in variantSet.getCallSets()]
         someCallSetIds = callSetIds[0:3]
         for referenceName in self._referenceNames:
             # passing None as the callSetIds argument should be equivalent

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -208,13 +208,12 @@ class TestTopLevelObjectGenerator(unittest.TestCase):
 
         self.request = FakeRequest()
         self.request.pageToken = None
-        self.idMap = {
-            "a": FakeTopLevelObject(),
-            "b": FakeTopLevelObject(),
-            "c": FakeTopLevelObject(),
-        }
-        self.idList = sorted(self.idMap.keys())
+        self.numObjects = 3
+        self.objects = [FakeTopLevelObject() for j in range(self.numObjects)]
         self.backend = backend.AbstractBackend()
+
+    def getObjectByIndex(self, index):
+        return self.objects[index]
 
     def testPageToken(self):
         self.request.pageToken = "1"
@@ -225,7 +224,7 @@ class TestTopLevelObjectGenerator(unittest.TestCase):
 
     def _assertNumItems(self, numItems):
         iterator = self.backend._topLevelObjectGenerator(
-            self.request, self.idMap, self.idList)
+            self.request, self.numObjects, self.getObjectByIndex)
         items = list(iterator)
         self.assertEqual(len(items), numItems)
 


### PR DESCRIPTION
This removes the need for passing around references to internal
structures, and allows us to program against an interface rather than an
internal representation.

Depends on PR  #575, which should be reviewed first.