### PR TITLE
Adds tests for unmapped reads and multiple readGroups - Issue #684

### DIFF
--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -101,12 +101,10 @@ class TestFrontend(unittest.TestCase):
         request.variantSetId = variantSets[0].id
         return self.sendPostRequest('/callsets/search', request)
 
-    def sendReadsSearch(self, readGroupIds=None):
-        if readGroupIds is None:
-            readGroupIds = [self.readGroupId]
+    def sendReadsSearch(self, readGroupIds=None, referenceId=None):
         request = protocol.SearchReadsRequest()
         request.readGroupIds = readGroupIds
-        request.referenceId = self.referenceId
+        request.referenceId = referenceId
         return self.sendPostRequest('/reads/search', request)
 
     def sendDatasetsSearch(self):
@@ -361,7 +359,8 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(len(responseData.callSets), 1)
 
     def testReadsSearch(self):
-        response = self.sendReadsSearch()
+        response = self.sendReadsSearch(readGroupIds=[self.readGroupId],
+                                        referenceId=self.referenceId)
         self.assertEqual(200, response.status_code)
         responseData = protocol.SearchReadsResponse.fromJsonString(
             response.data)
@@ -380,3 +379,13 @@ class TestFrontend(unittest.TestCase):
     def testNoAuthentication(self):
         path = '/oauth2callback'
         self.assertEqual(501, self.app.get(path).status_code)
+
+    def testSearchUnmappedReads(self):
+        response = self.sendReadsSearch(readGroupIds=[self.readGroupId],
+                                        referenceId=None)
+        self.assertEqual(501, response.status_code)
+
+    def testSearchReadsMultipleReadGroupSets(self):
+        response = self.sendReadsSearch(readGroupIds=[self.readGroupId, "42"],
+                                        referenceId=self.referenceId)
+        self.assertEqual(501, response.status_code)


### PR DESCRIPTION
Tests for Issue #684 

This adds a few more unit tests to cover cases where a reference is not specified or multiple readGroupIds are sent. In all cases the response is expected to be a 501.
