### PR TITLE
Pins pyjwkest==1.0.1 to resolve dependency issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ requirements = [
     "Flask==0.10.1",
     "avro==1.7.7",
     "humanize==0.5.1",
+    "pyjwkest==1.0.1",
     "pysam==0.8.3",
     "oic==0.7.6",
     "requests==2.7.0",


### PR DESCRIPTION
Issue #1003.

This may need to be applied to master also, or it might be better to update OIC if it has fixed this issue upstream.

I suggest we follow this up with a quick release of 0.2.1 with just this change to fix this breaking bug.