### PR TITLE
Add test_client_json, remove datasetId reference

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -523,9 +523,9 @@ class SearchVariantAnnotationsRunner(
         """
         Returns all variant annotation sets on the server.
         """
-        for dataset in self.getAllDatasets():
+        for variantSet in self.getAllVariantSets():
             iterator = self._client.searchVariantAnnotationSets(
-                datasetId=dataset.id)
+                variantSetId=variantSet.id)
             for variantAnnotationSet in iterator:
                 yield variantAnnotationSet
 
@@ -728,7 +728,6 @@ def addAnnotationsSearchOptions(parser):
     addReferenceIdArgument(parser)
     addStartArgument(parser)
     addEndArgument(parser)
-    addFeatureIdsArgument(parser)
     addEffectsArgument(parser)
     addPageSizeArgument(parser)
 
@@ -747,7 +746,7 @@ def addVariantSetIdMandatoryArgument(parser):
 def addAnnotationSetIdArgument(parser):
     parser.add_argument(
         "--variantAnnotationSetId", "-V", default=None,
-        help="The annotation set id to search over")
+        help="The variant annotation set id to search over")
 
 
 def addReferenceNameArgument(parser):
@@ -906,8 +905,8 @@ def addVariantSetsSearchParser(subparsers):
 def addVariantAnnotationSearchParser(subparsers):
     parser = subparsers.add_parser(
         "variantannotations-search",
-        description="Search for variant annotaions",
-        help="Search for variantAnnotaions.")
+        description="Search for variant annotations",
+        help="Search for variant annotations.")
     parser.set_defaults(runner=SearchVariantAnnotationsRunner)
     addUrlArgument(parser)
     addOutputFormatArgument(parser)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -273,6 +273,10 @@ class AbstractClient(object):
         request.start = start
         request.end = end
         request.effects = effects
+        for effect in request.effects:
+            if 'id' not in effect:
+                raise exceptions.BadRequestException(
+                    "Each ontology term should have an id set")
         request.pageSize = self._pageSize
         return self._runSearchRequest(
             request, "variantannotations",

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -225,3 +225,34 @@ class TestClientJson(TestClientOutput):
                 test_executed += self.verifyParsedOutputsEqual(
                     iterator, "variants-search", args)
         self.assertGreater(test_executed, 0)
+
+    def testSearchVariantAnnotationSets(self):
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                iterator = self._client.searchVariantAnnotationSets(
+                    variantSet.id)
+                args = "{}".format(variantSet.id)
+                self.verifyParsedOutputsEqual(
+                    iterator, "variantannotationsets-search", args)
+
+    def testSearchVariantAnnotations(self):
+        test_executed = 0
+        start = 0
+        end = 10000000
+        referenceName = "1"
+        for dataset in self._client.searchDatasets():
+            for variantSet in self._client.searchVariantSets(dataset.id):
+                searchIterator = self._client.searchVariantAnnotationSets(
+                    variantSet.id)
+                for variantAnnotationSet in searchIterator:
+                    iterator = self._client.searchVariantAnnotations(
+                        variantAnnotationSet.id,
+                        start=start,
+                        end=end,
+                        referenceName=referenceName)
+                    args = ("--variantAnnotationSetId {}"
+                            " --start {} --end {} -r {}").format(
+                        variantAnnotationSet.id, start, end, referenceName)
+                    test_executed += self.verifyParsedOutputsEqual(
+                        iterator, "variantannotations-search", args)
+        self.assertGreater(test_executed, 0)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -237,7 +237,7 @@ class TestClientArguments(unittest.TestCase):
             "variantannotations-search "
             "--variantAnnotationSetId VARIANTANNOTATIONSETID "
             "--referenceName REFERENCENAME --start 1 "
-            "--end 2 --featureIds FEATUREIDS --effects EFFECTS "
+            "--end 2 --effects EFFECTS "
             "--pageSize 3 BASEURL")
         args = self.parser.parse_args(cliInput.split())
         self.assertEqual(
@@ -245,7 +245,6 @@ class TestClientArguments(unittest.TestCase):
         self.assertEqual(args.referenceName, "REFERENCENAME")
         self.assertEqual(args.start, 1)
         self.assertEqual(args.end, 2)
-        self.assertEqual(args.featureIds, "FEATUREIDS")
         self.assertEqual(args.effects, "EFFECTS")
         self.assertEqual(args.pageSize, 3)
         self.assertEqual(args.baseUrl, "BASEURL")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,6 +14,7 @@ import ga4gh.backend as backend
 import ga4gh.client as client
 import ga4gh.datarepo as datarepo
 import tests.utils as utils
+import ga4gh.exceptions as exceptions
 
 
 class TestSearchMethodsCallRunRequest(unittest.TestCase):
@@ -108,6 +109,14 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.httpClient._runSearchRequest.assert_called_once_with(
             request, "variantannotations",
             protocol.SearchVariantAnnotationsResponse)
+        with self.assertRaises(exceptions.BadRequestException):
+            self.httpClient.searchVariantAnnotations(
+                self.variantAnnotationSetId,
+                referenceName=self.referenceName,
+                start=self.start,
+                end=self.end,
+                effects=[{"term": "just a term"}, {"id": "an id"}],
+                referenceId=self.referenceId)
 
     def testSearchReferenceSets(self):
         request = protocol.SearchReferenceSetsRequest()


### PR DESCRIPTION
Client: remove reference to feature ID

Client: Searching by term field alone in the client is handled before sending a request. Closes #1024 

Client: Handle the case when no variant annotation set ID is provided to cli. Closes #1025 

Add tests for variant annotation in test_client_json. Closes #1015