### PR TITLE
Routine to set sam flags mistakenly assumes integer is passed by ref

### DIFF
--- a/ga4gh/converters.py
+++ b/ga4gh/converters.py
@@ -158,34 +158,40 @@ class SamLine(object):
     def toSamFlag(cls, read):
         flag = 0
         if read.numberReads:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.NUMBER_READS)
         if read.properPlacement:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.PROPER_PLACEMENT)
         if read.alignment.position.strand == protocol.Strand.NEG_STRAND:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.REVERSED)
         if (read.nextMatePosition is not None and
                 read.nextMatePosition.strand == protocol.Strand.NEG_STRAND):
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.NEXT_MATE_REVERSED)
-        if read.readNumber:
-            reads.SamFlags.setFlag(
+        if read.readNumber == 0:
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.READ_NUMBER_ONE)
-            reads.SamFlags.setFlag(
+        elif read.readNumber == 1:
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.READ_NUMBER_TWO)
+        elif read.readNumber == 2:
+            flag = reads.SamFlags.setFlag(
+                flag,
+                reads.SamFlags.READ_NUMBER_ONE |
+                reads.SamFlags.READ_NUMBER_TWO)
         if read.secondaryAlignment:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.SECONDARY_ALIGNMENT)
         if read.failedVendorQualityChecks:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.FAILED_VENDOR_QUALITY_CHECKS)
         if read.duplicateFragment:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.DUPLICATE_FRAGMENT)
         if read.supplementaryAlignment:
-            reads.SamFlags.setFlag(
+            flag = reads.SamFlags.setFlag(
                 flag, reads.SamFlags.SUPPLEMENTARY_ALIGNMENT)
         return flag
 

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -82,7 +82,7 @@ class SamFlags(object):
 
     @staticmethod
     def setFlag(flagAttr, flag):
-        flagAttr |= flag
+        return flagAttr | flag
 
 
 class AbstractReadGroupSet(datamodel.DatamodelObject):
@@ -608,7 +608,11 @@ class HtslibReadGroup(datamodel.PysamDatamodelMixin, AbstractReadGroup):
         ret.readNumber = None
         if SamFlags.isFlagSet(read.flag, SamFlags.NUMBER_READS):
             ret.numberReads = 2
-            if SamFlags.isFlagSet(read.flag, SamFlags.READ_NUMBER_ONE):
+            if SamFlags.isFlagSet(read.flag,
+                                  SamFlags.READ_NUMBER_ONE |
+                                  SamFlags.READ_NUMBER_TWO):
+                ret.readNumber = 2
+            elif SamFlags.isFlagSet(read.flag, SamFlags.READ_NUMBER_ONE):
                 ret.readNumber = 0
             elif SamFlags.isFlagSet(read.flag, SamFlags.READ_NUMBER_TWO):
                 ret.readNumber = 1

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -24,9 +24,15 @@ class TestSamConverter(unittest.TestCase):
         self._client = client.LocalClient(self._backend)
 
     def verifySamRecordsEqual(self, sourceReads, convertedReads):
+        """
+        Verify that a read from pysam matches a read from the reference server
+        """
         self.assertEqual(len(sourceReads), len(convertedReads))
         for source, converted in zip(sourceReads, convertedReads):
+            self.assertEqual(source.query_name, converted.query_name)
             self.assertEqual(source.query_sequence, converted.query_sequence)
+            self.assertEqual(source.qual, converted.qual)
+            self.assertEqual(source.flag, converted.flag)
             # TODO add more comparisons.
 
     def verifyFullConversion(self, readGroupSet, readGroup, reference):


### PR DESCRIPTION
Make this routine return the value instead.