### PR TITLE
Bug fix for VA search

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -257,10 +257,6 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
             ret = self._matchAnyEffects(effect) or ret
         return ret
 
-    def _checkTermEquality(self, requestedEffect, effect):
-        return self._termPresent(requestedEffect) and (
-            effect.term == requestedEffect['term'])
-
     def _checkIdEquality(self, requestedEffect, effect):
         return self._idPresent(requestedEffect) and (
             effect.id == requestedEffect['id'])
@@ -268,20 +264,10 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
     def _idPresent(self, requestedEffect):
         return "id" in requestedEffect
 
-    def _termPresent(self, requestedEffect):
-        return "term" in requestedEffect
-
     def _matchOntologyTerm(self, requestedEffect, effect):
-        if self._idPresent(requestedEffect):
-            if self._checkIdEquality(requestedEffect, effect):
-                if self._checkTermEquality(requestedEffect, effect):
-                    return True
-                # In case the ID and terms don't match
-                elif not self._termPresent(requestedEffect):
-                    return True
-        elif self._termPresent(requestedEffect):
-            if self._checkTermEquality(requestedEffect, effect):
-                return True
+        if self._idPresent(requestedEffect) and \
+                self._checkIdEquality(requestedEffect, effect):
+            return True
         return False
 
     def _matchAnyEffects(self, effect):

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import requests
 import posixpath
 import logging
-import json
 
 import ga4gh.protocol as protocol
 import ga4gh.exceptions as exceptions
@@ -262,13 +261,10 @@ class AbstractClient(object):
 
     def searchVariantAnnotations(
             self, variantAnnotationSetId, referenceName=None, referenceId=None,
-            start=None, end=None, featureIds=[], effects=[]):
+            start=None, end=None, effects=[]):
         """
         Returns an iterator over the Annotations fulfilling the specified
         conditions from the specified AnnotationSet.
-
-        The JSON string for an effect term must be specified on the
-        command line : `--effects '{"term": "exon_variant"}'`.
         """
         request = protocol.SearchVariantAnnotationsRequest()
         request.variantAnnotationSetId = variantAnnotationSetId
@@ -276,17 +272,7 @@ class AbstractClient(object):
         request.referenceId = referenceId
         request.start = start
         request.end = end
-        # request.feature_ids = featureIds
-        soTerms = []
-        for eff in effects:
-            try:
-                soTerms.append(json.loads(eff))
-            except ValueError:
-                print("The effect argument is malformed.")
-                print("e.g. command line : `--effects "
-                      "'{\"term\": \"exon_variant\"}'`")
-                exit()
-        request.effects = soTerms
+        request.effects = effects
         request.pageSize = self._pageSize
         return self._runSearchRequest(
             request, "variantannotations",
@@ -561,6 +547,7 @@ class LocalClient(AbstractClient):
             "variants": self._backend.runSearchVariants,
             "readgroupsets": self._backend.runSearchReadGroupSets,
             "reads": self._backend.runSearchReads,
+            "variantannotations": self._backend.runSearchVariantAnnotations,
             "variantannotationsets":
                 self._backend.runSearchVariantAnnotationSets
         }

--- a/tests/end_to_end/test_gestalt.py
+++ b/tests/end_to_end/test_gestalt.py
@@ -26,6 +26,8 @@ class TestGestalt(server_test.ServerTest):
         self.simulatedReadGroupId = "c2ltdWxhdGVkRGF0YXNldDA6c2ltUmdzMDpyZzA"
         self.simulatedReferenceSetId = "cmVmZXJlbmNlU2V0MA"
         self.simulatedReferenceId = "cmVmZXJlbmNlU2V0MDpzcnMw"
+        self.simulatedVariantAnnotationSetId = \
+            "c2ltdWxhdGVkRGF0YXNldDA6c2ltVmFzMDp2YXJpYW50YW5ub3RhdGlvbnM"
         self.client = client.ClientForTesting(self.server.getUrl())
         self.runVariantsRequest()
         self.assertLogsWritten()
@@ -79,6 +81,12 @@ class TestGestalt(server_test.ServerTest):
             self.client,
             "variants-search",
             "-s 0 -e 2 -V {}".format(self.simulatedVariantSetId))
+
+    def runVariantAnnotationsRequest(self):
+        self.runClientCmd(
+            self.client,
+            "variantannotations-search",
+            "{}".format(self.simulatedVariantAnnotationSetId))
 
     def runReadsRequest(self):
         args = "--readGroupIds {} --referenceId {}".format(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -28,6 +28,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.objectName = "objectName"
         self.datasetId = "datasetId"
         self.variantSetId = "variantSetId"
+        self.variantAnnotationSetId = "variantAnnotationSetId"
         self.referenceSetId = "referenceSetId"
         self.referenceId = "referenceId"
         self.readGroupIds = ["readGroupId"]
@@ -87,6 +88,26 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient._runSearchRequest.assert_called_once_with(
             request, "variantannotationsets",
             protocol.SearchVariantAnnotationSetsResponse)
+
+    def testSearchVariantAnnotations(self):
+        request = protocol.SearchVariantAnnotationsRequest()
+        request.variantAnnotationSetId = self.variantAnnotationSetId
+        request.pageSize = self.pageSize
+        request.referenceName = self.referenceName
+        request.referenceId = self.referenceId
+        request.effects = []
+        request.start = self.start
+        request.end = self.end
+        self.httpClient.searchVariantAnnotations(
+            self.variantAnnotationSetId,
+            referenceName=self.referenceName,
+            start=self.start,
+            end=self.end,
+            effects=[],
+            referenceId=self.referenceId)
+        self.httpClient._runSearchRequest.assert_called_once_with(
+            request, "variantannotations",
+            protocol.SearchVariantAnnotationsResponse)
 
     def testSearchReferenceSets(self):
         request = protocol.SearchReferenceSetsRequest()

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -597,8 +597,9 @@ class TestSimulatedStack(unittest.TestCase):
         response = self.sendJsonPostRequest(path, request.toJsonString())
         responseData = protocol.SearchVariantAnnotationSetsResponse. \
             fromJsonString(response.data)
-        self.assertIsNotNone(responseData.nextPageToken,
-                             "Expected more than one page of results")
+        self.assertIsNotNone(
+            responseData.nextPageToken,
+            "Expected more than one page of results")
 
         request = protocol.SearchVariantAnnotationsRequest()
         request.variantAnnotationSetId = variantAnnotationSet.getId()
@@ -609,8 +610,9 @@ class TestSimulatedStack(unittest.TestCase):
         response = self.sendJsonPostRequest(path, request.toJsonString())
         responseData = protocol.SearchVariantAnnotationsResponse. \
             fromJsonString(response.data)
-        self.assertEquals(len(responseData.variantAnnotations), 0,
-                          "There should be no results for a nonsense effect")
+        self.assertEquals(
+            len(responseData.variantAnnotations), 0,
+            "There should be no results for a nonsense effect")
 
         request = protocol.SearchVariantAnnotationsRequest()
         request.variantAnnotationSetId = variantAnnotationSet.getId()
@@ -622,9 +624,10 @@ class TestSimulatedStack(unittest.TestCase):
             fromJsonString(response.data)
         self.assertGreater(len(responseData.variantAnnotations), 0)
         for ann in responseData.variantAnnotations:
-            self.assertGreater(len(ann.transcriptEffects), 0,
-                               ("When no effects are requested ensure "
-                                "some transcript effects are still present"))
+            self.assertGreater(
+                len(ann.transcriptEffects), 0,
+                ("When no effects are requested ensure "
+                    "some transcript effects are still present"))
 
         request = protocol.SearchVariantAnnotationsRequest()
         request.variantAnnotationSetId = variantAnnotationSet.getId()
@@ -635,8 +638,10 @@ class TestSimulatedStack(unittest.TestCase):
         response = self.sendJsonPostRequest(path, request.toJsonString())
         responseData = protocol.SearchVariantAnnotationsResponse. \
             fromJsonString(response.data)
-        self.assertGreater(len(responseData.variantAnnotations), 0,
-                           "There should be some results for a known effect")
+        responseLength = len(responseData.variantAnnotations)
+        self.assertGreater(
+            responseLength, 0,
+            "There should be some results for a known effect")
         for ann in responseData.variantAnnotations:
             effectPresent = False
             for effect in ann.transcriptEffects:
@@ -644,8 +649,34 @@ class TestSimulatedStack(unittest.TestCase):
                     if ontologyTerm.id in map(
                             lambda e: e['id'], request.effects):
                         effectPresent = True
-            self.assertEquals(True, effectPresent,
-                              "The ontology term should appear at least once")
+            self.assertEquals(
+                True, effectPresent,
+                "The ontology term should appear at least once")
+
+        request = protocol.SearchVariantAnnotationsRequest()
+        request.variantAnnotationSetId = variantAnnotationSet.getId()
+        request.start = 0
+        request.end = 5
+        request.referenceName = "1"
+        request.effects = [{"id": "B4DID"}, {"id": "SO:0001627"}]
+        response = self.sendJsonPostRequest(path, request.toJsonString())
+        responseData = protocol.SearchVariantAnnotationsResponse. \
+            fromJsonString(response.data)
+        self.assertEqual(
+            len(responseData.variantAnnotations),
+            responseLength,
+            "Order shall not affect results")
+        for ann in responseData.variantAnnotations:
+            effectPresent = False
+            for effect in ann.transcriptEffects:
+                for ontologyTerm in effect.effects:
+                    if ontologyTerm.id in map(
+                            lambda e: e['id'], request.effects):
+                        effectPresent = True
+            self.assertEquals(
+                True,
+                effectPresent,
+                "The ontology term should appear at least once")
 
         request = protocol.SearchVariantAnnotationsRequest()
         request.variantAnnotationSetId = variantAnnotationSet.getId()
@@ -680,6 +711,17 @@ class TestSimulatedStack(unittest.TestCase):
                         effectPresent = True
             self.assertEquals(True, effectPresent,
                               "The ontology term should appear at least once")
+
+        request = protocol.SearchVariantAnnotationsRequest()
+        request.variantAnnotationSetId = variantAnnotationSet.getId()
+        request.start = 0
+        request.end = 10
+        request.referenceName = "1"
+        request.effects = [{"id": "SO:0001627"}, {"id": "SO:0001791"}]
+        response = self.sendJsonPostRequest(path, request.toJsonString())
+        responseData = protocol.SearchVariantAnnotationsResponse. \
+            fromJsonString(response.data)
+        self.assertGreater(len(responseData.variantAnnotations), 0)
 
     def testListReferenceBases(self):
         for referenceSet in self.dataRepo.getReferenceSets():

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -683,19 +683,6 @@ class TestSimulatedStack(unittest.TestCase):
         request.start = 0
         request.end = 5
         request.referenceName = "1"
-        request.effects = [{"id": "SO:0001627", "term": "TermDoesNotMatchID"}]
-        response = self.sendJsonPostRequest(path, request.toJsonString())
-        responseData = protocol.SearchVariantAnnotationsResponse. \
-            fromJsonString(response.data)
-        self.assertEquals(len(responseData.variantAnnotations), 0,
-                          ("There should be no results when "
-                           "term and ID don't match"))
-
-        request = protocol.SearchVariantAnnotationsRequest()
-        request.variantAnnotationSetId = variantAnnotationSet.getId()
-        request.start = 0
-        request.end = 5
-        request.referenceName = "1"
         request.effects = [{"id": "SO:0001627"}]
         response = self.sendJsonPostRequest(path, request.toJsonString())
         responseData = protocol.SearchVariantAnnotationsResponse. \


### PR DESCRIPTION
Ontology term arrays in the request were not being checked correctly. This PR fixes the variant annotation endpoint to return any ontology terms in the request. A test has been added to ensure order does not affect results. Some refactoring for readability. Fixes https://github.com/ga4gh/server/issues/981