### PR TITLE
Implement read strand flags

### DIFF
--- a/ga4gh/converters.py
+++ b/ga4gh/converters.py
@@ -11,6 +11,7 @@ import collections
 import pysam
 
 import ga4gh.datamodel.reads as reads
+import ga4gh.protocol as protocol
 
 
 class AbstractConverter(object):
@@ -144,6 +145,12 @@ class SamLine(object):
         if read.properPlacement:
             reads.SamFlags.setFlag(
                 flag, reads.SamFlags.PROPER_PLACEMENT)
+        if read.alignment.position.strand == protocol.Strand.NEG_STRAND:
+            reads.SamFlags.setFlag(
+                flag, reads.SamFlags.REVERSED)
+        if read.alignment.position.strand == protocol.Strand.NEG_STRAND:
+            reads.SamFlags.setFlag(
+                flag, reads.SamFlags.NEXT_MATE_REVERSED)
         if read.readNumber:
             reads.SamFlags.setFlag(
                 flag, reads.SamFlags.READ_NUMBER_ONE)

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -51,6 +51,8 @@ class SamFlags(object):
     """
     NUMBER_READS = 0x1
     PROPER_PLACEMENT = 0x2
+    REVERSED = 0x10
+    NEXT_MATE_REVERSED = 0x20
     READ_NUMBER_ONE = 0x40
     READ_NUMBER_TWO = 0x80
     SECONDARY_ALIGNMENT = 0x100
@@ -349,8 +351,9 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
         ret.alignment.position.referenceName = samFile.getrname(
             read.reference_id)
         ret.alignment.position.position = read.reference_start
-        ret.alignment.position.strand = \
-            protocol.Strand.POS_STRAND  # TODO fix this!
+        ret.alignment.position.strand = protocol.Strand.POS_STRAND
+        if SamFlags.isFlagSet(read.flag, SamFlags.REVERSED):
+            ret.alignment.position.strand = protocol.Strand.NEG_STRAND
         ret.alignment.cigar = []
         for operation, length in read.cigar:
             gaCigarUnit = protocol.CigarUnit()
@@ -372,8 +375,9 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
             ret.nextMatePosition.referenceName = samFile.getrname(
                 read.next_reference_id)
             ret.nextMatePosition.position = read.next_reference_start
-            ret.nextMatePosition.strand = \
-                protocol.Strand.POS_STRAND  # TODO fix this!
+            ret.nextMatePosition.strand = protocol.Strand.POS_STRAND
+            if SamFlags.isFlagSet(read.flag, SamFlags.NEXT_MATE_REVERSED):
+                ret.nextMatePosition.strand = protocol.Strand.NEG_STRAND
         # TODO Is this the correct mapping between numberReads and
         # sam flag 0x1? What about the mapping between numberReads
         # and 0x40 and 0x80?


### PR DESCRIPTION
I am not a Python programmer, and I have not attempted to feed this to a python.  Your mileage may vary.  But I do know what (SAM) plugs into what (GA4GH).  Fixes #491.

(Not too sure why there's this `SamFlags` class rather than using `is_reverse(read)` et al as supplied by pysam…?)