### PR TITLE
Ignore hidden files for datadriven tests

### DIFF
--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -42,7 +42,8 @@ def makeTests(testDataDir, testClass, fnmatchGlob="*"):
     """
     for localId in os.listdir(testDataDir):
         if (fnmatch.fnmatch(localId, fnmatchGlob) and
-                not fnmatch.fnmatch(localId, '*.json')):
+                not fnmatch.fnmatch(localId, '*.json') and
+                not localId.startswith(".")):  # hidden files start with `.`
             path = os.path.join(testDataDir, localId)
             tester = testClass(localId, path)
             for name, _ in inspect.getmembers(testClass):


### PR DESCRIPTION
Hidden files have a leading `.` and are picked up by the datadriven test framework. This should handle many cases of picking up unwanted files. fix #913 