### PR TITLE
Remove virtualenv for simple_op server.

### DIFF
--- a/oidc-provider/run.sh
+++ b/oidc-provider/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-./setupenv.sh
-. bin/activate
 HOSTNAME=`python -c 'import socket; print socket.gethostname()'`
 cd simple_op && python src/run.py --base https://${HOSTNAME}:8443 -p 8443 -d settings.yaml
 

--- a/oidc-provider/setupenv.sh
+++ b/oidc-provider/setupenv.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-virtualenv .
-. bin/activate
-pip install -r simple_op/requirements.txt

--- a/oidc-provider/simple_op/requirements.txt
+++ b/oidc-provider/simple_op/requirements.txt
@@ -1,6 +1,0 @@
-cherrypy==3.2.4
-pyaml==15.03.1
-Jinja2==2.7.3
-oic==0.7.6
-yubico-client==1.9.1
-pyjwkest==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,9 @@ Sphinx==1.3.1
 oic==0.7.6
 pyOpenSSL==0.15.1
 lxml==3.4.4
-CherryPy==3.8.0
+# Requirements for test OIDC provider.
+cherrypy==3.2.4
+pyaml==15.03.1
+Jinja2==2.7.3
+yubico-client==1.9.1
+pyjwkest==1.0.1

--- a/tests/end_to_end/server.py
+++ b/tests/end_to_end/server.py
@@ -236,13 +236,6 @@ class OidcOpServerForTesting(ServerForTesting):
             subdirectory="oidc-provider/simple_op",
             pingStatusCode=404)
 
-    def start(self):
-        # Setup environment for OP server
-        with tempfile.TemporaryFile() as tempFile:
-            subprocess.check_call(["./setupenv.sh"], cwd="oidc-provider",
-                                  stdout=tempFile, stderr=subprocess.STDOUT)
-        super(OidcOpServerForTesting, self).start()
-
     def getCmdLine(self):
         return ("python src/run.py --base https://localhost:{}" +
                 " -p {} -d settings.yaml").format(oidcOpPort, oidcOpPort)

--- a/tests/end_to_end/test_oidc.py
+++ b/tests/end_to_end/test_oidc.py
@@ -8,8 +8,9 @@ from __future__ import unicode_literals
 
 import requests
 import subprocess
-from lxml import html
 from urlparse import urlparse
+
+import lxml.html as html
 
 import client
 import server


### PR DESCRIPTION
This should fix the current CI problems of issue #792.

We had an embedded virtualenv to run the simple_op provider, which started to cause trouble on travis's setup. This was always going to cause issues in any case as it meant we couldn't run the tests from a virtualenv (I don't think venv's nest very well).

Let's see if this fixes the problem anyway.