### PR TITLE
Refactor CompoundIds to eliminate separators

### DIFF
--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import base64
 import collections
 import glob
@@ -99,15 +100,14 @@ fileHandleCache = PysamFileHandleCache()
 
 class CompoundId(object):
     """
-    Base class for an id composed of several different parts, separated
-    by a separator. Each compound ID consists of a set of fields, each
-    of which corresponds to a local ID in the data hierarchy. For example,
-    we might have fields like ["dataset", "variantSet"] for a variantSet.
-    These are available as cid.dataset, and cid.variantSet.  The actual IDs
-    of the containing objects can be obtained using the corresponding
-    like cid.datasetId and cid.variantSetId.
+    Base class for an id composed of several different parts.  Each
+    compound ID consists of a set of fields, each of which corresponds to a
+    local ID in the data hierarchy. For example, we might have fields like
+    ["dataset", "variantSet"] for a variantSet.  These are available as
+    cid.dataset, and cid.variantSet.  The actual IDs of the containing
+    objects can be obtained using the corresponding attributes, e.g.
+    cid.datasetId and cid.variantSetId.
     """
-    separator = ':'
     fields = []
     """
     The fields that the compound ID is composed of. These are parsed and
@@ -154,20 +154,56 @@ class CompoundId(object):
             localIds = localIds[:differentiatorIndex] + tuple([
                 self.differentiator]) + localIds[differentiatorIndex:]
         for field, localId in zip(self.fields[index:], localIds):
-            setattr(self, field, str(localId))
+            encodedLocalId = self.encode(str(localId))
+            setattr(self, field, encodedLocalId)
         if len(localIds) != len(self.fields) - index:
             raise ValueError(
                 "Incorrect number of fields provided to instantiate ID")
         for idFieldName, prefix in self.containerIds:
             values = [getattr(self, f) for f in self.fields[:prefix + 1]]
-            containerId = self.separator.join(values)
+            containerId = self.join(values)
             obfuscated = self.obfuscate(containerId)
             setattr(self, idFieldName, obfuscated)
 
     def __str__(self):
         values = [getattr(self, f) for f in self.fields]
-        compoundIdStr = self.separator.join(values)
+        compoundIdStr = self.join(values)
         return self.obfuscate(compoundIdStr)
+
+    @classmethod
+    def join(cls, splits):
+        """
+        Join an array of ids into a compound id string
+        """
+        segments = []
+        for split in splits:
+            segments.append('"{}",'.format(split))
+        if len(segments) > 0:
+            segments[-1] = segments[-1][:-1]
+        jsonString = '[{}]'.format(''.join(segments))
+        return jsonString
+
+    @classmethod
+    def split(cls, jsonString):
+        """
+        Split a compound id string into an array of ids
+        """
+        splits = json.loads(jsonString)
+        return splits
+
+    @classmethod
+    def encode(cls, idString):
+        """
+        Encode a string by escaping problematic characters
+        """
+        return idString.replace('"', '\\"')
+
+    @classmethod
+    def decode(cls, encodedString):
+        """
+        Decode an encoded string
+        """
+        return encodedString.replace('\\"', '"')
 
     @classmethod
     def parse(cls, compoundIdStr):
@@ -190,8 +226,9 @@ class CompoundId(object):
             # this as an ID not found error.
             raise exceptions.ObjectWithIdNotFoundException(compoundIdStr)
         try:
-            splits = deobfuscated.split(cls.separator)
-        except UnicodeDecodeError:
+            encodedSplits = cls.split(deobfuscated)
+            splits = [cls.decode(split) for split in encodedSplits]
+        except (UnicodeDecodeError, ValueError):
             # Sometimes base64 decoding succeeds but we're left with
             # unicode gibberish. This is also and IdNotFound.
             raise exceptions.ObjectWithIdNotFoundException(compoundIdStr)

--- a/tests/datadriven/test_sequenceAnnotations.py
+++ b/tests/datadriven/test_sequenceAnnotations.py
@@ -84,8 +84,10 @@ _testDataForFeatureSetName = {
 
 
 def _getFeatureCompoundId(dataSetName, featureSetName, featureId):
-    return datamodel.CompoundId.obfuscate(":".join(
-        [dataSetName, featureSetName, str(featureId)]))
+    splits = [dataSetName, featureSetName, str(featureId)]
+    joined = datamodel.CompoundId.join(splits)
+    obfuscated = datamodel.CompoundId.obfuscate(joined)
+    return obfuscated
 
 
 def testFeatureSets():

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -328,7 +328,8 @@ class VariantSetTest(datadriven.DataDrivenTest):
             keyMap[metadata.key] = metadata
             # Check that ID is present and has the right 'structure'
             deobfuscatedId = datamodel.CompoundId.deobfuscate(metadata.id)
-            self.assertTrue(deobfuscatedId.endswith(metadata.key))
+            splits = datamodel.CompoundId.split(deobfuscatedId)
+            self.assertTrue(splits[-1].endswith(metadata.key))
 
         metadata = keyMap["version"]
         self.assertEqual(metadata.value, self._vcfVersion)

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -46,10 +46,10 @@ featuresPath2 = os.path.join(
     testDataDir, 'datasets/dataset1/sequenceAnnotations/specialCasesTest.db')
 
 # simulated object ids
-simulatedDatasetId = "simulatedDataset0"
-simulatedVariantSetId = "simulatedDataset0:vs:simVs0"
-simulatedReadGroupId = "simulatedDataset0:rgs:simRgs0:rg0"
-simulatedReferenceSetId = "referenceSet0"
-simulatedReferenceId = "referenceSet0:srs0"
+simulatedDatasetId = '["simulatedDataset0"]'
+simulatedVariantSetId = '["simulatedDataset0","vs","simVs0"]'
+simulatedReadGroupId = '["simulatedDataset0","rgs","simRgs0","rg0"]'
+simulatedReferenceSetId = '["referenceSet0"]'
+simulatedReferenceId = '["referenceSet0","srs0"]'
 simulatedVariantAnnotationSetId = (
-    "simulatedDataset0:simVas0:variantannotations")
+    '["simulatedDataset0","vs","simVas0","variantannotations"]')

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import unittest
 
 import ga4gh.datamodel as datamodel
@@ -16,7 +17,6 @@ import ga4gh.datamodel.reads as reads
 
 
 class ExampleCompoundId(datamodel.CompoundId):
-    separator = ';'
     fields = ['foo', 'bar', 'baz']
     containerIds = [('foobar', 1), ('foobarbaz', 2)]
 
@@ -32,6 +32,41 @@ class TestCompoundIds(unittest.TestCase):
         readGroupSet = reads.AbstractReadGroupSet(dataset, idStr)
         variantSet = variants.AbstractVariantSet(dataset, idStr)
         self.assertNotEqual(readGroupSet.getId(), variantSet.getId())
+
+    def testSplit(self):
+        idStrs = ['["a","b","c"]', '["a", "b", "c"]']
+        for idStr in idStrs:
+            splits1 = datamodel.CompoundId.split(idStr)
+            splits2 = json.loads(idStr)
+            self.assertEqual(splits1, splits2)
+
+    def testJoin(self):
+        splits = ["a", "b", "c"]
+        idStr = datamodel.CompoundId.join(splits)
+        self.assertEqual(idStr, '["a","b","c"]')
+        splits = []
+        idStr = datamodel.CompoundId.join(splits)
+        self.assertEqual(idStr, '[]')
+
+    def testEncodeDecode(self):
+        idStrs = ['ab', '"a"b""']
+        expectedStrs = ['ab', '\\"a\\"b\\"\\"']
+        for idStr, expectedStr in zip(idStrs, expectedStrs):
+            encoded = datamodel.CompoundId.encode(idStr)
+            self.assertEqual(encoded, expectedStr)
+            decoded = datamodel.CompoundId.decode(encoded)
+            self.assertEqual(idStr, decoded)
+
+    def testEncodeRoundTrip(self):
+        splits = ['"a"', 'b', '"c']
+        compoundId = ExampleCompoundId(None, *splits)
+        self.assertEqual(compoundId.foo, '\\"a\\"')
+        self.assertEqual(compoundId.bar, 'b')
+        self.assertEqual(compoundId.baz, '\\"c')
+        obfuscated = str(compoundId)
+        parsedCompoundId = ExampleCompoundId.parse(obfuscated)
+        self.assertEqual(parsedCompoundId.foobar, compoundId.foobar)
+        self.assertEqual(parsedCompoundId.foobarbaz, compoundId.foobarbaz)
 
     def testURLUnsafe(self):
         hasSlashes = "???"  # base64 encodes to 'Pz8/'
@@ -88,19 +123,22 @@ class TestCompoundIds(unittest.TestCase):
             obfuscated)
 
     def testAttrs(self):
-        obfuscated = datamodel.CompoundId.obfuscate('a;b;c')
+        idStr = '["a","b","c"]'
+        idStr2 = '["a","b"]'
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
         compoundId = ExampleCompoundId.parse(obfuscated)
         self.assertEqual(compoundId.foo, 'a')
         self.assertEqual(compoundId.bar, 'b')
         self.assertEqual(compoundId.baz, 'c')
-        obfuscated = datamodel.CompoundId.obfuscate("a;b")
+        obfuscated = datamodel.CompoundId.obfuscate(idStr2)
         self.assertEqual(compoundId.foobar, obfuscated)
-        obfuscated = datamodel.CompoundId.obfuscate("a;b;c")
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
         self.assertEqual(compoundId.foobarbaz, obfuscated)
 
     def testInstantiate(self):
+        idStr = '["a","5","c"]'
         compoundId = ExampleCompoundId(None, "a", "5", "c")
-        obfuscated = datamodel.CompoundId.obfuscate("a;5;c")
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
         compoundIdStr = str(compoundId)
         self.assertEqual(compoundIdStr, obfuscated)
         self.assertEqual(compoundId.__class__, ExampleCompoundId)
@@ -128,7 +166,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.dataset, localId)
 
     def testDatasetParse(self):
-        idStr = "a"
+        idStr = '["a"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.DatasetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -145,7 +183,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.datasetId, dataset.getId())
 
     def testVariantSetParse(self):
-        idStr = "a:vs:b"
+        idStr = '["a","vs","b"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.VariantSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -167,7 +205,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.variantSetId, variantSet.getId())
 
     def testCallSetParse(self):
-        idStr = "a:vs:b:c"
+        idStr = '["a","vs","b","c"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.CallSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -198,7 +236,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.variantSetId, variantSet.getId())
 
     def testVariantParse(self):
-        idStr = "a:vs:b:c:d:e"
+        idStr = '["a","vs","b","c","d","e"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.VariantCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -216,7 +254,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.referenceSet, localId)
 
     def testReferenceSetParse(self):
-        idStr = "a"
+        idStr = '["a"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ReferenceSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.referenceSet, "a")
@@ -235,7 +273,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.referenceSetId, referenceSet.getId())
 
     def testReferenceParse(self):
-        idStr = "a:b"
+        idStr = '["a","b"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ReferenceCompoundId.parse(obfuscated)
         self.assertEqual(cid.referenceSet, "a")
@@ -254,7 +292,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.readGroupSet, localId)
 
     def testReadGroupSetParse(self):
-        idStr = "a:rgs:b"
+        idStr = '["a","rgs","b"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ReadGroupSetCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -277,7 +315,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.readGroupSetId, readGroupSet.getId())
 
     def testReadGroupParse(self):
-        idStr = "a:rgs:b:c"
+        idStr = '["a","rgs","b","c"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ReadGroupCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -302,7 +340,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.readGroupSetId, readGroupSet.getId())
 
     def testReadAlignmentParse(self):
-        idStr = "a:rgs:b:c"
+        idStr = '["a","rgs","b","c"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ReadAlignmentCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -326,7 +364,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.experiment, localId)
 
     def testExperimentParse(self):
-        idStr = "a:rgs:b:c:d"
+        idStr = '["a","rgs","b","c","d"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.ExperimentCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")
@@ -349,7 +387,7 @@ class TestCompoundIds(unittest.TestCase):
         self.assertEqual(cid.key, localId)
 
     def testVariantSetMetadataCompoundIdParse(self):
-        idStr = "a:vs:b:c"
+        idStr = '["a","vs","b","c"]'
         obfuscated = datamodel.CompoundId.obfuscate(idStr)
         cid = datamodel.VariantSetMetadataCompoundId.parse(obfuscated)
         self.assertEqual(cid.dataset, "a")

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -307,7 +307,8 @@ class TestFrontend(unittest.TestCase):
         self.assertEqual(200, response.status_code)
 
         # Test Error: 404, ID not found
-        obfuscated = datamodel.CompoundId.obfuscate("notValid")
+        idStr = '["notValid"]'
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
         compoundId = datamodel.DatasetCompoundId.parse(obfuscated)
         response = self.sendGetDataset(str(compoundId))
         self.assertEqual(404, response.status_code)
@@ -319,7 +320,8 @@ class TestFrontend(unittest.TestCase):
         variantSetId = responseData.variantSets[0].id
         response = self.sendGetVariantSet(variantSetId)
         self.assertEqual(200, response.status_code)
-        obfuscated = datamodel.CompoundId.obfuscate("notValid:vs:notValid")
+        idStr = '["notValid","vs","notValid"]'
+        obfuscated = datamodel.CompoundId.obfuscate(idStr)
         compoundId = datamodel.VariantSetCompoundId.parse(obfuscated)
         response = self.sendGetVariantSet(str(compoundId))
         self.assertEqual(404, response.status_code)


### PR DESCRIPTION
Use json/arrays instead

Issue #1018

Alternate to fix in #1029 (see discussion there)