### PR TITLE
Remove shared state from test_exceptions

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -17,6 +17,11 @@ class TestExceptionHandler(unittest.TestCase):
     """
     Test that caught exceptions are handled correctly
     """
+    @classmethod
+    def setUpClass(cls):
+        frontend.reset()
+        frontend.configure(baseConfig="TestConfig")
+
     class UnknownException(Exception):
         pass
 


### PR DESCRIPTION
Tests that act on `frontend` must set it to a pristine state before acting. This came up when testing sequence annotations end to end, the exceptions tests were failing because the development config had been activated in another test. This fix simply resets the `frontend`'s state for the test case.

To reproduce create a file `tests/unit/break_exceptions.py`

```
"""
Tests related to exceptions
"""
from __future__ import division
from __future__ import print_function
from __future__ import unicode_literals

import unittest
import inspect

import ga4gh.exceptions as exceptions
import ga4gh.frontend as frontend
import ga4gh.protocol as protocol


class TestBreakExceptions(unittest.TestCase):
    """
    Test that caught exceptions are handled correctly
    """
    @classmethod
    def setUpClass(cls):
        frontend.reset()
        frontend.configure(baseConfig="DevelopmentConfig")

    def testCase(self):
        pass
```

Then `nosetests tests.unit.break_exceptions tests.unit.test_exceptions`.

Will give:

```
======================================================================
ERROR: testCallSetNotInVariantSetException (tests.unit.test_exceptions.TestExceptionHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/david/ga4gh/server-1/tests/unit/test_exceptions.py", line 35, in testCallSetNotInVariantSetException
    response = frontend.handleException(exception)
  File "/Users/david/ga4gh/server-1/ga4gh/frontend.py", line 321, in handleException
    app.log_exception(exception)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/app.py", line 1421, in log_exception
    request.path,
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 343, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 302, in _get_current_object
    return self.__local()
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/globals.py", line 20, in _lookup_req_object
    raise RuntimeError('working outside of request context')
RuntimeError: working outside of request context

======================================================================
ERROR: testNotImplementedException (tests.unit.test_exceptions.TestExceptionHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/david/ga4gh/server-1/tests/unit/test_exceptions.py", line 50, in testNotImplementedException
    response = frontend.handleException(exception)
  File "/Users/david/ga4gh/server-1/ga4gh/frontend.py", line 321, in handleException
    app.log_exception(exception)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/app.py", line 1421, in log_exception
    request.path,
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 343, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 302, in _get_current_object
    return self.__local()
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/globals.py", line 20, in _lookup_req_object
    raise RuntimeError('working outside of request context')
RuntimeError: working outside of request context

======================================================================
ERROR: testObjectNotFoundException (tests.unit.test_exceptions.TestExceptionHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/david/ga4gh/server-1/tests/unit/test_exceptions.py", line 29, in testObjectNotFoundException
    response = frontend.handleException(exception)
  File "/Users/david/ga4gh/server-1/ga4gh/frontend.py", line 321, in handleException
    app.log_exception(exception)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/app.py", line 1421, in log_exception
    request.path,
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 343, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 302, in _get_current_object
    return self.__local()
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/globals.py", line 20, in _lookup_req_object
    raise RuntimeError('working outside of request context')
RuntimeError: working outside of request context

======================================================================
ERROR: testUnknownExceptionBecomesServerError (tests.unit.test_exceptions.TestExceptionHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/david/ga4gh/server-1/tests/unit/test_exceptions.py", line 42, in testUnknownExceptionBecomesServerError
    response = frontend.handleException(exception)
  File "/Users/david/ga4gh/server-1/ga4gh/frontend.py", line 321, in handleException
    app.log_exception(exception)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/app.py", line 1421, in log_exception
    request.path,
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 343, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/werkzeug/local.py", line 302, in _get_current_object
    return self.__local()
  File "/Users/david/ga4gh/server-1/server-1/lib/python2.7/site-packages/flask/globals.py", line 20, in _lookup_req_object
    raise RuntimeError('working outside of request context')
RuntimeError: working outside of request context

----------------------------------------------------------------------
Ran 9 tests in 0.051s

FAILED (errors=4)
```

This PR properly isolates the test.