### PR TITLE
Compliance downloader: properly check for tempdir

### DIFF
--- a/scripts/prepare_compliance_data.py
+++ b/scripts/prepare_compliance_data.py
@@ -20,6 +20,7 @@ import zipfile
 
 class ComplianceDataMunger(object):
     def __init__(self, args):
+        self.tempdir = None
         self.inputDirectory = args.inputDirectory
         self.outputDirectory = args.outputDirectory
         # If no input directory is specified download from GitHub
@@ -158,7 +159,7 @@ class ComplianceDataMunger(object):
                     os.path.join(sequenceOntologyDir, "sequence_ontology.txt"))
 
     def cleanup(self):
-        if self.tempdir:
+        if self.tempdir is not None:
             shutil.rmtree(self.tempdir)
         utils.log("Done converting compliance data.")
 


### PR DESCRIPTION
Even though it would run successfully, when importing existing data an error would be thrown trying to find the tempdir.

From github:
`python scripts/prepare_compliance_data.py -o ga4gh-example-data`

From compliance test data:
`python scripts/prepare_compliance_data.py -i ~/compliance/test-data -o ga4gh-example-data`