### PR TITLE
Use URLs to specify data sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Some general rules to follow:
 * Create a branch for each update that you're working on. These branches 
   are often called "feature" or "topic" branches. Any changes that you 
   push to your feature branch will automatically be shown in the pull request.
+* Test your code (by running `nosetests`) before creating a pull request.
 * Keep your pull requests as small as possible. Large pull requests are 
   hard to review. Try to break up your changes into self-contained and 
   incremental pull requests.

--- a/ga4gh/serverconfig.py
+++ b/ga4gh/serverconfig.py
@@ -20,7 +20,7 @@ class BaseConfig(object):
     REQUEST_VALIDATION = False
     RESPONSE_VALIDATION = False
     DEFAULT_PAGE_SIZE = 100
-    DATA_SOURCE = "__EMPTY__"
+    DATA_SOURCE = "empty://"
 
     # Options for the simulated backend.
     SIMULATED_BACKEND_RANDOM_SEED = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coverage==3.7.1
 flake8==2.3.0  # Set due to conflict with pep8 in version 2.4.0
 guppy==0.1.10
 humanize==0.5.1
-mock==1.2.0
+mock==1.0.0
 nose==1.3.7
 pep8==1.6.2
 pysam==0.8.3

--- a/tests/end_to_end/server.py
+++ b/tests/end_to_end/server.py
@@ -172,7 +172,7 @@ class Ga4ghServerForTesting(ServerForTesting):
         config = """
 SIMULATED_BACKEND_NUM_VARIANT_SETS = 10
 SIMULATED_BACKEND_VARIANT_DENSITY = 1
-DATA_SOURCE = "__SIMULATED__"
+DATA_SOURCE = "simulated://"
 DEBUG = True
 """
         if self.useOidc:

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -100,11 +100,11 @@ class TestFrontendOidc(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         config = {
-            "DATA_SOURCE": "__SIMULATED__",
             "SIMULATED_BACKEND_RANDOM_SEED": 1111,
             "SIMULATED_BACKEND_NUM_CALLS": 1,
             "SIMULATED_BACKEND_VARIANT_DENSITY": 1.0,
             "SIMULATED_BACKEND_NUM_VARIANT_SETS": 1,
+            "DATA_SOURCE": "simulated://",
             "OIDC_CLIENT_ID": "123",
             "OIDC_CLIENT_SECRET": RANDSTR,
             "OIDC_PROVIDER": "http://auth.com"

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -29,7 +29,7 @@ class TestSimulatedStack(unittest.TestCase):
         # Set the random seed to make tests reproducible.
         random.seed(1)
         config = {
-            "DATA_SOURCE": "__SIMULATED__",
+            "DATA_SOURCE": "simulated://",
             "SIMULATED_BACKEND_RANDOM_SEED": 1111,
             "SIMULATED_BACKEND_NUM_CALLS": 5,
             "SIMULATED_BACKEND_VARIANT_DENSITY": 1.0,

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -22,7 +22,7 @@ class TestFrontend(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         config = {
-            "DATA_SOURCE": "__SIMULATED__",
+            "DATA_SOURCE": "simulated://",
             "SIMULATED_BACKEND_RANDOM_SEED": 1111,
             "SIMULATED_BACKEND_NUM_CALLS": 1,
             "SIMULATED_BACKEND_VARIANT_DENSITY": 1.0,


### PR DESCRIPTION
Instead of `__EMPTY__` we use `empty://`. Instead of `__SIMULATED__` we use things like `simulated://?numCalls=5&numReferencesPerReferenceSet=1` (and pull the un-specified values from the config). Currently-used file paths get automatically turned into `file://` URLs, and `file://` URLs can be accepted.

Unless your config requested `__EMPTY__` or `__SIMULATED__`, this is backwards-compatible. It also potentially will let us do stuff like `mysql://` in the future if we get more different backends. Maybe one for `graphdatabase://`?

I sort of thought this might help with #717, keeping with the theme of improving the simulated backend.