### PR TITLE
Use setuptools_scm to set version numbers.

### DIFF
--- a/ga4gh/__init__.py
+++ b/ga4gh/__init__.py
@@ -2,4 +2,9 @@
 Reference implementation of the GA4GH APIs.
 """
 
-__version__ = '0.2.0a1'
+__version__ = "undefined"
+try:
+    from . import _version
+    __version__ = _version.version
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import re
-
 # First, we try to use setuptools. If it's not available locally,
 # we fall back on ez_setup.
 try:
@@ -9,44 +7,14 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
-
-# Following the recommendations of PEP 396 we parse the version number
-# out of the module.
-def parseVersion(moduleFile):
-    """
-    Parses the version string from the specified file.
-
-    This implementation is ugly, but there doesn't seem to be a good way
-    to do this in general at the moment.
-    """
-    f = open(moduleFile)
-    s = f.read()
-    f.close()
-    match = re.findall("__version__ = '([^']+)'", s)
-    return match[0]
-
-f = open("README.pypi.rst")
-ga4ghReadme = f.read()
-f.close()
-ga4ghVersion = parseVersion("ga4gh/__init__.py")
-# Flask must come after all other requirements that have "flask" as a prefix
-# due to a setuptools bug.
-requirements = [
-    "Flask-Cors==2.0.1",
-    "Flask==0.10.1",
-    "avro==1.7.7",
-    "humanize==0.5.1",
-    "pysam==0.8.4",
-    "oic==0.7.6",
-    "requests==2.7.0",
-]
+with open("README.pypi.rst") as readmeFile:
+    long_description = readmeFile.read()
 
 setup(
     name="ga4gh",
-    version=ga4ghVersion,
     description="A reference implementation of the ga4gh API",
     license='Apache License 2.0',
-    long_description=ga4ghReadme,
+    long_description=long_description,
     packages=["ga4gh", "ga4gh.datamodel", "ga4gh.templates"],
     include_package_data=True,
     zip_safe=False,
@@ -67,13 +35,24 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-
-        # We should add other versions that we can confirm pass the tests
-        # (2.6?)
         'Programming Language :: Python :: 2.7',
-
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
     keywords='genomics reference',
-    install_requires=requirements,
+    # Flask must come after all other requirements that have "flask" as a
+    # prefix due to a setuptools bug.
+    install_requires=[
+        "Flask-Cors==2.0.1",
+        "Flask==0.10.1",
+        "avro==1.7.7",
+        "humanize==0.5.1",
+        "pysam==0.8.4",
+        "oic==0.7.6",
+        "requests==2.7.0",
+    ],
+    # Use setuptools_scm to set the version number automatically from Git
+    setup_requires=['setuptools_scm'],
+    use_scm_version={
+        "write_to": "ga4gh/_version.py"
+    },
 )

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -147,9 +147,7 @@ class ImportGraphLayerChecker(object):
     but as it stands the time for these tests is dominated by file
     operations and and parsing the ASTs
     """
-    excludedPythonFilenames = set([
-        '__init__.py',
-    ])
+    excludedPythonFilenames = set(['__init__.py', '_version.py'])
 
     # each file/module is in one and only one moduleGroup
     moduleGroupNames = {


### PR DESCRIPTION
Issue #790 

Also a minor refactor of setup.py.

@reece --- it would be great to get your thoughts here. I based this off what you've done in hgvs, but thought the ``"write_to": "ga4gh/_version.py"`` was a bit simpler than ``pkg_resources`` (which I think could potentially be misleading for a developer?). 