### PR TITLE
Remove padding from identifiers and add it back in as needed

### DIFF
--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -187,14 +187,17 @@ class CompoundId(object):
         fashion. This is not intended for security purposes, but rather to
         dissuade users from depending on our internal ID structures.
         """
-        return base64.b64encode(idStr)
+        return base64.urlsafe_b64encode(str(idStr)).replace(b'=', b'')
 
     @classmethod
-    def deobfuscate(cls, idStr):
+    def deobfuscate(cls, data):
         """
         Reverses the obfuscation done by the :meth:`obfuscate` method.
+        If an identifier arrives without correct base64 padding this
+        function will append it to the end.
         """
-        return base64.b64decode(idStr)
+        return base64.urlsafe_b64decode(str((
+            data + b'A=='[(len(data) - 1) % 4:])))
 
 
 class ReferenceSetCompoundId(CompoundId):

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -21,10 +21,10 @@ class TestGestalt(server_test.ServerTest):
     An end-to-end test of the client and server
     """
     def testEndToEnd(self):
-        self.simulatedDatasetId = "c2ltdWxhdGVkRGF0YXNldDA="
+        self.simulatedDatasetId = "c2ltdWxhdGVkRGF0YXNldDA"
         self.simulatedVariantSetId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltVnMw"
-        self.simulatedReadGroupId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltUmdzMDpyZzA="
-        self.simulatedReferenceSetId = "cmVmZXJlbmNlU2V0MA=="
+        self.simulatedReadGroupId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltUmdzMDpyZzA"
+        self.simulatedReferenceSetId = "cmVmZXJlbmNlU2V0MA"
         self.simulatedReferenceId = "cmVmZXJlbmNlU2V0MDpzcnMw"
         self.client = client.ClientForTesting(self.server.getUrl())
         self.runVariantsRequest()

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -25,6 +25,24 @@ class TestCompoundIds(unittest.TestCase):
     """
     Test the compound ids
     """
+    def testURLUnsafe(self):
+        hasSlashes = "???"  # base64 encodes to 'Pz8/'
+        needsPadding = "padme"  # base64 encodes to 'cGFkbWU='
+        realistic = ("YnJjYTE6V0FTSDdQX2Fubm90YXRpb246MToxNzY5"
+                     "NDpmMzQxM2JkMTVjNWNiYzI4ZDFiYjY2OGY4ZWM2NzczMg")
+        unsafeCharacters = ['$', '&', '+', ',', '/', ':', ';', '=', '?', '@']
+        for char in unsafeCharacters:
+            self.assertNotIn(char, datamodel.CompoundId.obfuscate(
+                    hasSlashes))
+            self.assertNotIn(char, datamodel.CompoundId.obfuscate(
+                    needsPadding))
+            self.assertNotIn(char, datamodel.CompoundId.obfuscate(
+                    realistic))
+        for idStr in [hasSlashes, needsPadding]:
+            obfuscated = datamodel.CompoundId.obfuscate(idStr)
+            deobfuscated = datamodel.CompoundId.deobfuscate(obfuscated)
+            self.assertEqual(idStr, deobfuscated)
+
     def testBadParse(self):
         for badId in ['a;b', 'a;b;c;d', 'a;b;sd;', ';;;;']:
             obfuscated = datamodel.CompoundId.obfuscate(badId)


### PR DESCRIPTION
Putting `=` in identifiers was a side effect of base64 encoding. This PR attempts to hide them from the user while not functionally changing the identifier scheme. Fix #860 