### PR TITLE
Fix download data script

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -102,7 +102,6 @@ class AbstractFileDownloader(object):
     def __init__(self, args):
         self.args = args
         self.datasetName = 'dataset1'
-        self.readGroupSetName = 'low-coverage'
         self.variantSetName = '1kg-phase3-subset'
         self.referenceSetName = 'GRCh38-subset'
         self.chromMinMax = ChromMinMax()
@@ -130,8 +129,6 @@ class AbstractFileDownloader(object):
             '20': 'CM000682.2',
             '21': 'CM000683.2',
             '22': 'CM000684.2',
-            'X': 'CM000685.2',
-            'Y': 'CM000686.2',
         }
         self.samples = self.args.samples.split(',')
         self.studyMap = {
@@ -148,15 +145,6 @@ class AbstractFileDownloader(object):
             str(i) for i in range(1, 23)
             if str(i) in self.chromosomes]
         fileNames = [baseFileName.format(chrName) for chrName in chrNames]
-        # the X and Y files use a different filename prefix
-        if 'X' in self.chromosomes:
-            fileNames.append(
-                'ALL.chrX.phase3_shapeit2_mvncall_integrated_v1a.'
-                '20130502.genotypes.vcf.gz')
-        if 'Y' in self.chromosomes:
-            fileNames.append(
-                'ALL.chrY.phase3_integrated_v1a.'
-                '20130502.genotypes.vcf.gz')
         return fileNames
 
     def getVcfBaseUrl(self):
@@ -228,8 +216,7 @@ class AbstractFileDownloader(object):
 
     def downloadBams(self):
         dirList = [
-            self.args.dir_name, self.datasetName, 'reads',
-            self.readGroupSetName]
+            self.args.dir_name, self.datasetName, 'reads']
         mkdirAndChdirList(dirList)
         cleanDir()
         baseUrl = self.getBamBaseUrl()
@@ -264,7 +251,7 @@ class AbstractFileDownloader(object):
             os.remove(baiFileName)
             utils.log("Indexing '{}'".format(fileName))
             pysam.index(fileName.encode('utf-8'))
-        escapeDir()
+        escapeDir(3)
 
     def downloadFastas(self):
         dirList = [
@@ -334,7 +321,7 @@ def parseArgs():
         "--num-reads", default=1000,
         help="the number of reads to download per reference")
     parser.add_argument(
-        "--chromosomes", default="1,2,3,X,Y",
+        "--chromosomes", default="1,2,3",
         help="the chromosomes whose corresponding reads should be downloaded")
     args = parser.parse_args()
     return args


### PR DESCRIPTION
- remove X and Y chroms
- make data conform to new read dir structure

Issue #614

Default run now produces:
```
$ find ga4gh-downloaded-data/
ga4gh-downloaded-data/
ga4gh-downloaded-data//dataset1
ga4gh-downloaded-data//dataset1/reads
ga4gh-downloaded-data//dataset1/reads/HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam
ga4gh-downloaded-data//dataset1/reads/HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam.bai
ga4gh-downloaded-data//dataset1/reads/HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522.bam
ga4gh-downloaded-data//dataset1/reads/HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522.bam.bai
ga4gh-downloaded-data//dataset1/reads/HG00534.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522.bam
ga4gh-downloaded-data//dataset1/reads/HG00534.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522.bam.bai
ga4gh-downloaded-data//dataset1/variants
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz
ga4gh-downloaded-data//dataset1/variants/1kg-phase3-subset/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi
ga4gh-downloaded-data//references
ga4gh-downloaded-data//references/GRCh38-subset
ga4gh-downloaded-data//references/GRCh38-subset/1.fa.gz
ga4gh-downloaded-data//references/GRCh38-subset/1.fa.gz.fai
ga4gh-downloaded-data//references/GRCh38-subset/1.fa.gz.gzi
ga4gh-downloaded-data//references/GRCh38-subset/2.fa.gz
ga4gh-downloaded-data//references/GRCh38-subset/2.fa.gz.fai
ga4gh-downloaded-data//references/GRCh38-subset/2.fa.gz.gzi
ga4gh-downloaded-data//references/GRCh38-subset/3.fa.gz
ga4gh-downloaded-data//references/GRCh38-subset/3.fa.gz.fai
ga4gh-downloaded-data//references/GRCh38-subset/3.fa.gz.gzi
```