### PR TITLE
Update schemas to v0.6.0a1.

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -11,7 +11,7 @@ from protocol import SearchResponse
 
 import avro.schema
 
-version = '0.6.4628a2fe0'
+version = '0.6.0a1'
 
 
 class Call(ProtocolElement):


### PR DESCRIPTION
Result of running 

```
python scripts/process_schemas.py  v0.6.0a1
```

No differences other than schema version.