### PR TITLE
Change created field of variant annotation to ISO8601

### DIFF
--- a/ga4gh/_protocol_definitions.py
+++ b/ga4gh/_protocol_definitions.py
@@ -134,14 +134,14 @@ class Analysis(ProtocolElement):
         self.recordCreateTime = kwargs.get(
             'recordCreateTime', None)
         """
-        The time at which this record was created.    Format: ISO
-        8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+        The time at which this record was created.    Format: :ref:ISO
+        8601 <metadata_date_time>
         """
         self.recordUpdateTime = kwargs.get(
             'recordUpdateTime', None)
         """
-        The time at which this record was last updated.   Format: ISO
-        8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+        The time at which this record was last updated.   Format:
+        :ref:ISO 8601 <metadata_date_time>
         """
         self.software = kwargs.get(
             'software', [])
@@ -660,21 +660,21 @@ class Experiment(ProtocolElement):
         self.recordCreateTime = kwargs.get(
             'recordCreateTime', None)
         """
-        The time at which this record was created.    Format: ISO
-        8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+        The time at which this record was created.    Format: :ref:ISO
+        8601 <metadata_date_time>
         """
         self.recordUpdateTime = kwargs.get(
             'recordUpdateTime', None)
         """
-        The time at which this record was last updated.   Format: ISO
-        8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+        The time at which this record was last updated.   Format:
+        :ref:ISO 8601 <metadata_date_time>
         """
         self.runTime = kwargs.get(
             'runTime', None)
         """
         The time at which this experiment was performed.   Granularity
-        here is variable (e.g. date only).   Format: ISO 8601, YYYY-
-        MM-DDTHH:MM:SS (e.g. 2015-02-10T00:03:42)
+        here is variable (e.g. date only).   Format: :ref:ISO 8601
+        <metadata_date_time>
         """
         self.selection = kwargs.get(
             'selection', None)
@@ -2959,9 +2959,14 @@ null, "doc": "", "type": ["null", "string"], "name": "referenceId"},
         self.effects = kwargs.get(
             'effects', None)
         """
-        Only return variant annotations including these effects (SO
-        terms). Exact   matching across all fields of the OntologyTerm
-        is required. If null, return   all variant annotations.
+        This filter allows variant, transcript combinations to be
+        extracted by effect   type(s).   Only return variant
+        annotations including any of these effects and only return
+        transcript effects including any of these effects. Exact
+        matching across all   fields of the Sequence Ontology
+        OntologyTerm is required.   (A transcript effect may have
+        multiple SO effects which will all be reported.)   If null,
+        return all variant annotations.
         """
         self.end = kwargs.get(
             'end', None)
@@ -3029,7 +3034,7 @@ class SearchVariantAnnotationsResponse(SearchResponse):
 "string", "name": "id"}, {"doc": "", "type": "string", "name":
 "variantId"}, {"doc": "", "type": "string", "name":
 "variantAnnotationSetId"}, {"default": null, "doc": "", "type":
-["null", "long"], "name": "created"}, {"default": [], "doc": "",
+["null", "string"], "name": "created"}, {"default": [], "doc": "",
 "type": {"items": {"doc": "", "type": "record", "name":
 "TranscriptEffect", "fields": [{"doc": "", "type": "string", "name":
 "id"}, {"doc": "", "type": "string", "name": "featureId"}, {"default":
@@ -3684,7 +3689,7 @@ class VariantAnnotation(ProtocolElement):
 "VariantAnnotation", "fields": [{"doc": "", "type": "string", "name":
 "id"}, {"doc": "", "type": "string", "name": "variantId"}, {"doc": "",
 "type": "string", "name": "variantAnnotationSetId"}, {"default": null,
-"doc": "", "type": ["null", "long"], "name": "created"}, {"default":
+"doc": "", "type": ["null", "string"], "name": "created"}, {"default":
 [], "doc": "", "type": {"items": {"doc": "", "type": "record", "name":
 "TranscriptEffect", "fields": [{"doc": "", "type": "string", "name":
 "id"}, {"doc": "", "type": "string", "name": "featureId"}, {"default":
@@ -3751,8 +3756,8 @@ null, "doc": "", "type": ["null", "string"], "name":
         self.created = kwargs.get(
             'created', None)
         """
-        The date this annotation was created in milliseconds from the
-        epoch.
+        The :ref:ISO 8601 <metadata_date_time> time at which this
+        record was created.
         """
         self.id = kwargs.get(
             'id', None)

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -407,7 +407,8 @@ class SimulatedVariantAnnotationSet(AbstractVariantSet):
         ann.variantId = variant.id
         ann.start = variant.start
         ann.end = variant.end
-        ann.created = int(datetime.datetime.now().strftime("%s"))
+        ann.created = datetime.datetime.now().strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ")
         # make a transcript effect for each alternate base element
         # multiplied by a random integer (0,5)
         ann.transcriptEffects = []
@@ -918,6 +919,11 @@ class HtslibVariantAnnotationSet(HtslibVariantSet):
         annotation = self._createGaVariantAnnotation()
         annotation.start = variant.start
         annotation.end = variant.end
+        for r in self.getMetadata().records:
+            # TODO handle more date formats
+            if r.key == "created":
+                annotation.created = datetime.datetime.strptime(
+                    r.value, "%Y-%m-%d").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         annotation.variantId = variant.id
         # Convert annotations from INFO field into TranscriptEffect
         annStr = record.info.get('ANN')
@@ -969,6 +975,7 @@ class HtslibVariantAnnotationSet(HtslibVariantSet):
                 analysis.info[r.key] = []
             analysis.info[r.key].append(r.value)
             if r.key == "created":
+                # TODO handle more date formats
                 analysis.recordCreateTime = datetime.datetime.strptime(
                     r.value, "%Y-%m-%d").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             if r.key == "software":

--- a/tests/unit/test_simulator.py
+++ b/tests/unit/test_simulator.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unittest
+import datetime
 
 import ga4gh.datamodel as datamodel
 import ga4gh.datamodel.datasets as datasets
@@ -148,6 +149,10 @@ class TestSimulatedVariantAnnotationSet(unittest.TestCase):
             "Variant Set ID should match the annotation's variant set ID")
         for ann in annotations:
             for key in protocol.VariantAnnotation().requiredFields:
+                self.assertEquals(datetime.datetime.strptime(
+                    ann.created, "%Y-%m-%dT%H:%M:%S.%fZ").strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"), ann.created,
+                        "Expect time format to be in ISO8601")
                 self.assertTrue(hasattr(ann, key),
                                 "Failed to find required key: " + key)
 


### PR DESCRIPTION
Variant annotations currently have a `created` field that uses unix timestamp. To come in line with https://github.com/ga4gh/schemas/pull/552 this PR adds a test to ensure the created time follows ISO8601.