### PR TITLE
Version bump example data

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,7 +63,7 @@ Download and unpack the example data:
 .. code-block:: bash
 
   $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar
-  $ tar -xf ga4gh-example-data-v3.1.tar
+  $ tar -xf ga4gh-example-data-v3.2.tar
 
 Create the WSGI file at ``/srv/ga4gh/application.wsgi`` and write the following
 contents:


### PR DESCRIPTION
Housekeeping for the example data, need to bump the version for the `tar` command. Also, the example data in the data release has been updated so we can close #1091.