### PR TITLE
Add branch miss coverage option to nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_script:
 # under it that we want to run (and want to be able to run) as local tests
 script: 
   - flake8 *.py tests ga4gh scripts --exclude=ez_setup.py
-  - coverage erase
   - nosetests --with-coverage --cover-package ga4gh
               --cover-inclusive --cover-min-percentage 85
+              --cover-branches --cover-erase
   - make clean -C docs
   - make -C docs


### PR DESCRIPTION
Good news: we're doing pretty good on branch coverage; our test coverage percentage only slips from 93 to 91 with the branch coverage option enabled.

Issue #700