### PR TITLE
Issue 704: Adds client json tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-Cors==2.0.1
 avro==1.7.7
 coverage==3.7.1
 flake8==2.3.0  # Set due to conflict with pep8 in version 2.4.0
+freezegun==0.3.6
 guppy==0.1.10
 humanize==0.5.1
 mock==1.0.0

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -7,6 +7,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import datetime
 import json
 import unittest
 
@@ -16,12 +17,16 @@ import ga4gh.cli as cli
 import ga4gh.datarepo as datarepo
 import tests.utils as utils
 
+import freezegun
 
+
+@freezegun.freeze_time(datetime.datetime.now())
 class TestClientOutput(unittest.TestCase):
     """
     Base class for client output tests
     """
     def setUp(self):
+        self._maxDiff = None
         self._dataDir = "tests/data"
         self._dataUrl = "file://{}".format(self._dataDir)
         dataRepository = datarepo.FileSystemDataRepository(self._dataDir)
@@ -90,28 +95,111 @@ class TestClientJson(TestClientOutput):
         cliOutput = self.captureJsonOutput(cliCommand, cliArguments)
         clientOutput = [gaObject.toJsonDict() for gaObject in clientIterator]
         self.assertEqual(clientOutput, cliOutput)
-
-    def testSearchAllDatasets(self):
-        iterator = self._client.searchDatasets()
-        self.verifyParsedOutputsEqual(iterator, "datasets-search")
-
-    def testSearchAllReferenceSets(self):
-        iterator = self._client.searchReferenceSets()
-        self.verifyParsedOutputsEqual(iterator, "referencesets-search")
-
-    def testSearchAllReferences(self):
-        for referenceSet in self._client.searchReferenceSets():
-            iterator = self._client.searchReferences(
-                referenceSetId=referenceSet.id)
-            args = "--referenceSetId={}".format(referenceSet.id)
-            self.verifyParsedOutputsEqual(iterator, "references-search", args)
+        return len(clientOutput)
 
     def testGetDataset(self):
         for dataset in self._client.searchDatasets():
             self.verifyParsedOutputsEqual(
                 [dataset], "datasets-get", dataset.id)
 
-    def testSearchAllReadGroups(self):
-        # TODO: add more rigorous testing here
-        cliOutput = self.captureJsonOutput("reads-search")
-        self.assertGreater(len(cliOutput), 0)
+    def testGetReadGroup(self):
+        for dataset in self._client.searchDatasets():
+            for readGroupSet in self._client.searchReadGroupSets(dataset.id):
+                for readGroup in readGroupSet.readGroups:
+                    self.verifyParsedOutputsEqual(
+                        [readGroup], "readgroups-get", readGroup.id)
+
+    def testGetReadGroupSet(self):
+        for dataset in self._client.searchDatasets():
+            for readGroupSet in self._client.searchReadGroupSets(dataset.id):
+                self.verifyParsedOutputsEqual(
+                    [readGroupSet], "readgroupsets-get", readGroupSet.id)
+
+    def testGetReference(self):
+        for referenceSet in self._client.searchReferenceSets():
+            for reference in self._client.searchReferences(referenceSet.id):
+                self.verifyParsedOutputsEqual(
+                    [reference], "references-get", reference.id)
+
+    def testGetReferenceSet(self):
+        for referenceSet in self._client.searchReferenceSets():
+            self.verifyParsedOutputsEqual(
+                [referenceSet], "referencesets-get", referenceSet.id)
+
+    def testGetVariant(self):
+        test_executed = 0
+        start = 0
+        end = 1000
+        referenceName = "1"
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                variants = self._client.searchVariants(
+                    variantSet.id, start=start, end=end,
+                    referenceName=referenceName)
+                for variant in variants:
+                    test_executed += self.verifyParsedOutputsEqual(
+                        [variant], "variants-get", variant.id)
+        self.assertGreater(test_executed, 0)
+
+    def testSearchDatasets(self):
+        iterator = self._client.searchDatasets()
+        self.verifyParsedOutputsEqual(iterator, "datasets-search")
+
+    def testSearchReadGroupSets(self):
+        for dataset in self._client.searchDatasets():
+            iterator = self._client.searchReadGroupSets(dataset.id)
+            self.verifyParsedOutputsEqual(
+                iterator, "readgroupsets-search",
+                "--datasetId {}".format(dataset.id))
+
+    def testSearchReads(self):
+        test_executed = 0
+        start = 0
+        end = 1000
+        for dataset in self._client.searchDatasets():
+            for readGroupSet in self._client.searchReadGroupSets(dataset.id):
+                for readGroup in readGroupSet.readGroups:
+                    reference = self._client.searchReferences(
+                        referenceSetId=readGroup.referenceSetId).next()
+                    referenceId = reference.id
+                    iterator = self._client.searchReads(
+                        [readGroup.id], referenceId=referenceId,
+                        start=start, end=end)
+                    args = "--start {} --end {} --readGroupIds {}\
+                    --referenceId {}".format(
+                        start, end, readGroup.id, referenceId)
+                    test_executed += self.verifyParsedOutputsEqual(
+                        iterator, "reads-search", args)
+        self.assertGreater(test_executed, 0)
+
+    def testSearchReferenceSets(self):
+        iterator = self._client.searchReferenceSets()
+        self.verifyParsedOutputsEqual(iterator, "referencesets-search")
+
+    def testSearchReferences(self):
+        for referenceSet in self._client.searchReferenceSets():
+            iterator = self._client.searchReferences(
+                referenceSetId=referenceSet.id)
+            args = "--referenceSetId={}".format(referenceSet.id)
+            self.verifyParsedOutputsEqual(iterator, "references-search", args)
+
+    def testSearchVariantSets(self):
+        for dataset in self._client.searchDatasets():
+            iterator = self._client.searchVariantSets(dataset.id)
+            self.verifyParsedOutputsEqual(iterator, "variantsets-search")
+
+    def testSearchVariants(self):
+        test_executed = 0
+        start = 0
+        end = 1000
+        referenceName = "1"
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                iterator = self._client.searchVariants(
+                    variantSet.id, start=start, end=end,
+                    referenceName=referenceName, callSetIds=[])
+                args = "--variantSetId {} --start {} --end {} -r {}".format(
+                    variantSet.id, start, end, referenceName)
+                test_executed += self.verifyParsedOutputsEqual(
+                    iterator, "variants-search", args)
+        self.assertGreater(test_executed, 0)


### PR DESCRIPTION
I've been working on building out these tests for Issue #704  and had a couple questions:

1. There are cli endpoints for get and search callset, but it looks like these methods haven't been implemented on the local file backend. Are there plans to support this? I added a skipped unit tests for each, but these can be removed if it won't be supported

2. There is currently no cli call for variantsets-get. Again added a skipped unit test. 

3. A few of the api calls take long enough that the system time is different between the interal api call and the call via the cli. This causes issues when comparing "updated" timestamps in the response object. The way I've dealt with this in the past is to use something like [freezegun](https://github.com/spulec/freezegun). I added this as a dependency, but if you have a better way to address this let me know.

4. I'm not really sure of the best way to test the get/search variant endpoints. Right now start, end, and referenceName are hard coded. This does pick up some variants, so it does test the output, but it's far from complete and wouldn't be robust if the test data is swapped out. I just didn't see a way to get the extents of the data or reference name since the referenceId attribute is empty on the test variant sets.