### PR TITLE
Issue #893: Adds api on local client for getCallset and searchCallset

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -531,7 +531,7 @@ class Backend(object):
 
     # Get requests.
 
-    def runGetCallset(self, id_):
+    def runGetCallSet(self, id_):
         """
         Returns a callset with the given id
         """

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -516,7 +516,7 @@ class GetCallsetRunner(AbstractGetRunner):
     """
     def __init__(self, args):
         super(GetCallsetRunner, self).__init__(args)
-        self._method = self._client.getCallset
+        self._method = self._client.getCallSet
 
 
 class GetDatasetRunner(AbstractGetRunner):

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -510,12 +510,12 @@ class GetReadGroupRunner(AbstractGetRunner):
         self._method = self._client.getReadGroup
 
 
-class GetCallsetRunner(AbstractGetRunner):
+class GetCallSetRunner(AbstractGetRunner):
     """
     Runner class for the callsets/{id} method
     """
     def __init__(self, args):
-        super(GetCallsetRunner, self).__init__(args)
+        super(GetCallSetRunner, self).__init__(args)
         self._method = self._client.getCallSet
 
 
@@ -759,7 +759,7 @@ def addReadGroupSetsSearchParser(subparsers):
     return parser
 
 
-def addCallsetsSearchParser(subparsers):
+def addCallSetsSearchParser(subparsers):
     parser = subparsers.add_parser(
         "callsets-search",
         description="Search for callSets",
@@ -854,12 +854,12 @@ def addReadGroupsGetParser(subparsers):
     addGetArguments(parser)
 
 
-def addCallsetsGetParser(subparsers):
+def addCallSetsGetParser(subparsers):
     parser = subparsers.add_parser(
         "callsets-get",
-        description="Get a callset",
-        help="Get a callset")
-    parser.set_defaults(runner=GetCallsetRunner)
+        description="Get a callSet",
+        help="Get a callSet")
+    parser.set_defaults(runner=GetCallSetRunner)
     addGetArguments(parser)
 
 
@@ -902,14 +902,14 @@ def getClientParser():
     addReferenceSetsSearchParser(subparsers)
     addReferencesSearchParser(subparsers)
     addReadGroupSetsSearchParser(subparsers)
-    addCallsetsSearchParser(subparsers)
+    addCallSetsSearchParser(subparsers)
     addReadsSearchParser(subparsers)
     addDatasetsSearchParser(subparsers)
     addReferenceSetsGetParser(subparsers)
     addReferencesGetParser(subparsers)
     addReadGroupSetsGetParser(subparsers)
     addReadGroupsGetParser(subparsers)
-    addCallsetsGetParser(subparsers)
+    addCallSetsGetParser(subparsers)
     addVariantsGetParser(subparsers)
     addDatasetsGetParser(subparsers)
     addReferencesBasesListParser(subparsers)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -478,6 +478,7 @@ class LocalClient(AbstractClient):
         super(LocalClient, self).__init__()
         self._backend = backend
         self._getMethodMap = {
+            "callsets": self._backend.runGetCallset,
             "datasets": self._backend.runGetDataset,
             "referencesets": self._backend.runGetReferenceSet,
             "references": self._backend.runGetReference,
@@ -487,6 +488,7 @@ class LocalClient(AbstractClient):
             "readgroups": self._backend.runGetReadGroup,
         }
         self._searchMethodMap = {
+            "callsets": self._backend.runSearchCallSets,
             "datasets": self._backend.runSearchDatasets,
             "referencesets": self._backend.runSearchReferenceSets,
             "references": self._backend.runSearchReferences,

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -478,7 +478,7 @@ class LocalClient(AbstractClient):
         super(LocalClient, self).__init__()
         self._backend = backend
         self._getMethodMap = {
-            "callsets": self._backend.runGetCallset,
+            "callsets": self._backend.runGetCallSet,
             "datasets": self._backend.runGetDataset,
             "referencesets": self._backend.runGetReferenceSet,
             "references": self._backend.runGetReference,

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -540,9 +540,9 @@ def getReadGroup(id):
 @DisplayedRoute(
     '/callsets/<no(search):id>',
     pathDisplay='/callsets/<id>')
-def getCallset(id):
+def getCallSet(id):
     return handleFlaskGetRequest(
-        id, flask.request, app.backend.runGetCallset)
+        id, flask.request, app.backend.runGetCallSet)
 
 
 @app.route('/oauth2callback', methods=['GET'])

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -98,6 +98,13 @@ class TestClientJson(TestClientOutput):
         self.assertEqual(clientOutput, cliOutput)
         return len(clientOutput)
 
+    def testGetCallSet(self):
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                for callSet in self._client.searchCallSets(variantSet.id):
+                    self.verifyParsedOutputsEqual(
+                        [callSet], "callsets-get", callSet.id)
+
     def testGetDataset(self):
         for dataset in self._client.searchDatasets():
             self.verifyParsedOutputsEqual(
@@ -147,6 +154,14 @@ class TestClientJson(TestClientOutput):
             for variantSet in self._client.searchVariantSets(dataset.id):
                 self.verifyParsedOutputsEqual(
                     [variantSet], "variantsets-get", variantSet.id)
+
+    def testSearchCallsets(self):
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                iterator = self._client.searchCallSets(variantSet.id)
+                args = "--variantSetId {}".format(variantSet.id)
+                self.verifyParsedOutputsEqual(
+                    iterator, "callsets-search", args)
 
     def testSearchDatasets(self):
         iterator = self._client.searchDatasets()

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -155,7 +155,7 @@ class TestClientJson(TestClientOutput):
                 self.verifyParsedOutputsEqual(
                     [variantSet], "variantsets-get", variantSet.id)
 
-    def testSearchCallsets(self):
+    def testSearchCallSets(self):
         for dataset in self._client.searchDatasets():
             for variantSet in self._client.searchVariantSets(dataset.id):
                 iterator = self._client.searchCallSets(variantSet.id)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -210,7 +210,7 @@ class TestClientArguments(unittest.TestCase):
 
     def testCallSetGetArguments(self):
         self.verifyGetArguments(
-            "callsets-get", cli.GetCallsetRunner)
+            "callsets-get", cli.GetCallSetRunner)
 
     def testDatasetsGetArguments(self):
         self.verifyGetArguments(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -161,7 +161,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient._runGetRequest.assert_called_once_with(
             "readgroups", protocol.ReadGroup, self.objectId)
 
-    def testGetCallsets(self):
+    def testGetCallSets(self):
         self.httpClient.getCallSet(self.objectId)
         self.httpClient._runGetRequest.assert_called_once_with(
             "callsets", protocol.CallSet, self.objectId)

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -160,7 +160,7 @@ class TestFrontend(unittest.TestCase):
         response = self.sendGetRequest(path)
         return response
 
-    def sendGetCallset(self, id_=None):
+    def sendGetCallSet(self, id_=None):
         if id_ is None:
             id_ = self.callSetId
         path = "/callsets/{}".format(id_)
@@ -261,7 +261,7 @@ class TestFrontend(unittest.TestCase):
         self.verifySearchRouting('/referencesets/search', True)
         self.verifySearchRouting('/references/search', True)
 
-    def testRouteCallsets(self):
+    def testRouteCallSets(self):
         path = '/callsets/search'
         self.assertEqual(415, self.app.post(path).status_code)
         self.assertEqual(200, self.app.options(path).status_code)
@@ -340,8 +340,8 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(
             responseData.id, self.readGroupId)
 
-    def testGetCallset(self):
-        response = self.sendGetCallset()
+    def testGetCallSet(self):
+        response = self.sendGetCallSet()
         self.assertEqual(200, response.status_code)
         responseData = protocol.CallSet.fromJsonString(
             response.data)


### PR DESCRIPTION
In addition to adding these methods, I went through and standardardize the way callSet was referenced -- in some places it was callset and in others it was callSet. It seems like the apis are usually capitalizing Set, so I went with that convention. 