### PR TITLE
Add landing page snippet

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -410,6 +410,12 @@ RESPONSE_VALIDATION
     that they conform to the protocol. This should only be used for development
     purposes.
 
+LANDING_MESSAGE_HTML
+    The server provides a simple landing page at its root. By setting this 
+    value to point at an HTML snippet it is possible to customize the landing 
+    page. This can be helpful to provide support links or details about the 
+    hosted datasets.
+
 OIDC_PROVIDER
     If this value is provided, then OIDC is configured and SSL is used. It is
     the URI of the OpenID Connect provider, which should return an OIDC

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -412,9 +412,9 @@ RESPONSE_VALIDATION
 
 LANDING_MESSAGE_HTML
     The server provides a simple landing page at its root. By setting this 
-    value to point at an HTML snippet it is possible to customize the landing 
-    page. This can be helpful to provide support links or details about the 
-    hosted datasets.
+    value to point at a file containing an HTML block element it is possible to
+    customize the landing page. This can be helpful to provide support links
+    or details about the hosted datasets.
 
 OIDC_PROVIDER
     If this value is provided, then OIDC is configured and SSL is used. It is

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -95,12 +95,16 @@ class ServerStatus(object):
 
     def getLandingMessageHtml(self):
         filePath = app.config.get('LANDING_MESSAGE_HTML')
-        if os.path.exists(filePath):
-            with open(filePath, 'r') as html:
-                return html.read()
-        else:
-            with open("ga4gh/templates/landing_message.html", 'r') as html:
-                return html.read()
+        try:
+            htmlFile = open(filePath, 'r')
+            html = htmlFile.read()
+        except:
+            filePath = "ga4gh/templates/landing_message.html"
+            htmlFile = open(filePath, 'r')
+            html = htmlFile.read()
+        finally:
+            htmlFile.close()
+        return html
 
     def getNaturalUptime(self):
         """

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -83,7 +83,7 @@ class ServerStatus(object):
         # TODO what other config keys are appropriate to export here?
         keys = [
             'DEBUG', 'REQUEST_VALIDATION', 'RESPONSE_VALIDATION',
-            'DEFAULT_PAGE_SIZE', 'MAX_RESPONSE_LENGTH',
+            'DEFAULT_PAGE_SIZE', 'MAX_RESPONSE_LENGTH', 'LANDING_MESSAGE_HTML'
         ]
         return [(k, app.config[k]) for k in keys]
 
@@ -92,6 +92,15 @@ class ServerStatus(object):
         Returns the server precisely.
         """
         return self.startupTime.strftime("%H:%M:%S %d %b %Y")
+
+    def getLandingMessageHtml(self):
+        filePath = app.config.get('LANDING_MESSAGE_HTML')
+        if os.path.exists(filePath):
+            with open(filePath, 'r') as html:
+                return html.read()
+        else:
+            with open("ga4gh/templates/landing_message.html", 'r') as html:
+                return html.read()
 
     def getNaturalUptime(self):
         """

--- a/ga4gh/serverconfig.py
+++ b/ga4gh/serverconfig.py
@@ -34,6 +34,8 @@ class BaseConfig(object):
 
     FILE_HANDLE_CACHE_MAX_SIZE = 50
 
+    LANDING_MESSAGE_HTML = "landing_message.html"
+
 
 class DevelopmentConfig(BaseConfig):
     """

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -15,7 +15,7 @@
             {{ info.getLandingMessageHtml() | safe}}
         </div>
         <div>
-            <h3>Session Token {{ session['key']}}</h3>
+            <h3>Session Token <span class="session-token">{{ session['key']}}</span></h3>
         </div>
         <div>
             <h3>Operations available</h3>

--- a/ga4gh/templates/index.html
+++ b/ga4gh/templates/index.html
@@ -12,6 +12,9 @@
             <h3>Protocol version {{ info.getProtocolVersion() }}</h3>
         </div>
         <div>
+            {{ info.getLandingMessageHtml() | safe}}
+        </div>
+        <div>
             <h3>Session Token {{ session['key']}}</h3>
         </div>
         <div>

--- a/ga4gh/templates/landing_message.html
+++ b/ga4gh/templates/landing_message.html
@@ -1,0 +1,11 @@
+<!-- //
+    If you would like a different landing message to appear you can modify
+    this file, or set the `LANDING_MESSAGE_HTML` configuration value to
+    point to an HTML snippet.
+//-->
+<div>
+    Welcome to the GA4GH reference server landing page! This page describes
+    the available operations, configuration, and datasets made available by
+    this server instance. For more information please visit
+    <a href="https://github.com/ga4gh/server">our github repository.</a>
+</div>

--- a/tests/end_to_end/test_oidc.py
+++ b/tests/end_to_end/test_oidc.py
@@ -44,10 +44,12 @@ def getClientKey(server_url, username, password):
     keyPage = session.post(nextUrl, data, verify=False)
     # Extract the key from the page
     keyTree = html.fromstring(keyPage.text)
-    tokenMarker = 'Session Token '  # the token always appears after this text
-    tokenTag = (tag for tag in keyTree.iterdescendants()
-                if tag.text_content().startswith(tokenMarker)).next()
-    return tokenTag.text_content()[len(tokenMarker):]
+    sessionTokenTags = keyTree.find_class("session-token")
+    if len(sessionTokenTags) > 0:
+        sessionKey = keyTree.find_class("session-token")[0].text_content()
+    else:
+        raise StopIteration
+    return sessionKey
 
 
 class TestOidc(server_test.ServerTestClass):


### PR DESCRIPTION
By setting the `LANDING_MESSAGE_HTML` configuration variable to point at an HTML snippet one can modify the landing page without editing the template directly. A default message has been added in the template directory, `landing_message.html`, which links to the reference server github repo.

I refactored the OIDC test, which was examining strings in HTML tags and was brittle to the inclusion of an HTML comment in the landing page. It now selects the session token tag by class.

Closes #1088