### PR TITLE
CLI refactor

### DIFF
--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -101,14 +101,6 @@ class HttpClient(object):
             jsonResponseString)
         return responseObject
 
-    def _updateNotDone(self, responseObject, protocolRequest):
-        if hasattr(responseObject, 'nextPageToken'):
-            protocolRequest.pageToken = responseObject.nextPageToken
-            notDone = responseObject.nextPageToken is not None
-        else:
-            notDone = False
-        return notDone
-
     def _doRequest(self, httpMethod, url, protocolResponseClass,
                    httpParams={}, httpData=None):
         """
@@ -146,22 +138,31 @@ class HttpClient(object):
             self._logger.info("Response pageSize={}".format(len(valueList)))
             for extract in valueList:
                 yield extract
-            notDone = self._updateNotDone(responseObject, protocolRequest)
+            notDone = responseObject.nextPageToken is not None
+            protocolRequest.pageToken = responseObject.nextPageToken
 
-    def runListRequest(self, protocolRequest, url,
-                       protocolResponseClass, id_):
+    def listReferenceBases(self, id_, start=None, end=None):
         """
-        Asks the server to list objects of type protocolResponseClass and
-        returns an iterator over the results.
+        Returns an iterator over the bases from the server in the form
+        of consecutive strings. This command does not conform to the
+        patterns of the other search and get requests, and is implemented
+        differently.
         """
+        url = "references/{id}/bases"
         fullUrl = posixpath.join(self._urlPrefix, url).format(id=id_)
+        request = protocol.ListReferenceBasesRequest()
+        request.start = start
+        request.end = end
         notDone = True
         while notDone:
-            requestDict = protocolRequest.toJsonDict()
-            responseObject = self._doRequest(
-                'GET', fullUrl, protocolResponseClass, requestDict)
-            yield responseObject
-            notDone = self._updateNotDone(responseObject, protocolRequest)
+            response = self._doRequest(
+                'GET', fullUrl, protocol.ListReferenceBasesResponse,
+                request.toJsonDict())
+            self._logger.info("Response pageSize={}".format(
+                len(response.sequence)))
+            yield response.sequence
+            notDone = response.nextPageToken is not None
+            request.pageToken = response.nextPageToken
 
     def runGetRequest(self, objectName, protocolResponseClass, id_):
         """
@@ -217,20 +218,21 @@ class HttpClient(object):
         """
         return self.runGetRequest("variants", protocol.Variant, id_)
 
-    def listReferenceBases(self, protocolRequest, id_):
-        """
-        Returns an iterator over the bases from the server
-        """
-        return self.runListRequest(
-            protocolRequest, "references/{id}/bases",
-            protocol.ListReferenceBasesResponse, id_)
-
-    def searchVariants(self, protocolRequest):
+    def searchVariants(
+            self, variantSetId, start=None, end=None, referenceName=None,
+            callSetIds=None, pageSize=None):
         """
         Returns an iterator over the Variants from the server
         """
+        request = protocol.SearchVariantsRequest()
+        request.referenceName = referenceName
+        request.start = start
+        request.end = end
+        request.variantSetId = variantSetId
+        request.callSetIds = callSetIds
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "variants", protocol.SearchVariantsResponse)
+            request, "variants", protocol.SearchVariantsResponse)
 
     def getVariantSet(self, id_):
         """
@@ -238,54 +240,87 @@ class HttpClient(object):
         """
         return self.runGetRequest("variantsets", protocol.VariantSet, id_)
 
-    def searchVariantSets(self, protocolRequest):
+    def searchVariantSets(self, datasetId, pageSize=None):
         """
-        Returns an iterator over the VariantSets from the server.
+        Returns an iterator over the VariantSets on the server. If datasetId
+        is specified, return only the VariantSets in this dataset.
         """
+        request = protocol.SearchVariantSetsRequest()
+        request.datasetId = datasetId
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "variantsets",
-            protocol.SearchVariantSetsResponse)
+            request, "variantsets", protocol.SearchVariantSetsResponse)
 
-    def searchReferenceSets(self, protocolRequest):
+    def searchReferenceSets(
+            self, accession=None, md5checksum=None, assemblyId=None,
+            pageSize=None):
         """
         Returns an iterator over the ReferenceSets from the server.
         """
+        request = protocol.SearchReferenceSetsRequest()
+        request.accession = accession
+        request.md5checksum = md5checksum
+        request.assemblyId = assemblyId
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "referencesets",
-            protocol.SearchReferenceSetsResponse)
+            request, "referencesets", protocol.SearchReferenceSetsResponse)
 
-    def searchReferences(self, protocolRequest):
+    def searchReferences(
+            self, referenceSetId, accession=None, md5checksum=None,
+            pageSize=None):
         """
         Returns an iterator over the References from the server
         """
+        request = protocol.SearchReferencesRequest()
+        request.referenceSetId = referenceSetId
+        request.accession = accession
+        request.md5checksum = md5checksum
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "references", protocol.SearchReferencesResponse)
+            request, "references", protocol.SearchReferencesResponse)
 
-    def searchCallSets(self, protocolRequest):
+    def searchCallSets(self, variantSetId, name=None, pageSize=None):
         """
         Returns an iterator over the CallSets from the server
         """
+        request = protocol.SearchCallSetsRequest()
+        request.variantSetId = variantSetId
+        request.name = name
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "callsets", protocol.SearchCallSetsResponse)
+            request, "callsets", protocol.SearchCallSetsResponse)
 
-    def searchReadGroupSets(self, protocolRequest):
+    def searchReadGroupSets(self, datasetId, name=None, pageSize=None):
         """
         Returns an iterator over the ReadGroupSets from the server
         """
+        request = protocol.SearchReadGroupSetsRequest()
+        request.datasetId = datasetId
+        request.name = name
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "readgroupsets",
-            protocol.SearchReadGroupSetsResponse)
+            request, "readgroupsets", protocol.SearchReadGroupSetsResponse)
 
-    def searchReads(self, protocolRequest):
+    def searchReads(
+            self, readGroupIds, referenceId=None, start=None, end=None,
+            pageSize=None):
         """
         Returns an iterator over the Reads from the server
         """
+        request = protocol.SearchReadsRequest()
+        request.readGroupIds = readGroupIds
+        request.referenceId = referenceId
+        request.start = start
+        request.end = end
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "reads", protocol.SearchReadsResponse)
+            request, "reads", protocol.SearchReadsResponse)
 
-    def searchDatasets(self, protocolRequest):
+    def searchDatasets(self, pageSize=None):
         """
         Returns an iterator over the Datasets from the server
         """
+        request = protocol.SearchDatasetsRequest()
+        request.pageSize = pageSize
         return self.runSearchRequest(
-            protocolRequest, "datasets", protocol.SearchDatasetsResponse)
+            request, "datasets", protocol.SearchDatasetsResponse)

--- a/ga4gh/converters.py
+++ b/ga4gh/converters.py
@@ -18,9 +18,10 @@ class AbstractConverter(object):
     """
     Abstract base class for converter classes
     """
-    def __init__(self, httpClient, apiRequest, outputFile, binaryOutput):
-        self._httpClient = httpClient
-        self._apiRequest = apiRequest
+    def __init__(
+            self, container, objectIterator, outputFile, binaryOutput):
+        self._container = container
+        self._objectIterator = objectIterator
         self._outputFile = outputFile
         self._binaryOutput = binaryOutput
 
@@ -54,8 +55,7 @@ class SamConverter(AbstractConverter):
             fileString = self._outputFile
         alignmentFile = pysam.AlignmentFile(
             fileString, flags, header=header)
-        iterator = self._httpClient.searchReads(self._apiRequest)
-        for read in iterator:
+        for read in self._objectIterator:
             alignedSegment = SamLine.toAlignedSegment(read, targetIds)
             alignmentFile.write(alignedSegment)
         alignmentFile.close()
@@ -220,9 +220,7 @@ class VcfConverter(AbstractConverter):
     VCF format using pysam.
     """
     def _writeHeader(self):
-        # We support exactly one variantSet.
-        variantSetId = self._apiRequest.variantSetIds[0]
-        variantSet = self._httpClient.getVariantSet(variantSetId)
+        variantSet = self._container
         # TODO convert this into pysam types and write to the output file.
         # For now, just print out some stuff to demonstrate how to get the
         # attributes we have.
@@ -233,7 +231,7 @@ class VcfConverter(AbstractConverter):
             print("\t", metadata)
 
     def _writeBody(self):
-        for variant in self._httpClient.searchVariants(self._apiRequest):
+        for variant in self._objectIterator:
             # TODO convert each variant object into pysam objects and write to
             # the output file. For now, just print the first variant and break.
             print(variant)

--- a/tests/end_to_end/client.py
+++ b/tests/end_to_end/client.py
@@ -21,10 +21,11 @@ class ClientForTesting(object):
         self.outFile = None
         self.errFile = None
         if flags is None:
-            self.flags = "-v -O"
+            self.flags = "-v"
         else:
             self.flags = flags
-        self.cmdLine = "python client_dev.py {flags} {command} {serverUrl}"
+        self.cmdLine = (
+            "python client_dev.py {flags} {command} {serverUrl} {arguments}")
         self._createLogFiles()
 
     def _createLogFiles(self):
@@ -41,11 +42,12 @@ class ClientForTesting(object):
     def getErrLines(self):
         return utils.getLinesFromLogFile(self.errFile)
 
-    def runCommand(self, command, debugOnFail=True):
+    def runCommand(self, command, arguments, debugOnFail=True):
         clientCmdLine = self.cmdLine.format(**{
             "flags": self.flags,
             "command": command,
-            "serverUrl": self.serverUrl})
+            "serverUrl": self.serverUrl,
+            "arguments": arguments})
         splits = shlex.split(clientCmdLine)
         try:
             subprocess.check_call(

--- a/tests/end_to_end/server_test.py
+++ b/tests/end_to_end/server_test.py
@@ -15,9 +15,9 @@ class ClientHelperMixin(object):
     """
     Helper methods involving the client for server tests
     """
-    def runClientCmd(self, client, command):
+    def runClientCmd(self, client, command, arguments=""):
         try:
-            client.runCommand(command)
+            client.runCommand(command, arguments)
         except subprocess.CalledProcessError as error:
             self.server.printDebugInfo()
             raise error
@@ -82,9 +82,9 @@ class RemoteServerTest(ServerTest):
     def getServer(self):
         raise NotImplementedError("Must subclass RemoteServerTest")
 
-    def runClientCmd(self, client, command):
+    def runClientCmd(self, client, command, arguments=""):
         try:
-            client.runCommand(command)
+            client.runCommand(command, arguments)
         except subprocess.CalledProcessError as error:
             self.server.printDebugInfo()
             self.remoteServer.printDebugInfo()

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -77,31 +77,33 @@ class TestGestalt(server_test.ServerTest):
     def runVariantsRequest(self):
         self.runClientCmd(
             self.client,
-            "variants-search -s 0 -e 2 -V {}".format(
-                self.simulatedVariantSetId))
+            "variants-search",
+            "-s 0 -e 2 -V {}".format(self.simulatedVariantSetId))
 
     def runReadsRequest(self):
-        cmd = (
-            "reads-search --readGroupIds {} "
-            "--referenceId {}".format(
-                self.simulatedReadGroupId, self.simulatedReferenceId))
-        self.runClientCmd(self.client, cmd)
+        args = "--readGroupIds {} --referenceId {}".format(
+            self.simulatedReadGroupId, self.simulatedReferenceId)
+        self.runClientCmd(self.client, "reads-search", args)
 
     def runReferencesRequest(self):
         referenceSetId = self.simulatedReferenceSetId
         referenceId = self.simulatedReferenceId
         cmd = "referencesets-search"
         self.runClientCmd(self.client, cmd)
-        cmd = "references-search --referenceSetId={}".format(referenceSetId)
-        self.runClientCmd(self.client, cmd)
-        cmd = "referencesets-get {}".format(referenceSetId)
-        self.runClientCmd(self.client, cmd)
-        cmd = "references-get {}".format(referenceId)
-        self.runClientCmd(self.client, cmd)
-        cmd = "references-list-bases {}".format(referenceId)
-        self.runClientCmd(self.client, cmd)
+        cmd = "references-search"
+        args = "--referenceSetId={}".format(referenceSetId)
+        self.runClientCmd(self.client, cmd, args)
+        cmd = "referencesets-get"
+        args = "{}".format(referenceSetId)
+        self.runClientCmd(self.client, cmd, args)
+        cmd = "references-get"
+        args = "{}".format(referenceId)
+        self.runClientCmd(self.client, cmd, args)
+        cmd = "references-list-bases"
+        args = "{}".format(referenceId)
+        self.runClientCmd(self.client, cmd, args)
 
     def runVariantSetsRequestDatasetTwo(self):
-        datasetId = self.simulatedDatasetId
-        cmd = "variantsets-search --datasetId {}".format(datasetId)
-        self.runClientCmd(self.client, cmd)
+        cmd = "variantsets-search"
+        args = "--datasetId {}".format(self.simulatedDatasetId)
+        self.runClientCmd(self.client, cmd, args)

--- a/tests/end_to_end/test_oidc.py
+++ b/tests/end_to_end/test_oidc.py
@@ -84,8 +84,8 @@ class TestOidc(server_test.ServerTestClass):
             serverUrl, flags="--key {}".format('ABC'))
         with self.assertRaises(subprocess.CalledProcessError):
             test_client.runCommand(
-                "variants-search -s 0 -e 2 -V {}".format(
-                    self.simulatedVariantSetId),
+                "variants-search",
+                "-s 0 -e 2 -V {}".format(self.simulatedVariantSetId),
                 debugOnFail=False)
         test_client.cleanup()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -63,105 +63,152 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
     """
     def setUp(self):
         self.httpClient = utils.makeHttpClient()
-        self.protocolRequest = DummyRequest()
         self.httpClient.runSearchRequest = mock.Mock()
-        self.httpClient.runListRequest = mock.Mock()
         self.httpClient.runGetRequest = mock.Mock()
-        self._id = "SomeId"
+        self.objectId = "SomeId"
+        self.objectName = "objectName"
+        self.datasetId = "datasetId"
+        self.variantSetId = "variantSetId"
+        self.referenceSetId = "referenceSetId"
+        self.referenceId = "referenceId"
+        self.readGroupIds = ["readGroupId"]
+        self.referenceName = "referenceName"
+        self.start = 100
+        self.end = 101
+        self.referenceName = "referenceName"
+        self.callSetIds = ["id1", "id2"]
+        self.pageSize = 1000
+        self.assemblyId = "assemblyId"
+        self.accession = "accession"
+        self.md5checksum = "md5checksum"
 
     def testSearchVariants(self):
-        self.httpClient.searchVariants(self.protocolRequest)
+        request = protocol.SearchVariantsRequest()
+        request.referenceName = self.referenceName
+        request.start = self.start
+        request.end = self.end
+        request.variantSetId = self.variantSetId
+        request.callSetIds = self.callSetIds
+        request.pageSize = self.pageSize
+        self.httpClient.searchVariants(
+            self.variantSetId, start=self.start, end=self.end,
+            referenceName=self.referenceName, callSetIds=self.callSetIds,
+            pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "variants",
+            request, "variants",
             protocol.SearchVariantsResponse)
 
-    def testSearchVariantSets(self):
-        self.httpClient.searchVariantSets(self.protocolRequest)
+    def testSearchDatasets(self):
+        request = protocol.SearchDatasetsRequest()
+        request.pageSize = self.pageSize
+        self.httpClient.searchDatasets(self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "variantsets",
-            protocol.SearchVariantSetsResponse)
+            request, "datasets", protocol.SearchDatasetsResponse)
+
+    def testSearchVariantSets(self):
+        request = protocol.SearchVariantSetsRequest()
+        request.datasetId = self.datasetId
+        request.pageSize = self.pageSize
+        self.httpClient.searchVariantSets(self.datasetId, self.pageSize)
+        self.httpClient.runSearchRequest.assert_called_once_with(
+            request, "variantsets", protocol.SearchVariantSetsResponse)
 
     def testSearchReferenceSets(self):
-        self.httpClient.searchReferenceSets(self.protocolRequest)
+        request = protocol.SearchReferenceSetsRequest()
+        request.pageSize = self.pageSize
+        request.accession = self.accession
+        request.md5checksum = self.md5checksum
+        request.assemblyId = self.assemblyId
+        self.httpClient.searchReferenceSets(
+            accession=self.accession, md5checksum=self.md5checksum,
+            assemblyId=self.assemblyId, pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "referencesets",
-            protocol.SearchReferenceSetsResponse)
+            request, "referencesets", protocol.SearchReferenceSetsResponse)
 
     def testSearchReferences(self):
-        self.httpClient.searchReferences(self.protocolRequest)
+        request = protocol.SearchReferencesRequest()
+        request.referenceSetId = self.referenceSetId
+        request.pageSize = self.pageSize
+        request.accession = self.accession
+        request.md5checksum = self.md5checksum
+        self.httpClient.searchReferences(
+            self.referenceSetId, accession=self.accession,
+            md5checksum=self.md5checksum, pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "references",
-            protocol.SearchReferencesResponse)
+            request, "references", protocol.SearchReferencesResponse)
 
     def testSearchReadGroupSets(self):
-        self.httpClient.searchReadGroupSets(self.protocolRequest)
+        request = protocol.SearchReadGroupSetsRequest()
+        request.datasetId = self.datasetId
+        request.name = self.objectName
+        request.pageSize = self.pageSize
+        self.httpClient.searchReadGroupSets(
+            self.datasetId, name=self.objectName, pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "readgroupsets",
-            protocol.SearchReadGroupSetsResponse)
+            request, "readgroupsets", protocol.SearchReadGroupSetsResponse)
 
     def testSearchCallSets(self):
-        self.httpClient.searchCallSets(self.protocolRequest)
+        request = protocol.SearchCallSetsRequest()
+        request.variantSetId = self.variantSetId
+        request.name = self.objectName
+        request.pageSize = self.pageSize
+        self.httpClient.searchCallSets(
+            self.variantSetId, name=self.objectName, pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "callsets",
-            protocol.SearchCallSetsResponse)
+            request, "callsets", protocol.SearchCallSetsResponse)
 
     def testSearchReads(self):
-        self.httpClient.searchReads(self.protocolRequest)
+        request = protocol.SearchReadsRequest()
+        request.readGroupIds = self.readGroupIds
+        request.referenceId = self.referenceId
+        request.start = self.start
+        request.end = self.end
+        request.pageSize = self.pageSize
+        self.httpClient.searchReads(
+            self.readGroupIds, referenceId=self.referenceId,
+            start=self.start, end=self.end, pageSize=self.pageSize)
         self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "reads",
-            protocol.SearchReadsResponse)
-
-    def testSearchDatasets(self):
-        self.httpClient.searchDatasets(self.protocolRequest)
-        self.httpClient.runSearchRequest.assert_called_once_with(
-            self.protocolRequest, "datasets",
-            protocol.SearchDatasetsResponse)
+            request, "reads", protocol.SearchReadsResponse)
 
     def testGetReferenceSet(self):
-        self.httpClient.getReferenceSet(self._id)
+        self.httpClient.getReferenceSet(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "referencesets", protocol.ReferenceSet, self._id)
+            "referencesets", protocol.ReferenceSet, self.objectId)
 
     def testGetVariantSet(self):
-        self.httpClient.getVariantSet(self._id)
+        self.httpClient.getVariantSet(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "variantsets", protocol.VariantSet, self._id)
+            "variantsets", protocol.VariantSet, self.objectId)
 
     def testGetReference(self):
-        self.httpClient.getReference(self._id)
+        self.httpClient.getReference(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "references", protocol.Reference, self._id)
+            "references", protocol.Reference, self.objectId)
 
     def testGetReadGroupSets(self):
-        self.httpClient.getReadGroupSet(self._id)
+        self.httpClient.getReadGroupSet(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "readgroupsets", protocol.ReadGroupSet, self._id)
+            "readgroupsets", protocol.ReadGroupSet, self.objectId)
 
     def testGetReadGroup(self):
-        self.httpClient.getReadGroup(self._id)
+        self.httpClient.getReadGroup(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "readgroups", protocol.ReadGroup, self._id)
+            "readgroups", protocol.ReadGroup, self.objectId)
 
     def testGetCallsets(self):
-        self.httpClient.getCallset(self._id)
+        self.httpClient.getCallset(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "callsets", protocol.CallSet, self._id)
+            "callsets", protocol.CallSet, self.objectId)
 
     def testGetDatasets(self):
-        self.httpClient.getDataset(self._id)
+        self.httpClient.getDataset(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "datasets", protocol.Dataset, self._id)
+            "datasets", protocol.Dataset, self.objectId)
 
     def testGetVariant(self):
-        self.httpClient.getVariant(self._id)
+        self.httpClient.getVariant(self.objectId)
         self.httpClient.runGetRequest.assert_called_once_with(
-            "variants", protocol.Variant, self._id)
-
-    def testListReferenceBases(self):
-        self.httpClient.listReferenceBases(self.protocolRequest, self._id)
-        self.httpClient.runListRequest.assert_called_once_with(
-            self.protocolRequest, "references/{id}/bases",
-            protocol.ListReferenceBasesResponse, self._id)
+            "variants", protocol.Variant, self.objectId)
 
 
 class TestRunRequest(unittest.TestCase):
@@ -241,7 +288,7 @@ class TestRunRequest(unittest.TestCase):
                 httpMethod, url, params=params, headers=headers, data=data,
                 verify=False)
 
-    def testRunListRequest(self):
+    def testRunListReferenceBases(self):
         # setup
         mockGet = mock.Mock()
         with mock.patch('requests.request', mockGet):
@@ -250,23 +297,16 @@ class TestRunRequest(unittest.TestCase):
                 "sequence": "sequence",
                 "nextPageToken": "pageTok",
             }
-            mockGet.side_effect = [
-                DummyResponse(json.dumps(text)), DummyResponse('{}')]
-            protocolRequest = protocol.ListReferenceBasesRequest()
-            protocolRequest.start = 1
-            protocolRequest.end = 5
-            url = "references/{id}/bases"
-            protocolResponseClass = protocol.ListReferenceBasesResponse
+            mockGet.side_effect = [DummyResponse(json.dumps(text))]
             id_ = 'myId'
 
             # invoke SUT
-            result = [base for base in self.httpClient.runListRequest(
-                protocolRequest, url, protocolResponseClass, id_)]
+            result = [chunk for chunk in self.httpClient.listReferenceBases(
+                id_, start=1, end=5)]
 
             # verify results of invocation
-            self.assertEqual(len(result), 2)
-            self.assertEqual(result[0].offset, 123)
-            self.assertEqual(result[0].sequence, "sequence")
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0], "sequence")
 
             # verify requests.get called correctly
             httpMethod = 'GET'
@@ -281,12 +321,6 @@ class TestRunRequest(unittest.TestCase):
             firstCall = mockGet.call_args_list[0]
             self.assertRequestsCall(
                 firstCall, httpMethod, url, headers, data, params, False)
-
-            # assert second call correct
-            params['pageToken'] = 'pageTok'
-            secondCall = mockGet.call_args_list[1]
-            self.assertRequestsCall(
-                secondCall, httpMethod, url, headers, data, params, False)
 
     def assertRequestsCall(
             self, call, httpMethod, url,

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import mock
 import tempfile
 import unittest
 
@@ -13,7 +12,6 @@ import pysam
 
 import ga4gh.protocol as protocol
 import ga4gh.converters as converters
-import tests.utils as utils
 
 
 class TestSamConverter(unittest.TestCase):
@@ -23,7 +21,7 @@ class TestSamConverter(unittest.TestCase):
     """
     readsFilePath = 'tests/unit/reads.dat'
 
-    def _getReads(self):
+    def getReads(self):
         readsFile = file(self.readsFilePath)
         lines = readsFile.readlines()
         reads = []
@@ -31,34 +29,6 @@ class TestSamConverter(unittest.TestCase):
             read = protocol.ReadAlignment.fromJsonString(line)
             reads.append(read)
         return reads
-
-    def getHttpClient(self):
-        httpClient = utils.makeHttpClient()
-        httpClient.searchReads = self.getSearchReadsResponse
-        return httpClient
-
-    def getSearchReadsRequest(self):
-        request = protocol.SearchReadsRequest()
-        return request
-
-    def getSearchReadsResponse(self, request):
-        return self._getReads()
-
-
-class TestSamConverterLogic(TestSamConverter):
-    """
-    Test the SamConverter logic
-    """
-    def testSamConverter(self):
-        mockPysam = mock.Mock()
-        with mock.patch('pysam.AlignmentFile', mockPysam):
-            httpClient = self.getHttpClient()
-            searchReadsRequest = self.getSearchReadsRequest()
-            outputFile = None
-            binaryOutput = False
-            samConverter = converters.SamConverter(
-                httpClient, searchReadsRequest, outputFile, binaryOutput)
-            samConverter.convert()
 
 
 class TestSamConverterRoundTrip(TestSamConverter):
@@ -68,11 +38,9 @@ class TestSamConverterRoundTrip(TestSamConverter):
     def _testRoundTrip(self, binaryOutput):
         with tempfile.NamedTemporaryFile() as fileHandle:
             # write SAM file
-            httpClient = self.getHttpClient()
-            searchReadsRequest = self.getSearchReadsRequest()
             filePath = fileHandle.name
             samConverter = converters.SamConverter(
-                httpClient, searchReadsRequest, filePath, binaryOutput)
+                None, self.getReads(), filePath, binaryOutput)
             samConverter.convert()
 
             # read SAM file


### PR DESCRIPTION
This is a WIP, so comments welcome. The PR depends on #641 and #634, so has a pretty large diff right now. This should look more sensible once these are merged and this is rebased.

The basic idea here is to refactor the CLI and client library so that we can make the client application smarter. If we give ``variant-sets-search`` no dataset arguments, we run the search over all datasets. Similar logic applies to all the other requests: if we don't specify enough information, the client application will query the server and do the right thing. We also add JSON output, which I think is quite useful and might persuade people to stop using CURL to query the server. These changes are all motivated by the upcoming documentation updates, which are going to be hard to write with any clarity using the current CLI.

The major refactoring here is that we change the client methods like ``searchVariants`` to take the arguments directly as parameters, and not the request objects. We therefore insulate the user from this detail of the protocol, and allow them to use the methods in a relatively high-level way.