### PR TITLE
Adds reference search filters.

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -95,14 +95,14 @@ class RequestFactory(object):
 
     def createSearchReferenceSetsRequest(self):
         request = protocol.SearchReferenceSetsRequest()
-        setCommaSeparatedAttribute(request, self.args, 'accessions')
-        setCommaSeparatedAttribute(request, self.args, 'md5checksums')
+        request.accession = self.args.accession
+        request.md5checksum = self.args.md5checksum
         return request
 
     def createSearchReferencesRequest(self):
         request = protocol.SearchReferencesRequest()
-        setCommaSeparatedAttribute(request, self.args, 'accessions')
-        setCommaSeparatedAttribute(request, self.args, 'md5checksums')
+        request.accession = self.args.accession
+        request.md5checksum = self.args.md5checksum
         request.referenceSetId = self.args.referenceSetId
         return request
 
@@ -677,16 +677,16 @@ def addUrlArgument(parser):
     parser.add_argument("baseUrl", help="The URL of the API endpoint")
 
 
-def addAccessionsArgument(parser):
+def addAccessionArgument(parser):
     parser.add_argument(
-        "--accessions", default=None,
-        help="The accessions to search over")
+        "--accession", default=None,
+        help="The accession to search for")
 
 
-def addMd5ChecksumsArgument(parser):
+def addMd5ChecksumArgument(parser):
     parser.add_argument(
-        "--md5checksums", default=None,
-        help="The md5checksums to search over")
+        "--md5checksum", default=None,
+        help="The md5checksum to search for")
 
 
 def addPageSizeArgument(parser):
@@ -778,11 +778,11 @@ def addReferenceSetsSearchParser(subparsers):
     parser.set_defaults(runner=SearchReferenceSetsRunner)
     addUrlArgument(parser)
     addPageSizeArgument(parser)
-    addAccessionsArgument(parser)
-    addMd5ChecksumsArgument(parser)
+    addAccessionArgument(parser)
+    addMd5ChecksumArgument(parser)
     parser.add_argument(
         "--assemblyId",
-        help="The assembly id to search over")
+        help="The assembly id to search for")
     return parser
 
 
@@ -794,8 +794,8 @@ def addReferencesSearchParser(subparsers):
     parser.set_defaults(runner=SearchReferencesRunner)
     addUrlArgument(parser)
     addPageSizeArgument(parser)
-    addAccessionsArgument(parser)
-    addMd5ChecksumsArgument(parser)
+    addAccessionArgument(parser)
+    addMd5ChecksumArgument(parser)
     addReferenceSetIdArgument(parser)
     return parser
 

--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -291,8 +291,9 @@ class SimulatedReferenceSet(AbstractReferenceSet):
         self._isDerived = bool(random.randint(0, 1))
         self._ncbiTaxonId = random.randint(0, 2**16)
         self._sourceAccessions = []
-        for i in range(random.randint(0, 5)):
-                self._sourceAccessions.append("sim_accession_{}".format(i))
+        for i in range(random.randint(1, 3)):
+                self._sourceAccessions.append("sim_accession_{}".format(
+                    random.randint(1, 2**32)))
         self._sourceUri = "http://example.com/reference.fa"
         for i in range(numReferences):
             referenceSeed = self._randomGenerator.getrandbits(32)
@@ -322,8 +323,9 @@ class SimulatedReference(AbstractReference):
             self._sourceDivergence = rng.uniform(0, 0.1)
         self._ncbiTaxonId = random.randint(0, 2**16)
         self._sourceAccessions = []
-        for i in range(random.randint(0, 5)):
-                self._sourceAccessions.append("sim_accession_{}".format(i))
+        for i in range(random.randint(1, 3)):
+                self._sourceAccessions.append("sim_accession_{}".format(
+                    random.randint(1, 2**32)))
         self._sourceUri = "http://example.com/reference.fa"
 
     def getBases(self, start, end):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -121,12 +121,12 @@ class TestClientArguments(unittest.TestCase):
         DATASETID"""
 
     def testReferenceSetsSearchArguments(self):
-        self.cliInput = """referencesets-search --pageSize 1 --accessions
-        ACC,ESS,IONS --md5checksums MD5,CHECKSUMS --assemblyId ASSEMBLYID"""
+        self.cliInput = """referencesets-search --pageSize 1 --accession
+        ACCESSION --md5checksum MD5CHECKSUMS --assemblyId ASSEMBLYID"""
 
     def testReferencesSearchArguments(self):
-        self.cliInput = """references-search --pageSize 1 --accessions
-        ACC,ESS,IONS --md5checksums MD5,CHECKSUMS"""
+        self.cliInput = """references-search --pageSize 1 --accession
+        ACCESSIONS --md5checksum MD5CHECKSUM"""
 
     def testReadGroupSetsSearchArguments(self):
         self.cliInput = """readgroupsets-search --pageSize 1 --datasetId


### PR DESCRIPTION
Also brings cli up to date with reference schema changes.

We add filtering to reference and reference sets search in the most straightforward way I could think of. It is disappointing that we have to build a list of all the objects, but this avoids a lot of tricky issues. The number of references and reference sets is likely to be rather small, so I doubt this will be an issue in practice.

The tests aren't entirely exhaustive, but they should exercise the code well enough.

Issues #539 and #540.

