### PR TITLE
WIP InconsistentMetaDataException repomanager bug

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -1327,9 +1327,10 @@ class CheckRunner(AbstractRepoCommandRunner):
 
     def __init__(self, args):
         super(CheckRunner, self).__init__(args)
+        self.doConsistencyCheck = not args.skipConsistencyCheck
 
     def run(self):
-        self.repoManager.check()
+        self.repoManager.check(self.doConsistencyCheck)
 
 
 class ListRunner(AbstractRepoCommandRunner):
@@ -1457,6 +1458,12 @@ def addRepoArgument(subparser):
         "repoPath", help="the file path of the data repository")
 
 
+def addSkipConsistencyCheckArgument(subparser):
+    subparser.add_argument(
+        "-s", "--skipConsistencyCheck", action='store_true', default=False,
+        help="skip the data repo consistency check")
+
+
 def addForceArgument(subparser):
     subparser.add_argument(
         "-f", "--force", action='store_true',
@@ -1517,6 +1524,7 @@ def getRepoParser():
         subparsers, "check", "Check to see if repo is well-formed")
     checkParser.set_defaults(runner=CheckRunner)
     addRepoArgument(checkParser)
+    addSkipConsistencyCheckArgument(checkParser)
 
     listParser = addSubparser(
         subparsers, "list", "List the contents of the repo")

--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -468,13 +468,23 @@ class PysamDatamodelMixin(object):
         EmptyDirException if no data files are found.
         """
         numDataFiles = 0
+        filenames = self._getDataFilenames(dataDir, patterns)
+        for filename in filenames:
+            self._addDataFile(filename)
+            numDataFiles += 1
+        if numDataFiles == 0:
+            raise exceptions.EmptyDirException(dataDir, patterns)
+
+    def _getDataFilenames(self, dataDir, patterns):
+        """
+        Return a list of filenames in dataDir that match one of patterns
+        """
+        filenames = []
         for pattern in patterns:
             scanPath = os.path.join(dataDir, pattern)
             for filename in glob.glob(scanPath):
-                self._addDataFile(filename)
-                numDataFiles += 1
-        if numDataFiles == 0:
-            raise exceptions.EmptyDirException(dataDir, patterns)
+                filenames.append(filename)
+        return filenames
 
     def getFileHandle(self, dataFile):
         return fileHandleCache.getFileHandle(dataFile, self.openFile)

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -535,21 +535,52 @@ class HtslibVariantSet(datamodel.PysamDatamodelMixin, AbstractVariantSet):
         self._setAccessTimes(dataDir)
         self._chromFileMap = {}
         self._metadata = None
-        self._scanDataFiles(dataDir, ['*.bcf', '*.vcf.gz'])
+        self._patterns = ['*.bcf', '*.vcf.gz']
+        self._scanDataFiles(self._dataDir, self._patterns)
 
     def _updateMetadata(self, variantFile):
         """
         Updates the metadata for his variant set based on the specified
-        variant file, and ensures that it is consistent with already
-        existing metadata.
+        variant file
         """
         metadata = self._getMetadataFromVcf(variantFile)
         if self._metadata is None:
             self._metadata = metadata
-        else:
-            if self._metadata != metadata:
-                raise exceptions.InconsistentMetaDataException(
+
+    def _checkMetadata(self, variantFile):
+        """
+        Checks that metadata is consistent
+        """
+        metadata = self._getMetadataFromVcf(variantFile)
+        if self._metadata is not None and self._metadata != metadata:
+            raise exceptions.InconsistentMetaDataException(
+                variantFile.filename)
+
+    def _checkCallSetIds(self, variantFile):
+        """
+        Checks callSetIds for consistency
+        """
+        if len(self._callSetIdMap) > 0:
+            callSetIds = set([
+                self.getCallSetId(sample)
+                for sample in variantFile.header.samples])
+            if callSetIds != set(self._callSetIdMap.keys()):
+                raise exceptions.InconsistentCallSetIdException(
                     variantFile.filename)
+
+    def checkConsistency(self):
+        """
+        Perform consistency check on the variant set
+        """
+        filenames = self._getDataFilenames(self._dataDir, self._patterns)
+        for filename in filenames:
+            varFile = self.openFile(filename)
+            for chrom in varFile.index:
+                chrom, _, _ = self.sanitizeVariantFileFetch(chrom)
+                if not isEmptyIter(varFile.fetch(chrom)):
+                    self._checkMetadata(varFile)
+                    self._checkCallSetIds(varFile)
+            varFile.close()
 
     def getNumVariants(self):
         """
@@ -562,18 +593,9 @@ class HtslibVariantSet(datamodel.PysamDatamodelMixin, AbstractVariantSet):
         """
         Updates the call set IDs based on the specified variant file.
         """
-        # If this is the first file, we add in the samples. If not, we check
-        # for consistency.
         if len(self._callSetIdMap) == 0:
             for sample in variantFile.header.samples:
                 self.addCallSet(sample)
-        else:
-            callSetIds = set([
-                self.getCallSetId(sample)
-                for sample in variantFile.header.samples])
-            if callSetIds != set(self._callSetIdMap.keys()):
-                raise exceptions.InconsistentCallSetIdException(
-                    variantFile.filename)
 
     def openFile(self, filename):
         return pysam.VariantFile(filename)

--- a/ga4gh/datarepo.py
+++ b/ga4gh/datarepo.py
@@ -181,7 +181,7 @@ class FileSystemDataRepository(AbstractDataRepository):
     datasetsDirName = "datasets"
     ontologiesDirName = "ontologies"
 
-    def __init__(self, dataDir, doConsistencyCheck=True):
+    def __init__(self, dataDir):
         super(FileSystemDataRepository, self).__init__()
         self._dataDir = dataDir
         sourceDirNames = [self.referenceSetsDirName,
@@ -199,8 +199,6 @@ class FileSystemDataRepository(AbstractDataRepository):
                 relativePath = os.path.join(sourceDir, setName)
                 if os.path.isdir(relativePath):
                     objectAdder(constructor(setName, relativePath, self))
-        if doConsistencyCheck:
-            self.checkConsistency()
 
     def checkConsistency(self):
         """
@@ -212,3 +210,5 @@ class FileSystemDataRepository(AbstractDataRepository):
         for dataset in self.getDatasets():
             for readGroupSet in dataset.getReadGroupSets():
                 readGroupSet.checkConsistency(self)
+            for variantSet in dataset.getVariantSets():
+                variantSet.checkConsistency()

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -210,7 +210,6 @@ def configure(configFile=None, baseConfig="ProductionConfig",
     elif dataSource.scheme == "file":
         dataRepository = datarepo.FileSystemDataRepository(os.path.join(
             dataSource.netloc, dataSource.path))
-        dataRepository.checkConsistency()
     else:
         raise exceptions.ConfigurationException(
             "Unsupported data source scheme: " + dataSource.scheme)

--- a/ga4gh/repo_manager.py
+++ b/ga4gh/repo_manager.py
@@ -274,11 +274,14 @@ class RepoManager(object):
         self._removePath(self._repoPath)
         self._repoEmit("Destroyed")
 
-    def check(self):
+    def check(self, doConsistencyCheck=False):
         """
         Check the repository for well-formedness
         """
         self._check()
+        if doConsistencyCheck:
+            dataRepo = datarepo.FileSystemDataRepository(self._repoPath)
+            dataRepo.checkConsistency()
         self._repoEmit("Well-formed".format(self._repoPath))
 
     def addDataset(self, datasetName):
@@ -492,8 +495,7 @@ class RepoManager(object):
         self._check()
         self._repoEmit("Listing")
 
-        dataRepo = datarepo.FileSystemDataRepository(
-            self._repoPath, doConsistencyCheck=False)
+        dataRepo = datarepo.FileSystemDataRepository(self._repoPath)
         self._emit(self.referenceSetsDirName)
         for referenceSet in dataRepo.getReferenceSets():
             self._emitIndent(referenceSet.getLocalId())

--- a/tests/end_to_end/test_repo_manager.py
+++ b/tests/end_to_end/test_repo_manager.py
@@ -39,7 +39,7 @@ class RepoManagerEndToEndTest(unittest.TestCase):
         self._runCmd("add-dataset", self.datasetName)
         self._runCmd("add-readgroupset", self.datasetName, paths.bamPath)
         self._runCmd("add-variantset", self.datasetName, paths.vcfDirPath)
-        self._runCmd("check")
+        self._runCmd("check", "--skipConsistencyCheck")
         self._runCmd("list")
         self._runCmd(
             "remove-variantset", self.datasetName, paths.variantSetName,

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -47,8 +47,10 @@ class TestInconsistentMetaData(FaultyVariantDataTest):
     def testInstantiation(self):
         for localId in self.localIds:
             path = self.getFullPath(localId)
+            variantSet = variants.HtslibVariantSet(
+                self.dataset, localId, path, None)
             with self.assertRaises(exceptions.InconsistentMetaDataException):
-                variants.HtslibVariantSet(self.dataset, localId, path, None)
+                variantSet.checkConsistency()
 
 
 class TestInconsistentCallSetId(FaultyVariantDataTest):
@@ -57,8 +59,10 @@ class TestInconsistentCallSetId(FaultyVariantDataTest):
     def testInstantiation(self):
         for localId in self.localIds:
             path = self.getFullPath(localId)
+            variantSet = variants.HtslibVariantSet(
+                self.dataset, localId, path, None)
             with self.assertRaises(exceptions.InconsistentCallSetIdException):
-                variants.HtslibVariantSet(self.dataset, localId, path, None)
+                variantSet.checkConsistency()
 
 
 class TestOverlappingVcfVariants(FaultyVariantDataTest):

--- a/tests/unit/test_repo_manager.py
+++ b/tests/unit/test_repo_manager.py
@@ -50,6 +50,9 @@ class RepoManagerTest(AbstractRepoManagerTest):
             datasetName, paths.bamPath, self.moveMode)
         self.repoManager.addVariantSet(
             datasetName, paths.vcfDirPath, self.moveMode)
+        with self.assertRaises(exceptions.ReferenceSetNameNotFoundException):
+            # ReferenceSet named 'Default' does not exist
+            self.repoManager.check(doConsistencyCheck=True)
         self.repoManager.check()
         self.repoManager.list()
         self.repoManager.removeReadGroupSet(


### PR DESCRIPTION
So the problem here is that when we are initializing the server data model we also check for consistency in that model and throw errors if it is not consistent.  This is inconvenient for the repo manager since a data repo could very well have been put in an inconsistent state by a user, and we don't want to throw errors in that case.  The previous solution was to sever init and check functionality and to put the later into `checkConsistency` functions which were called on server startup, but not on data repo init.  In this case the 2 functionalities are a bit harder to disentangle.  @jeromekelleher do you think this is the right way to approach this?

Issue #946