### PR TITLE
Variant annotation with variant sets

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -213,11 +213,11 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
 
     @classmethod
     def _getStart(cls, annotation):
-        return annotation.variant.start
+        return annotation.start
 
     @classmethod
     def _getEnd(cls, annotation):
-        return annotation.variant.end
+        return annotation.end
 
     def next(self):
         while True:
@@ -234,7 +234,9 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
         if not vann.transcriptEffects:
             return False
         for teff in vann.transcriptEffects:
-            if not self.filterEffect(teff):
+            if self.filterEffect(teff):
+                return True
+            else:
                 return False
         return True
 
@@ -463,9 +465,15 @@ class Backend(object):
         """
         compoundId = datamodel.VariantSetCompoundId.parse(request.variantSetId)
         dataset = self.getDataRepository().getDataset(compoundId.datasetId)
-        return self._topLevelObjectGenerator(
-            request, dataset.getNumVariantAnnotationSets(),
-            dataset.getVariantAnnotationSetByIndex)
+        results = []
+        for annset in dataset.getVariantAnnotationSets():
+            try:
+                variantSetId = request.variantSetId
+            except ValueError:
+                variantSetId = ""
+            if str(annset._variantSetId) == str(variantSetId):
+                results.append(annset)
+        return self._objectListGenerator(request, results)
 
     def readsGenerator(self, request):
         """
@@ -692,6 +700,15 @@ class Backend(object):
         return self.runGetRequest(dataset)
 
     # Search requests.
+
+    def runGetVariantAnnotationSet(self, id_):
+        """
+        Runs a getVariantSet request for the specified ID.
+        """
+        compoundId = datamodel.VariantAnnotationSetCompoundId.parse(id_)
+        dataset = self.getDataset(compoundId.datasetId)
+        variantAnnotationSet = dataset.getVariantAnnotationSet(id_)
+        return self.runGetRequest(variantAnnotationSet)
 
     def runSearchReadGroupSets(self, request):
         """

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -208,6 +208,20 @@ class AbstractClient(object):
         return self._runGetRequest(
             "variantsets", protocol.VariantSet, variantSetId)
 
+    def getVariantAnnotationSet(self, variantAnnotationSetId):
+        """
+        Returns the VariantAnnotationSet with the specified ID from
+        the server.
+
+        :param str variantAnnotationSetId: The ID of the
+            VariantAnnotationSet of interest.
+        :return: The VariantAnnotationSet of interest.
+        :rtype: :class:`ga4gh.protocol.VariantAnnotationSet`
+        """
+        return self._runGetRequest(
+            "variantannotationsets", protocol.VariantAnnotationSet,
+            variantAnnotationSetId)
+
     def searchVariants(
             self, variantSetId, start=None, end=None, referenceName=None,
             callSetIds=None):
@@ -293,7 +307,7 @@ class AbstractClient(object):
         return self._runSearchRequest(
             request, "variantsets", protocol.SearchVariantSetsResponse)
 
-    def searchVariantAnnotationSets(self, datasetId):
+    def searchVariantAnnotationSets(self, variantSetId):
         """
         Returns an iterator over the AnnotationSets fulfilling the specified
         conditions from the specified Dataset.
@@ -304,7 +318,7 @@ class AbstractClient(object):
             objects defined by the query parameters.
         """
         request = protocol.SearchVariantAnnotationSetsRequest()
-        request.datasetId = datasetId
+        request.variantSetId = variantSetId
         request.pageSize = self._pageSize
         return self._runSearchRequest(
             request, "variantannotationsets",
@@ -522,6 +536,7 @@ class LocalClient(AbstractClient):
             "variants": self._backend.runGetVariant,
             "readgroupsets": self._backend.runGetReadGroupSet,
             "readgroups": self._backend.runGetReadGroup,
+            "variantannotationsets": self._backend.runGetVariantAnnotationSet
         }
         self._searchMethodMap = {
             "datasets": self._backend.runSearchDatasets,
@@ -531,6 +546,8 @@ class LocalClient(AbstractClient):
             "variants": self._backend.runSearchVariants,
             "readgroupsets": self._backend.runSearchReadGroupSets,
             "reads": self._backend.runSearchReads,
+            "variantannotationsets":
+                self._backend.runSearchVariantAnnotationSets
         }
 
     def _runGetRequest(self, objectName, protocolResponseClass, id_):

--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -210,12 +210,11 @@ class FileSystemDataset(AbstractDataset):
                     self, localId, relativePath, dataRepository)
                 self.addVariantSet(variantSet)
             # Variant annotations sets
-            variantAnnotationSetDir = os.path.join(
-                relativePath, "variantAnnotations")
-            if os.path.isdir(variantAnnotationSetDir):
-                variantAnnotationSet = variants.HtslibVariantAnnotationSet(
-                    self, localId, variantAnnotationSetDir, dataRepository)
-                self.addVariantAnnotationSet(variantAnnotationSet)
+                if variantSet._isAnnotated(relativePath, localId):
+                    variantAnnotationSet = variants.HtslibVariantAnnotationSet(
+                            self, localId, relativePath, dataRepository,
+                            variantSet)
+                    self.addVariantAnnotationSet(variantAnnotationSet)
 
         # Reads
         readGroupSetDir = os.path.join(dataDir, "reads")

--- a/ga4gh/datarepo.py
+++ b/ga4gh/datarepo.py
@@ -10,6 +10,7 @@ import os
 import ga4gh.exceptions as exceptions
 import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.references as references
+import ga4gh.datamodel.ontologies as ontologies
 
 
 class AbstractDataRepository(object):
@@ -23,6 +24,8 @@ class AbstractDataRepository(object):
         self._referenceSetIdMap = {}
         self._referenceSetNameMap = {}
         self._referenceSetIds = []
+        self._ontologyNameMap = {}
+        self._ontologyNames = []
 
     def addDataset(self, dataset):
         """
@@ -41,6 +44,14 @@ class AbstractDataRepository(object):
         self._referenceSetIdMap[id_] = referenceSet
         self._referenceSetNameMap[referenceSet.getLocalId()] = referenceSet
         self._referenceSetIds.append(id_)
+
+    def addOntology(self, ontology):
+        """
+        Adds ontologies to this backend.
+        """
+        for name in ontology.keys():
+            self._ontologyNameMap[name] = ontology.get(name)
+            self._ontologyNames.append(name)
 
     def getDatasets(self):
         """
@@ -88,6 +99,12 @@ class AbstractDataRepository(object):
         Returns the number of reference sets in this data repository.
         """
         return len(self._referenceSetIds)
+
+    def getOntology(self, name):
+        """
+        Returns ontologies
+        """
+        return self._ontologyNameMap[name]
 
     def getReferenceSet(self, id_):
         """
@@ -163,10 +180,12 @@ class FileSystemDataRepository(AbstractDataRepository):
     def __init__(self, dataDir):
         super(FileSystemDataRepository, self).__init__()
         self._dataDir = dataDir
-        sourceDirNames = ["referenceSets", "datasets"]
+        sourceDirNames = ["referenceSets", "ontologies", "datasets"]
         constructors = [
-            references.HtslibReferenceSet, datasets.FileSystemDataset]
-        objectAdders = [self.addReferenceSet, self.addDataset]
+            references.HtslibReferenceSet, ontologies.FileSystemOntologies,
+            datasets.FileSystemDataset]
+        objectAdders = [self.addReferenceSet, self.addOntology,
+                        self.addDataset]
         for sourceDirName, constructor, objectAdder in zip(
                 sourceDirNames, constructors, objectAdders):
             sourceDir = os.path.join(self._dataDir, sourceDirName)

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -145,6 +145,13 @@ class ServerStatus(object):
         """
         return app.backend.getDataRepository().getReferenceSets()
 
+    def getVariantAnnotationSets(self, datasetId):
+        """
+        Returns the list of ReferenceSets for this server.
+        """
+        return app.backend.getDataRepository().getDataset(
+            datasetId).getVariantAnnotationSets()
+
 
 def reset():
     """
@@ -622,6 +629,14 @@ def oidcCallback():
 def getDataset(id):
     return handleFlaskGetRequest(
         id, flask.request, app.backend.runGetDataset)
+
+
+@DisplayedRoute(
+    '/variantannotationsets/<no(search):id>',
+    pathDisplay='/variantannotationsets/<id>')
+def getVariantAnnotationSet(id):
+    return handleFlaskGetRequest(
+        id, flask.request, app.backend.runGetVariantAnnotationSet)
 
 # The below methods ensure that JSON is returned for various errors
 # instead of the default, html

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -84,6 +84,17 @@
                     </tr>
                     {% endfor %}
                 </table>
+                <h6>VariantAnnotationSets</h6>
+                <table class="table table-striped">
+                    <th>Name</th>
+                    <th>Id</th>
+                    {% for variantAnnotationSet in info.getVariantAnnotationSets(dataset.getId()) %}
+                    <tr>
+                        <td>{{ variantAnnotationSet.getLocalId() }}</td>
+                        <td>{{ variantAnnotationSet.getId() }}</td>
+                    </tr>
+                    {% endfor %}
+                </table>
                 <h6>ReadGroupSets</h6>
                 <table class="table table-striped">
                     <th>Name</th>

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -79,6 +79,15 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient._runSearchRequest.assert_called_once_with(
             request, "variantsets", protocol.SearchVariantSetsResponse)
 
+    def testSearchVariantAnnotationSets(self):
+        request = protocol.SearchVariantAnnotationSetsRequest()
+        request.variantSetId = self.variantSetId
+        request.pageSize = self.pageSize
+        self.httpClient.searchVariantAnnotationSets(self.variantSetId)
+        self.httpClient._runSearchRequest.assert_called_once_with(
+            request, "variantannotationsets",
+            protocol.SearchVariantAnnotationSetsResponse)
+
     def testSearchReferenceSets(self):
         request = protocol.SearchReferenceSetsRequest()
         request.pageSize = self.pageSize
@@ -140,6 +149,12 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient.getReferenceSet(self.objectId)
         self.httpClient._runGetRequest.assert_called_once_with(
             "referencesets", protocol.ReferenceSet, self.objectId)
+
+    def testGetVariantAnnotationSet(self):
+        self.httpClient.getVariantAnnotationSet(self.objectId)
+        self.httpClient._runGetRequest.assert_called_once_with(
+            "variantannotationsets", protocol.VariantAnnotationSet,
+            self.objectId)
 
     def testGetVariantSet(self):
         self.httpClient.getVariantSet(self.objectId)


### PR DESCRIPTION
This PR attempts to formalize the relationship between variant sets and variant annotation sets. Previously, it was possible to have variant annotations for variants that weren't present in GA4GH. Now annotation VCFs are considered a source of a variant set as well as a variant annotation set.

This is done by placing a small description JSON next to the VCF in the directory. For now, this file simply denotes whether the VCF is annotated or not.

    {
        "isAnnotated": true
    }

Furthermore, the requirement of placing the variant object within the annotation has been removed: annotations now maintain the start and end coordinates themselves so they can be searched across without looking up the variant.