### PR TITLE
Ensure treatment of request.end is the same regardless of how the iterator is initialised

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -102,7 +102,9 @@ class IntervalIterator(object):
         """
         self._searchAnchor = searchAnchor
         self._distanceFromAnchor = objectsToSkip
-        self._searchIterator = self._search(searchAnchor, self._request.end)
+        self._searchIterator = self._search(
+            searchAnchor,
+            self._request.end if self._request.end != 0 else None)
         obj = next(self._searchIterator)
         if searchAnchor == self._request.start:
             # This is the initial set of intervals, we just skip forward


### PR DESCRIPTION
Without this, the compliance test causes 400 errors as ultimately ga4gh.datamodel.assertValidRange explodes whenever a pageToken is used because the pageToken sets the start, but the end is left at 0. With this change, the end is forced to None, which avoids the problem.