### PR TITLE
Update docs to point to new example data

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,8 +62,8 @@ Download and unpack the example data:
 
 .. code-block:: bash
 
-  $ wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data-v3.0.tar
-  $ tar -xf ga4gh-example-data-v3.0.tar
+  $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.1.tar
+  $ tar -xf ga4gh-example-data-v3.1.tar
 
 Create the WSGI file at ``/srv/ga4gh/application.wsgi`` and write the following
 contents:


### PR DESCRIPTION
We've created a new release `data`, that we can add example data as needed. It is possible to add multiple files to a release, so we can manage changes by adding files in the same release, or by creating a new tag.

https://github.com/ga4gh/server/releases/tag/data

Close #998