### PR TITLE
Fixed reference name parsing bug

### DIFF
--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -384,7 +384,7 @@ class HtslibReferenceSet(datamodel.PysamDatamodelMixin, AbstractReferenceSet):
 
     def _addDataFile(self, path):
         dirname, filename = os.path.split(path)
-        localId = filename.split(".")[0]
+        localId = ".".join(filename.split(".")[:-2])
         metadataFileName = os.path.join(dirname, "{}.json".format(localId))
         with open(metadataFileName) as metadataFile:
             metadata = json.load(metadataFile)


### PR DESCRIPTION
References with dots in their name were crashing the server.