### PR TITLE
Made pageSize an attribute of httpClient.

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -144,20 +144,20 @@ class AbstractSearchRunner(FormattedOutputRunner):
     def __init__(self, args):
         super(AbstractSearchRunner, self).__init__(args)
         self._pageSize = args.pageSize
+        self._httpClient.setPageSize(self._pageSize)
 
     def getAllDatasets(self):
         """
         Returns all datasets on the server.
         """
-        return self._httpClient.searchDatasets(pageSize=self._pageSize)
+        return self._httpClient.searchDatasets()
 
     def getAllVariantSets(self):
         """
         Returns all variant sets on the server.
         """
         for dataset in self.getAllDatasets():
-            iterator = self._httpClient.searchVariantSets(
-                datasetId=dataset.id, pageSize=self._pageSize)
+            iterator = self._httpClient.searchVariantSets(datasetId=dataset.id)
             for variantSet in iterator:
                 yield variantSet
 
@@ -167,7 +167,7 @@ class AbstractSearchRunner(FormattedOutputRunner):
         """
         for dataset in self.getAllDatasets():
             iterator = self._httpClient.searchReadGroupSets(
-                datasetId=dataset.id, pageSize=self._pageSize)
+                datasetId=dataset.id)
             for readGroupSet in iterator:
                 yield readGroupSet
 
@@ -175,7 +175,7 @@ class AbstractSearchRunner(FormattedOutputRunner):
         """
         Returns all reference sets on the server.
         """
-        return self._httpClient.searchReferenceSets(pageSize=self._pageSize)
+        return self._httpClient.searchReferenceSets()
 
 
 # Runners for the various search methods
@@ -188,7 +188,7 @@ class SearchDatasetsRunner(AbstractSearchRunner):
         super(SearchDatasetsRunner, self).__init__(args)
 
     def run(self):
-        iterator = self._httpClient.searchDatasets(pageSize=self._pageSize)
+        iterator = self._httpClient.searchDatasets()
         self._output(iterator)
 
 
@@ -203,8 +203,7 @@ class SearchReferenceSetsRunner(AbstractSearchRunner):
 
     def run(self):
         iterator = self._httpClient.searchReferenceSets(
-            accession=self._accession, md5checksum=self._md5checksum,
-            pageSize=self._pageSize)
+            accession=self._accession, md5checksum=self._md5checksum)
         self._output(iterator)
 
 
@@ -221,7 +220,7 @@ class SearchReferencesRunner(AbstractSearchRunner):
     def _run(self, referenceSetId):
         iterator = self._httpClient.searchReferences(
             accession=self._accession, md5checksum=self._md5checksum,
-            referenceSetId=referenceSetId, pageSize=self._pageSize)
+            referenceSetId=referenceSetId)
         self._output(iterator)
 
     def run(self):
@@ -241,8 +240,7 @@ class SearchVariantSetsRunner(AbstractSearchRunner):
         self._datasetId = args.datasetId
 
     def _run(self, datasetId):
-        iterator = self._httpClient.searchVariantSets(
-            datasetId=datasetId, pageSize=self._pageSize)
+        iterator = self._httpClient.searchVariantSets(datasetId=datasetId)
         self._output(iterator)
 
     def run(self):
@@ -264,7 +262,7 @@ class SearchReadGroupSetsRunner(AbstractSearchRunner):
 
     def _run(self, datasetId):
         iterator = self._httpClient.searchReadGroupSets(
-            datasetId=datasetId, name=self._name, pageSize=self._pageSize)
+            datasetId=datasetId, name=self._name)
         self._output(iterator)
 
     def run(self):
@@ -286,8 +284,7 @@ class SearchCallSetsRunner(AbstractSearchRunner):
 
     def _run(self, variantSetId):
         iterator = self._httpClient.searchCallSets(
-            variantSetId=variantSetId, name=self._name,
-            pageSize=self._pageSize)
+            variantSetId=variantSetId, name=self._name)
         self._output(iterator)
 
     def run(self):
@@ -319,8 +316,7 @@ class SearchVariantsRunner(AbstractSearchRunner):
         iterator = self._httpClient.searchVariants(
             start=self._start, end=self._end,
             referenceName=self._referenceName,
-            variantSetId=variantSetId, callSetIds=self._callSetIds,
-            pageSize=self._pageSize)
+            variantSetId=variantSetId, callSetIds=self._callSetIds)
         self._output(iterator)
 
     def run(self):
@@ -368,7 +364,7 @@ class SearchReadsRunner(AbstractSearchRunner):
         # like we do with SearchVariants and others.
         iterator = self._httpClient.searchReads(
             readGroupIds=self._readGroupIds, referenceId=self._referenceId,
-            start=self._start, end=self._end, pageSize=self._pageSize)
+            start=self._start, end=self._end)
         self._output(iterator)
 
     def _textOutput(self, gaObjects):
@@ -850,8 +846,7 @@ class Ga2VcfRunner(SearchVariantsRunner):
             start=self._start, end=self._end,
             referenceName=self._referenceName,
             variantSetId=self._variantSetId,
-            callSetIds=self._callSetIds,
-            pageSize=self._pageSize)
+            callSetIds=self._callSetIds)
         # do conversion
         vcfConverter = converters.VcfConverter(
             variantSet, iterator, self._outputFile, self._binaryOutput)
@@ -918,7 +913,7 @@ class Ga2SamRunner(SearchReadsRunner):
         readGroup = self._httpClient.getReadGroup(self._readGroupIds[0])
         iterator = self._httpClient.searchReads(
             readGroupIds=self._readGroupIds, referenceId=self._referenceId,
-            start=self._start, end=self._end, pageSize=self._pageSize)
+            start=self._start, end=self._end)
         # do conversion
         samConverter = converters.SamConverter(
             readGroup, iterator, self._outputFile, self._binaryOutput)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -24,6 +24,7 @@ class HttpClient(object):
         self._debugLevel = debugLevel
         self._bytesRead = 0
         self._key = key
+        self._pageSize = None
 
         # logging config
         # TODO we need to revisit this logging setup so that we can
@@ -45,12 +46,26 @@ class HttpClient(object):
             requests.packages.urllib3.disable_warnings()
         requestsLog.propagate = True
 
+    def getPageSize(self):
+        """
+        Returns the suggested maximum size of pages of results returned by
+        the server.
+        """
+        return self._pageSize
+
     def getBytesRead(self):
         """
         Returns the total number of (non HTTP) bytes read from the server
         by this client.
         """
         return self._bytesRead
+
+    def setPageSize(self, pageSize):
+        """
+        Sets the requested maximum size of pages of results returned by the
+        server to the specified value.
+        """
+        self._pageSize = pageSize
 
     def _getAuth(self):
         return {'key': self._key}
@@ -220,7 +235,7 @@ class HttpClient(object):
 
     def searchVariants(
             self, variantSetId, start=None, end=None, referenceName=None,
-            callSetIds=None, pageSize=None):
+            callSetIds=None):
         """
         Returns an iterator over the Variants from the server
         """
@@ -230,7 +245,7 @@ class HttpClient(object):
         request.end = end
         request.variantSetId = variantSetId
         request.callSetIds = callSetIds
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "variants", protocol.SearchVariantsResponse)
 
@@ -240,20 +255,19 @@ class HttpClient(object):
         """
         return self.runGetRequest("variantsets", protocol.VariantSet, id_)
 
-    def searchVariantSets(self, datasetId, pageSize=None):
+    def searchVariantSets(self, datasetId):
         """
         Returns an iterator over the VariantSets on the server. If datasetId
         is specified, return only the VariantSets in this dataset.
         """
         request = protocol.SearchVariantSetsRequest()
         request.datasetId = datasetId
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "variantsets", protocol.SearchVariantSetsResponse)
 
     def searchReferenceSets(
-            self, accession=None, md5checksum=None, assemblyId=None,
-            pageSize=None):
+            self, accession=None, md5checksum=None, assemblyId=None):
         """
         Returns an iterator over the ReferenceSets from the server.
         """
@@ -261,13 +275,12 @@ class HttpClient(object):
         request.accession = accession
         request.md5checksum = md5checksum
         request.assemblyId = assemblyId
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "referencesets", protocol.SearchReferenceSetsResponse)
 
     def searchReferences(
-            self, referenceSetId, accession=None, md5checksum=None,
-            pageSize=None):
+            self, referenceSetId, accession=None, md5checksum=None):
         """
         Returns an iterator over the References from the server
         """
@@ -275,35 +288,34 @@ class HttpClient(object):
         request.referenceSetId = referenceSetId
         request.accession = accession
         request.md5checksum = md5checksum
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "references", protocol.SearchReferencesResponse)
 
-    def searchCallSets(self, variantSetId, name=None, pageSize=None):
+    def searchCallSets(self, variantSetId, name=None):
         """
         Returns an iterator over the CallSets from the server
         """
         request = protocol.SearchCallSetsRequest()
         request.variantSetId = variantSetId
         request.name = name
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "callsets", protocol.SearchCallSetsResponse)
 
-    def searchReadGroupSets(self, datasetId, name=None, pageSize=None):
+    def searchReadGroupSets(self, datasetId, name=None):
         """
         Returns an iterator over the ReadGroupSets from the server
         """
         request = protocol.SearchReadGroupSetsRequest()
         request.datasetId = datasetId
         request.name = name
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "readgroupsets", protocol.SearchReadGroupSetsResponse)
 
     def searchReads(
-            self, readGroupIds, referenceId=None, start=None, end=None,
-            pageSize=None):
+            self, readGroupIds, referenceId=None, start=None, end=None):
         """
         Returns an iterator over the Reads from the server
         """
@@ -312,15 +324,15 @@ class HttpClient(object):
         request.referenceId = referenceId
         request.start = start
         request.end = end
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "reads", protocol.SearchReadsResponse)
 
-    def searchDatasets(self, pageSize=None):
+    def searchDatasets(self):
         """
         Returns an iterator over the Datasets from the server
         """
         request = protocol.SearchDatasetsRequest()
-        request.pageSize = pageSize
+        request.pageSize = self._pageSize
         return self.runSearchRequest(
             request, "datasets", protocol.SearchDatasetsResponse)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -78,9 +78,18 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.referenceName = "referenceName"
         self.callSetIds = ["id1", "id2"]
         self.pageSize = 1000
+        self.httpClient.setPageSize(self.pageSize)
         self.assemblyId = "assemblyId"
         self.accession = "accession"
         self.md5checksum = "md5checksum"
+
+    def testSetPageSize(self):
+        httpClient = utils.makeHttpClient()
+        # pageSize is None by default
+        self.assertIsNone(httpClient.getPageSize())
+        for pageSize in [1, 10, 100]:
+            httpClient.setPageSize(pageSize)
+            self.assertEqual(httpClient.getPageSize(), pageSize)
 
     def testSearchVariants(self):
         request = protocol.SearchVariantsRequest()
@@ -92,8 +101,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.pageSize = self.pageSize
         self.httpClient.searchVariants(
             self.variantSetId, start=self.start, end=self.end,
-            referenceName=self.referenceName, callSetIds=self.callSetIds,
-            pageSize=self.pageSize)
+            referenceName=self.referenceName, callSetIds=self.callSetIds)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "variants",
             protocol.SearchVariantsResponse)
@@ -101,7 +109,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
     def testSearchDatasets(self):
         request = protocol.SearchDatasetsRequest()
         request.pageSize = self.pageSize
-        self.httpClient.searchDatasets(self.pageSize)
+        self.httpClient.searchDatasets()
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "datasets", protocol.SearchDatasetsResponse)
 
@@ -109,7 +117,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request = protocol.SearchVariantSetsRequest()
         request.datasetId = self.datasetId
         request.pageSize = self.pageSize
-        self.httpClient.searchVariantSets(self.datasetId, self.pageSize)
+        self.httpClient.searchVariantSets(self.datasetId)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "variantsets", protocol.SearchVariantSetsResponse)
 
@@ -121,7 +129,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.assemblyId = self.assemblyId
         self.httpClient.searchReferenceSets(
             accession=self.accession, md5checksum=self.md5checksum,
-            assemblyId=self.assemblyId, pageSize=self.pageSize)
+            assemblyId=self.assemblyId)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "referencesets", protocol.SearchReferenceSetsResponse)
 
@@ -133,7 +141,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.md5checksum = self.md5checksum
         self.httpClient.searchReferences(
             self.referenceSetId, accession=self.accession,
-            md5checksum=self.md5checksum, pageSize=self.pageSize)
+            md5checksum=self.md5checksum)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "references", protocol.SearchReferencesResponse)
 
@@ -143,7 +151,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.name = self.objectName
         request.pageSize = self.pageSize
         self.httpClient.searchReadGroupSets(
-            self.datasetId, name=self.objectName, pageSize=self.pageSize)
+            self.datasetId, name=self.objectName)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "readgroupsets", protocol.SearchReadGroupSetsResponse)
 
@@ -153,7 +161,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.name = self.objectName
         request.pageSize = self.pageSize
         self.httpClient.searchCallSets(
-            self.variantSetId, name=self.objectName, pageSize=self.pageSize)
+            self.variantSetId, name=self.objectName)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "callsets", protocol.SearchCallSetsResponse)
 
@@ -166,7 +174,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.pageSize = self.pageSize
         self.httpClient.searchReads(
             self.readGroupIds, referenceId=self.referenceId,
-            start=self.start, end=self.end, pageSize=self.pageSize)
+            start=self.start, end=self.end)
         self.httpClient.runSearchRequest.assert_called_once_with(
             request, "reads", protocol.SearchReadsResponse)
 


### PR DESCRIPTION
Having a pageSize argument on all of the  searchX methods in the httpClient is confusing. This is a low-level network utilisation knob, which doesn't affect the output of the methods in any way. It therefore makes much more sense to make this an attribute of the httpClient rather than to pass it in as a parameter to each search call. 