### PR TITLE
As discussed in schemas#488, simplify semantics for variants search t…

### DIFF
--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -468,18 +468,15 @@ class HtslibVariantSet(datamodel.PysamDatamodelMixin, AbstractVariantSet):
         raise exceptions.ObjectWithIdNotFoundException(compoundId)
 
     def getVariants(self, referenceName, startPosition, endPosition,
-                    callSetIds=None):
+                    callSetIds=[]):
         """
         Returns an iterator over the specified variants. The parameters
         correspond to the attributes of a GASearchVariantsRequest object.
         """
-        if callSetIds is None:
-            callSetIds = self._callSetIds
-        else:
-            for callSetId in callSetIds:
-                if callSetId not in self._callSetIds:
-                    raise exceptions.CallSetNotInVariantSetException(
-                        callSetId, self.getId())
+        for callSetId in callSetIds:
+            if callSetId not in self._callSetIds:
+                raise exceptions.CallSetNotInVariantSetException(
+                    callSetId, self.getId())
         if referenceName in self._chromFileMap:
             varFileName = self._chromFileMap[referenceName]
             referenceName, startPosition, endPosition = \

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -358,25 +358,18 @@ class VariantSetTest(datadriven.DataDrivenTest):
             returnedCallSet = variantSet.getCallSet(call_set_id)
             self.assertEqual(call_set_id, returnedCallSet.getId())
         for reference_name in self._reference_names:
-            # passing None as the call_set_ids argument should be equivalent
-            # to passing all of the possible call_set_ids as an argument
-            noneRecords = list(variantSet.getVariants(
-                reference_name, start, end, None))
-            allRecords = list(variantSet.getVariants(
-                reference_name, start, end, call_set_ids))
-            self.assertEqual(len(noneRecords), len(allRecords))
-            for noneRecord, allRecord in zip(noneRecords, allRecords):
-                for noneCall, allCall in zip(
-                        noneRecord.calls, allRecord.calls):
-                    self.assertEqual(
-                        noneCall.call_set_name, allCall.call_set_name)
-
             # passing an empty list as the call_set_ids argument should
             # return no callsets for any variant
-            emptyRecords = variantSet.getVariants(
-                reference_name, start, end, [])
+            emptyRecords = list(variantSet.getVariants(
+                reference_name, start, end, []))
             for record in emptyRecords:
                 self.assertEqual(len(record.calls), 0)
+
+            allRecords = list(variantSet.getVariants(
+                reference_name, start, end, call_set_ids))
+            self.assertEqual(len(emptyRecords), len(allRecords))
+            for allRecord in allRecords:
+                self.assertGreater(len(allRecord.calls), 0)
 
             # passing some call_set_ids as the call_set_ids argument should
             # return only those calls


### PR DESCRIPTION
…o avoid a blessed "null" case implying everything.

This commit makes the server match these semantics, and updates the corresponding test.
