### PR TITLE
Update docs to point at new example data

### DIFF
--- a/deploy/variants/centos-demo-noapache/Dockerfile
+++ b/deploy/variants/centos-demo-noapache/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir -p /data/
 WORKDIR /data/
 
 #wget the example data
-RUN wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar -nv -O - | tar -x
+RUN wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar -nv -O - | tar -x
 
 # Install setuptools and pip
 RUN easy_install setuptools

--- a/deploy/variants/demo/Dockerfile
+++ b/deploy/variants/demo/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /data/
 # Fetch the example data and extract
 # On some terminals the progress bar freezes during build
 WORKDIR /data/
-RUN curl http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar | tar -x
+RUN curl https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar | tar -x
 WORKDIR /
 
 # Set the dataset location explicitly

--- a/deploy/variants/ubuntu-demo-apache/Dockerfile
+++ b/deploy/variants/ubuntu-demo-apache/Dockerfile
@@ -25,8 +25,8 @@ RUN /bin/bash -c "source ga4gh-server-env/bin/activate"
 RUN pip install --pre ga4gh
 
 # Install relevant sample data
-RUN wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar && \
-    tar -xvf ga4gh-example-data.tar
+RUN wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar && \
+    tar -xvf ga4gh-example-data-v3.2.tar
 
 # Write application.wsgi
 RUN echo "from ga4gh.frontend import app as application\nimport ga4gh.frontend as frontend\nfrontend.configure(\"/srv/ga4gh/config.py\")" > application.wsgi

--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -59,7 +59,7 @@ Now we can download some example data, which we'll use for our demo:
 
 .. code-block:: bash
 
-    (ga4gh-env) $ wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data-v3.0.tar
+    (ga4gh-env) $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar
     (ga4gh-env) $ tar -xvf ga4gh-example-data-v3.0.tar
 
 After extracting the data, we can then run the ``ga4gh_server`` application:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,7 @@ Download and unpack the example data:
 
 .. code-block:: bash
 
-  $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.1.tar
+  $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar
   $ tar -xf ga4gh-example-data-v3.1.tar
 
 Create the WSGI file at ``/srv/ga4gh/application.wsgi`` and write the following

--- a/scripts/ga4gh_example.ipynb
+++ b/scripts/ga4gh_example.ipynb
@@ -27,7 +27,7 @@
     "This notebook provides an overview of how to call a the GA4GH reference server from an iPython notebook.  Before running this notebook:\n",
     "\n",
     "1. git clone https://github.com/ga4gh/server.git -b develop\n",
-    "2. Download the example data (if $scripts/download\\_data.py$ doens't work, wget http://www.well.ox.ac.uk/~jk/ga4gh-example-data-v3.0.tar and tar -xvf in the server/ directory\n",
+    "2. Download the example data (if $scripts/download\\_data.py$ doens't work, wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar and tar -xvf in the server/ directory\n",
     "3. Launch an instance of the reference server on localhost (\"python server_dev.py\")\n",
     "\n",
     "Note: If you have trouble importing the `ga4gh` module, either symlink this notebook into the `/server` directory or add the path to the GA4GH development repo to your `PYTHONPATH`."

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -41,7 +41,8 @@ def archiveExistingData():
 
 
 def downloadData():
-    url = "http://www.well.ox.ac.uk/~jk/ga4gh-example-data.tar"
+    url = ("https://github.com/ga4gh/server/releases/"
+           "download/data/ga4gh-example-data-v3.2.tar")
     fileDownloader = utils.HttpFileDownloader(url, tarballPath)
     fileDownloader.download()
     utils.log("Downloading finished")


### PR DESCRIPTION
Found a couple of other places where the old example data were being pointed to. Updates the URL to point at a version of the example data with ontologymaps.