### PR TITLE
Use caching to speed up build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ python:
   - "2.7"
 sudo: false
 
-before_install:
-  - wget 'http://www.well.ox.ac.uk/~jk/wheelhouse.tar'
-  - tar -xvf wheelhouse.tar
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 install:
-  - pip install --use-wheel --find-links=wheelhouse/ -r requirements.txt
+  - pip install pip --upgrade 
+  - pip --version
+  - pip install -r requirements.txt
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ cache:
 
 install:
   - pip install pip --upgrade 
-  - pip --version
   - pip install -r requirements.txt
-  - python setup.py install
+  - python setup.py sdist
+  - pip install dist/ga4gh*.tar.gz
 
 before_script:
   # the following two lines are to prevent travis from


### PR DESCRIPTION
Using Travis's cache and a recent version of pip we can cache binary packages. Reduces builds from ~7minutes to 1.5 minutes.

Also change the install script to build the source distribution and install from this, allowing us to test the distribution mechanisms.