### PR TITLE
Provide a useful error if server appears to already be running during the server end to end test

### DIFF
--- a/tests/end_to_end/server.py
+++ b/tests/end_to_end/server.py
@@ -56,7 +56,8 @@ class ServerForTesting(object):
         """
         Start the server
         """
-        assert not self.isRunning(), "Another server is running"
+        assert not self.isRunning(), "Another server is running at {}".format(
+            self.serverUrl)
         self.outFile = tempfile.TemporaryFile()
         self.errFile = tempfile.TemporaryFile()
         splits = shlex.split(self.getCmdLine())


### PR DESCRIPTION
I was poking around for a couple minutes and couldn't find the offending port, or an open terminal. This makes it easier.