### PR TITLE
Updates on repo manager

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -1636,6 +1636,14 @@ class RepoManager(object):
         readGroupSet.setReferenceSet(referenceSet)
         self._updateRepo(self._repo.insertReadGroupSet, readGroupSet)
 
+    def removeDataset(self):
+        """
+        Removes a dataset from the repo.
+        """
+        self._openRepo()
+        dataset = self._repo.getDatasetByName(self._args.datasetName)
+        self._updateRepo(self._repo.removeDataset, dataset)
+
     #
     # Methods to simplify adding common arguments to the parser.
     #
@@ -1728,12 +1736,6 @@ class RepoManager(object):
             subparsers, "list", "List the contents of the repo")
         listParser.set_defaults(runner="list")
         cls.addRepoArgument(listParser)
-
-        destroyParser = addSubparser(
-            subparsers, "destroy", "Destroy the repo")
-        destroyParser.set_defaults(runner="destroy")
-        cls.addRepoArgument(destroyParser)
-        cls.addForceOption(destroyParser)
 
         addDatasetParser = addSubparser(
             subparsers, "add-dataset", "Add a dataset to the data repo")

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -1625,7 +1625,9 @@ class RepoManager(object):
         dataUrl = self._args.dataFile
         indexFile = self._args.indexFile
         parsed = urlparse.urlparse(dataUrl)
-        if parsed.scheme == 'http':
+        # TODO, add https support and others when they have been
+        # tested.
+        if parsed.scheme in ['http', 'ftp']:
             if indexFile is None:
                 raise exceptions.MissingIndexException(dataUrl)
         else:
@@ -1824,7 +1826,7 @@ class RepoManager(object):
             "indexFile", nargs='?', default=None,
             help=(
                 "The file path of the BAM index for this ReadGroupSet. "
-                "If the dataFile is a argument is a local file, this will "
+                "If the dataFile argument is a local file, this will "
                 "be automatically inferred by appending '.bai' to the "
                 "file name. If the dataFile is a remote URL the path to "
                 "a local file containing the BAM index must be provided"))

--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -1656,6 +1656,19 @@ class RepoManager(object):
             self._updateRepo(self._repo.removeReferenceSet, referenceSet)
         self._confirmDelete("ReferenceSet", referenceSet.getLocalId(), func)
 
+    def removeReadGroupSet(self):
+        """
+        Removes a readGroupSet from the repo.
+        """
+        self._openRepo()
+        dataset = self._repo.getDatasetByName(self._args.datasetName)
+        readGroupSet = dataset.getReadGroupSetByName(
+            self._args.readGroupSetName)
+
+        def func():
+            self._updateRepo(self._repo.removeReadGroupSet, readGroupSet)
+        self._confirmDelete("ReadGroupSet", readGroupSet.getLocalId(), func)
+
     def removeDataset(self):
         """
         Removes a dataset from the repo.

--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import datetime
 import json
+import os.path
 import random
 
 import pysam
@@ -204,6 +205,10 @@ class AlignmentDataMixin(datamodel.PysamDatamodelMixin):
         return ret
 
     def openFile(self, dataFile):
+        # We need to check to see if the path exists here as pysam does
+        # not throw an error if the index is missing.
+        if not os.path.exists(self._indexFile):
+            raise exceptions.FileOpenFailedException(self._indexFile)
         return pysam.AlignmentFile(
             self._dataUrl, filepath_index=self._indexFile)
 

--- a/ga4gh/datarepo.py
+++ b/ga4gh/datarepo.py
@@ -430,6 +430,7 @@ class SqlDataRepository(AbstractDataRepository):
                 sourceUri TEXT,
                 UNIQUE (referenceSetId, name),
                 FOREIGN KEY(referenceSetId) REFERENCES ReferenceSet(id)
+                    ON DELETE CASCADE
             );
         """
         cursor.execute(sql)
@@ -508,7 +509,6 @@ class SqlDataRepository(AbstractDataRepository):
             raise exceptions.DuplicateNameException(referenceSet.getLocalId())
         self._dbConnection.commit()
         for reference in referenceSet.getReferences():
-            print(referenceSet.getId(), reference.getParentContainer().getId())
             self.insertReference(reference)
 
     def _readReferenceSetTable(self, cursor):
@@ -580,6 +580,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated TEXT,
                 UNIQUE (readGroupSetId, name),
                 FOREIGN KEY(readGroupSetId) REFERENCES ReadGroupSet(id)
+                    ON DELETE CASCADE
             );
         """
         cursor.execute(sql)
@@ -623,7 +624,8 @@ class SqlDataRepository(AbstractDataRepository):
                 dataUrl TEXT NOT NULL,
                 indexFile TEXT NOT NULL,
                 UNIQUE (datasetId, name),
-                FOREIGN KEY(datasetId) REFERENCES Dataset(id),
+                FOREIGN KEY(datasetId) REFERENCES Dataset(id)
+                    ON DELETE CASCADE,
                 FOREIGN KEY(referenceSetId) REFERENCES ReferenceSet(id)
             );
         """
@@ -657,6 +659,18 @@ class SqlDataRepository(AbstractDataRepository):
         for readGroup in readGroupSet.getReadGroups():
             self.insertReadGroup(readGroup)
 
+    def removeReferenceSet(self, referenceSet):
+        """
+        Removes the specified referenceSet from this repository. This performs
+        a cascading removal of all references within this referenceSet.
+        However, it does not remove any of the ReadGroupSets or items that
+        refer to this ReferenceSet. These must be deleted before the
+        referenceSet can be removed.
+        """
+        sql = "DELETE FROM ReferenceSet WHERE name=?"
+        cursor = self._dbConnection.cursor()
+        cursor.execute(sql, (referenceSet.getLocalId(),))
+
     def _readReadGroupSetTable(self, cursor):
         cursor.row_factory = sqlite3.Row
         cursor.execute("SELECT * FROM ReadGroupSet;")
@@ -680,6 +694,7 @@ class SqlDataRepository(AbstractDataRepository):
                 annotationType TEXT,
                 UNIQUE (variantSetId, name),
                 FOREIGN KEY(variantSetId) REFERENCES VariantSet(id)
+                    ON DELETE CASCADE
             );
         """
         cursor.execute(sql)
@@ -722,6 +737,7 @@ class SqlDataRepository(AbstractDataRepository):
                 variantSetId TEXT NOT NULL,
                 UNIQUE (variantSetId, name),
                 FOREIGN KEY(variantSetId) REFERENCES VariantSet(id)
+                    ON DELETE CASCADE
             );
         """
         cursor.execute(sql)
@@ -763,7 +779,8 @@ class SqlDataRepository(AbstractDataRepository):
                 metadata TEXT,
                 dataUrlIndexMap TEXT NOT NULL,
                 UNIQUE (datasetID, name),
-                FOREIGN KEY(datasetId) REFERENCES Dataset(id),
+                FOREIGN KEY(datasetId) REFERENCES Dataset(id)
+                    ON DELETE CASCADE,
                 FOREIGN KEY(referenceSetId) REFERENCES ReferenceSet(id)
             );
         """
@@ -820,7 +837,8 @@ class SqlDataRepository(AbstractDataRepository):
                 sourceUri TEXT,
                 dataUrl TEXT NOT NULL,
                 UNIQUE (datasetId, name),
-                FOREIGN KEY(datasetId) REFERENCES Dataset(id),
+                FOREIGN KEY(datasetId) REFERENCES Dataset(id)
+                    ON DELETE CASCADE,
                 FOREIGN KEY(referenceSetId) REFERENCES ReferenceSet(id)
             );
         """

--- a/ga4gh/datarepo.py
+++ b/ga4gh/datarepo.py
@@ -601,6 +601,15 @@ class SqlDataRepository(AbstractDataRepository):
             readGroup.getLocalId(), readGroup.getPredictedInsertSize(),
             readGroup.getSampleId()))
 
+    def removeReadGroupSet(self, readGroupSet):
+        """
+        Removes the specified readGroupSet from this repository. This performs
+        a cascading removal of all items within this readGroupSet.
+        """
+        sql = "DELETE FROM ReadGroupSet WHERE name=?"
+        cursor = self._dbConnection.cursor()
+        cursor.execute(sql, (readGroupSet.getLocalId(),))
+
     def _readReadGroupTable(self, cursor):
         cursor.row_factory = sqlite3.Row
         cursor.execute("SELECT * FROM ReadGroup;")

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -453,48 +453,6 @@ class InconsistentCallSetIdException(MalformedException):
             " directory.".format(fileName))
 
 
-class NotExactlyOneReferenceException(MalformedException):
-    """
-    A FASTA file has a reference count not equal to one
-    """
-    def __init__(self, fileName, numReferences):
-        self.message = (
-            "FASTA files must have one and only one reference.  "
-            "File {} has {} references.".format(fileName, numReferences))
-
-
-class InconsistentReferenceNameException(MalformedException):
-    """
-    A FASTA file has a reference name not equal to its file name.
-    """
-    def __init__(self, fileName):
-        self.message = (
-            "FASTA file {} has a reference not equal to its "
-            "file name.".format(fileName))
-
-
-class MissingReferenceMetadata(MalformedException):
-    """
-    A FASTA file is missing some metadata in the corresponding JSON file.
-    """
-    def __init__(self, fileName, key):
-        self.message = (
-            "JSON reference metadata for file {} is missing key {}".format(
-                fileName, key))
-
-
-class MissingReferenceSetMetadata(MalformedException):
-    """
-    A directory containing FASTA files is missing some metadata in the
-    corresponding JSON file.
-    """
-    def __init__(self, fileName, key):
-        self.message = (
-            "JSON reference set metadata for file {} "
-            "is missing key {}".format(
-                fileName, key))
-
-
 class ReadGroupReferenceNotFound(MalformedException):
     """
     A BAM file contains reference names that are not in the linked
@@ -595,3 +553,15 @@ class RepoManagerException(Exception):
     """
     Signals something went wrong inside the repo manager
     """
+
+
+class DuplicateNameException(RepoManagerException):
+    """
+    The user has tried to insert an object with the same name as
+    an existing object.
+    """
+    def __init__(self, objectName, containerName=None):
+        msg = "Name '{}' already exists".format(objectName)
+        if containerName is not None:
+            msg += " in '{}'".format(containerName)
+        super(DuplicateNameException, self).__init__(msg)

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -374,8 +374,7 @@ class DataException(BaseServerException):
 class FileOpenFailedException(DataException):
 
     def __init__(self, filename):
-        msg = "Failed to open file '{}'".format(filename)
-        super(FileOpenFailedException, self).__init__(msg)
+        self.message = "Failed to open file '{}'".format(filename)
 
 
 class EmptyDirException(DataException):
@@ -565,3 +564,13 @@ class DuplicateNameException(RepoManagerException):
         if containerName is not None:
             msg += " in '{}'".format(containerName)
         super(DuplicateNameException, self).__init__(msg)
+
+
+class MissingIndexException(RepoManagerException):
+    """
+    An index file for a remote BAM/VCF has not been provided.
+    """
+    def __init__(self, dataUrl):
+        msg = "An index file must be provided for remote file '{}'".format(
+            dataUrl)
+        super(MissingIndexException, self).__init__(msg)

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -557,7 +557,7 @@ class RepoManagerException(Exception):
 class DuplicateNameException(RepoManagerException):
     """
     The user has tried to insert an object with the same name as
-    an existing object.
+    an existing object within a given container.
     """
     def __init__(self, objectName, containerName=None):
         msg = "Name '{}' already exists".format(objectName)

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -13,9 +13,10 @@ testDataDir = os.path.join(testDir, 'data')
 
 # references
 referenceSetName = 'chr17'
-faPath = os.path.join(testDataDir, 'referenceSets/Default/chr17.fa.gz')
-faPath2 = os.path.join(testDataDir, 'referenceSets/example_1/simple.fa.gz')
-faPath3 = os.path.join(testDataDir, 'referenceSets/example_2/random1.fa.gz')
+faPath = os.path.join(testDataDir, 'referenceSets/Default.fa.gz')
+faPath2 = os.path.join(testDataDir, 'referenceSets/example_1.fa.gz')
+faPath3 = os.path.join(testDataDir, 'referenceSets/example_2.fa.gz')
+ncbi37FaPath = os.path.join(testDataDir, 'referenceSets/NCBI37.fa.gz')
 
 # variants
 variantSetName = '1kgPhase1'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -332,6 +332,19 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
         self.assertEquals(args.dataFile, self.filePath)
+        self.assertEquals(args.indexFile, None)
+        self.assertEquals(args.runner, "addReadGroupSet")
+
+    def testAddReadGroupSetWithIndexFile(self):
+        indexPath = self.filePath + ".bai"
+        cliInput = "add-readgroupset {} {} {} {}".format(
+            self.repoPath, self.datasetName, self.filePath,
+            indexPath)
+        args = self.parser.parse_args(cliInput.split())
+        self.assertEquals(args.repoPath, self.repoPath)
+        self.assertEquals(args.datasetName, self.datasetName)
+        self.assertEquals(args.dataFile, self.filePath)
+        self.assertEquals(args.indexFile, indexPath)
         self.assertEquals(args.runner, "addReadGroupSet")
 
     def testRemoveReadGroupSet(self):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -265,60 +265,46 @@ class TestClientArguments(unittest.TestCase):
 class TestRepoManagerCli(unittest.TestCase):
 
     def setUp(self):
-        self.parser = cli.getRepoParser()
+        self.parser = cli.RepoManager.getParser()
         self.repoPath = 'a/repo/path'
         self.datasetName = "datasetName"
         self.filePath = 'a/file/path'
 
-    @unittest.skip("Skip until repo manager completed")
     def testInit(self):
         cliInput = "init {}".format(self.repoPath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
-        self.assertEquals(args.runner, cli.InitRunner)
+        self.assertEquals(args.runner, "init")
 
-    @unittest.skip("Skip until repo manager completed")
-    def testCheck(self):
-        cliInput = "check {}".format(self.repoPath)
+    def testVerify(self):
+        cliInput = "verify {}".format(self.repoPath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
-        self.assertEquals(args.runner, cli.CheckRunner)
+        self.assertEquals(args.runner, "verify")
 
-    @unittest.skip("Skip until repo manager completed")
     def testList(self):
         cliInput = "list {}".format(self.repoPath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
-        self.assertEquals(args.runner, cli.ListRunner)
+        self.assertEquals(args.runner, "list")
 
-    @unittest.skip("Skip until repo manager completed")
-    def testDestroy(self):
-        cliInput = "destroy {} --force".format(self.repoPath)
-        args = self.parser.parse_args(cliInput.split())
-        self.assertEquals(args.repoPath, self.repoPath)
-        self.assertEquals(args.runner, cli.DestroyRunner)
-        self.assertEquals(args.force, True)
-
-    @unittest.skip("Skip until repo manager completed")
     def testAddDataset(self):
         cliInput = "add-dataset {} {}".format(
             self.repoPath, self.datasetName)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
-        self.assertEquals(args.runner, cli.AddDatasetRunner)
+        self.assertEquals(args.runner, "addDataset")
 
-    @unittest.skip("Skip until repo manager completed")
     def testRemoveDataset(self):
         cliInput = "remove-dataset {} {} -f".format(
             self.repoPath, self.datasetName)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
-        self.assertEquals(args.runner, cli.RemoveDatasetRunner)
+        self.assertEquals(args.runner, "removeDataset")
         self.assertEquals(args.force, True)
 
-    @unittest.skip("Skip until repo manager completed")
     def testAddReferenceSet(self):
         description = "description"
         cliInput = "add-referenceset {} {} --description={}".format(
@@ -327,9 +313,8 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.filePath, self.filePath)
         self.assertEquals(args.description, description)
-        self.assertEquals(args.runner, cli.AddReferenceSetRunner)
+        self.assertEquals(args.runner, "addReferenceSet")
 
-    @unittest.skip("Skip until repo manager completed")
     def testRemoveReferenceSet(self):
         referenceSetName = "referenceSetName"
         cliInput = "remove-referenceset {} {} -f".format(
@@ -337,21 +322,18 @@ class TestRepoManagerCli(unittest.TestCase):
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.referenceSetName, referenceSetName)
-        self.assertEquals(args.runner, cli.RemoveReferenceSetRunner)
+        self.assertEquals(args.runner, "removeReferenceSet")
         self.assertEquals(args.force, True)
 
-    @unittest.skip("Skip until repo manager completed")
     def testAddReadGroupSet(self):
-        cliInput = "add-readgroupset {} {} {} --moveMode=copy".format(
+        cliInput = "add-readgroupset {} {} {} ".format(
             self.repoPath, self.datasetName, self.filePath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
-        self.assertEquals(args.filePath, self.filePath)
-        self.assertEquals(args.moveMode, "copy")
-        self.assertEquals(args.runner, cli.AddReadGroupSetRunner)
+        self.assertEquals(args.dataFile, self.filePath)
+        self.assertEquals(args.runner, "addReadGroupSet")
 
-    @unittest.skip("Skip until repo manager completed")
     def testRemoveReadGroupSet(self):
         readGroupSetName = "readGroupSetName"
         cliInput = "remove-readgroupset {} {} {} -f".format(
@@ -360,21 +342,18 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
         self.assertEquals(args.readGroupSetName, readGroupSetName)
-        self.assertEquals(args.runner, cli.RemoveReadGroupSetRunner)
+        self.assertEquals(args.runner, "removeReadGroupSet")
         self.assertEquals(args.force, True)
 
-    @unittest.skip("Skip until repo manager completed")
     def testAddVariantSet(self):
-        cliInput = "add-variantset {} {} {} --moveMode=move".format(
+        cliInput = "add-variantset {} {} {} ".format(
             self.repoPath, self.datasetName, self.filePath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
         self.assertEquals(args.filePath, self.filePath)
-        self.assertEquals(args.moveMode, "move")
-        self.assertEquals(args.runner, cli.AddVariantSetRunner)
+        self.assertEquals(args.runner, "addVariantSet")
 
-    @unittest.skip("Skip until repo manager completed")
     def testRemoveVariantSet(self):
         variantSetName = "variantSetName"
         cliInput = "remove-variantset {} {} {}".format(
@@ -383,20 +362,17 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
         self.assertEquals(args.variantSetName, variantSetName)
-        self.assertEquals(args.runner, cli.RemoveVariantSetRunner)
+        self.assertEquals(args.runner, "removeVariantSet")
         self.assertEquals(args.force, False)
 
-    @unittest.skip("Skip until repo manager completed")
     def testAddOntologyMap(self):
-        cliInput = "add-ontologymap {} {} --moveMode=move".format(
+        cliInput = "add-ontologymap {} {}".format(
             self.repoPath, self.filePath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.filePath, self.filePath)
-        self.assertEquals(args.moveMode, "move")
-        self.assertEquals(args.runner, cli.AddOntologyMapRunner)
+        self.assertEquals(args.runner, "addOntologyMap")
 
-    @unittest.skip("Skip until repo manager completed")
     def testRemoveOntologyMap(self):
         ontologyMapName = "ontologyMap"
         cliInput = "remove-ontologymap {} {}".format(
@@ -404,7 +380,7 @@ class TestRepoManagerCli(unittest.TestCase):
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.ontologyMapName, ontologyMapName)
-        self.assertEquals(args.runner, cli.RemoveOntologyMapRunner)
+        self.assertEquals(args.runner, "removeOntologyMap")
         self.assertEquals(args.force, False)
 
 

--- a/tests/unit/test_repo_manager.py
+++ b/tests/unit/test_repo_manager.py
@@ -12,7 +12,34 @@ import unittest
 import ga4gh.exceptions as exceptions
 import ga4gh.datarepo as datarepo
 import ga4gh.cli as cli
-# import tests.paths as paths
+import tests.paths as paths
+
+
+class TestGetNameFromPath(unittest.TestCase):
+    """
+    Tests the method for deriving the default name of objects from file
+    paths.
+    """
+    def testError(self):
+        self.assertRaises(ValueError, cli.getNameFromPath, "")
+
+    def testLocalDirectory(self):
+        self.assertEqual(cli.getNameFromPath("no_extension"), "no_extension")
+        self.assertEqual(cli.getNameFromPath("x.y"), "x")
+        self.assertEqual(cli.getNameFromPath("x.y.z"), "x")
+
+    def testFullPaths(self):
+        self.assertEqual(cli.getNameFromPath("/no_ext"), "no_ext")
+        self.assertEqual(cli.getNameFromPath("/x.y"), "x")
+        self.assertEqual(cli.getNameFromPath("/x.y.z"), "x")
+        self.assertEqual(cli.getNameFromPath("/a/no_ext"), "no_ext")
+        self.assertEqual(cli.getNameFromPath("/a/x.y"), "x")
+        self.assertEqual(cli.getNameFromPath("/a/x.y.z"), "x")
+
+    def testUrls(self):
+        self.assertEqual(cli.getNameFromPath("file:///no_ext"), "no_ext")
+        self.assertEqual(cli.getNameFromPath("http://example.com/x.y"), "x")
+        self.assertEqual(cli.getNameFromPath("ftp://x.y.z"), "x")
 
 
 class AbstractRepoManagerTest(unittest.TestCase):
@@ -53,7 +80,123 @@ class TestAddDataset(AbstractRepoManagerTest):
         cmd = "add-dataset {} {}".format(self._repoPath, name)
         self.runCommand(cmd)
         self.assertRaises(
+            exceptions.DuplicateNameException, self.runCommand, cmd)
+
+
+class TestAddReferenceSet(AbstractRepoManagerTest):
+
+    def setUp(self):
+        super(TestAddReferenceSet, self).setUp()
+        self.runCommand("init {}".format(self._repoPath))
+
+    def testAddReferenceSetDefaults(self):
+        fastaFile = paths.ncbi37FaPath
+        name = os.path.split(fastaFile)[1].split(".")[0]
+        self.runCommand("add-referenceset {} {}".format(
+            self._repoPath, fastaFile))
+        repo = self.readRepo()
+        referenceSet = repo.getReferenceSetByName(name)
+        self.assertEqual(referenceSet.getLocalId(), name)
+        self.assertEqual(referenceSet.getDataUrl(), fastaFile)
+        # TODO check that the default values for all fields are set correctly.
+
+    def testAddReferenceSetWithName(self):
+        name = "test_reference_set"
+        fastaFile = paths.ncbi37FaPath
+        cmd = "add-referenceset {} {} --name={}".format(
+            self._repoPath, fastaFile, name)
+        self.runCommand(cmd)
+        repo = self.readRepo()
+        referenceSet = repo.getReferenceSetByName(name)
+        self.assertEqual(referenceSet.getLocalId(), name)
+        self.assertEqual(referenceSet.getDataUrl(), fastaFile)
+
+    def testAddReferenceSetWithSameName(self):
+        fastaFile = paths.ncbi37FaPath
+        # Default name
+        cmd = "add-referenceset {} {}".format(self._repoPath, fastaFile)
+        self.runCommand(cmd)
+        self.assertRaises(
             exceptions.RepoManagerException, self.runCommand, cmd)
+        # Specified name
+        cmd = "add-referenceset {} {} --name=testname".format(
+            self._repoPath, fastaFile)
+        self.runCommand(cmd)
+        self.assertRaises(
+            exceptions.DuplicateNameException, self.runCommand, cmd)
+
+
+class TestAddReadGroupSet(AbstractRepoManagerTest):
+
+    def setUp(self):
+        super(TestAddReadGroupSet, self).setUp()
+        self._datasetName = "test_ds"
+        self._referenceSetName = "test_rs"
+        self.runCommand("init {}".format(self._repoPath))
+        self.runCommand("add-dataset {} {}".format(
+            self._repoPath, self._datasetName))
+        fastaFile = paths.ncbi37FaPath
+        self.runCommand("add-referenceset {} {} --name={}".format(
+            self._repoPath, fastaFile, self._referenceSetName))
+
+    def verifyReadGroupSet(self, name, dataUrl, indexFile):
+        repo = self.readRepo()
+        dataset = repo.getDatasetByName(self._datasetName)
+        referenceSet = repo.getReferenceSetByName(self._referenceSetName)
+        readGroupSet = dataset.getReadGroupSetByName(name)
+        self.assertEqual(readGroupSet.getLocalId(), name)
+        self.assertEqual(readGroupSet.getReferenceSet(), referenceSet)
+        self.assertEqual(readGroupSet.getDataUrl(), dataUrl)
+        self.assertEqual(readGroupSet.getIndexFile(), indexFile)
+
+    def testAddReadGroupSetDefaultsLocalFile(self):
+        bamFile = paths.bamPath
+        name = os.path.split(bamFile)[1].split(".")[0]
+        cmd = "add-readgroupset {} {} {} --referenceSetName={}".format(
+                self._repoPath, self._datasetName, bamFile,
+                self._referenceSetName)
+        self.runCommand(cmd)
+        self.verifyReadGroupSet(name, bamFile, bamFile + ".bai")
+
+    def testAddReadGroupSetWithNameLocalFile(self):
+        bamFile = paths.bamPath
+        name = "test_rgs"
+        cmd = (
+            "add-readgroupset {} {} {} --referenceSetName={} "
+            "--name={}").format(
+            self._repoPath, self._datasetName, bamFile,
+            self._referenceSetName, name)
+        self.runCommand(cmd)
+        self.verifyReadGroupSet(name, bamFile, bamFile + ".bai")
+
+    def testAddReadGroupSetWithSameName(self):
+        # Default name
+        bamFile = paths.bamPath
+        name = os.path.split(bamFile)[1].split(".")[0]
+        cmd = "add-readgroupset {} {} {} --referenceSetName={}".format(
+                self._repoPath, self._datasetName, bamFile,
+                self._referenceSetName)
+        self.runCommand(cmd)
+        self.assertRaises(
+            exceptions.DuplicateNameException, self.runCommand, cmd)
+        # Specified name
+        name = "test_rgs"
+        cmd = (
+            "add-readgroupset {} {} {} --referenceSetName={} "
+            "--name={}").format(
+            self._repoPath, self._datasetName, bamFile,
+            self._referenceSetName, name)
+        self.runCommand(cmd)
+        self.assertRaises(
+            exceptions.DuplicateNameException, self.runCommand, cmd)
+
+    def testAddReadGroupSetMissingDataset(self):
+        bamFile = paths.bamPath
+        cmd = "add-readgroupset {} {} {} --referenceSetName={}".format(
+                self._repoPath, "not_a_dataset_name", bamFile,
+                self._referenceSetName)
+        self.assertRaises(
+            exceptions.DatasetNameNotFoundException, self.runCommand, cmd)
     # TODO adapt the code below to test the repo manager code within
     # the above framework.
 # class RepoManagerInidividualCommandTest(AbstractRepoManagerTest):

--- a/tests/unit/test_repo_manager.py
+++ b/tests/unit/test_repo_manager.py
@@ -84,6 +84,24 @@ class TestAddDataset(AbstractRepoManagerTest):
             exceptions.DuplicateNameException, self.runCommand, cmd)
 
 
+class TestRemoveDataset(AbstractRepoManagerTest):
+
+    def setUp(self):
+        super(TestRemoveDataset, self).setUp()
+        self.runCommand("init {}".format(self._repoPath))
+        self._datasetName = "test_dataset"
+        cmd = "add-dataset {} {}".format(self._repoPath, self._datasetName)
+        self.runCommand(cmd)
+
+    def testRemoveEmptyDatasetForce(self):
+        self.runCommand("remove-dataset {} {} -f".format(
+            self._repoPath, self._datasetName))
+        repo = self.readRepo()
+        self.assertRaises(
+            exceptions.DatasetNameNotFoundException,
+            repo.getDatasetByName, self._datasetName)
+
+
 class TestAddReferenceSet(AbstractRepoManagerTest):
 
     def setUp(self):
@@ -226,160 +244,3 @@ class TestAddReadGroupSet(AbstractRepoManagerTest):
                 "not_a_referenceset_name")
         self.assertRaises(
             exceptions.ReferenceSetNameNotFoundException, self.runCommand, cmd)
-
-    # TODO adapt the code below to test the repo manager code within
-    # the above framework.
-# class RepoManagerInidividualCommandTest(AbstractRepoManagerTest):
-    # """
-    # Tests for individiual repo manager commands
-    # """
-    # def setUp(self):
-    #     self.tempdir = self.getTempDirPath()
-    #     # self.repoManager = repo_manager.RepoManager(self.tempdir)
-    #     self.repoManager.init()
-
-    # def tearDown(self):
-    #     try:
-    #         self.repoManager.destroy()
-    #     except exceptions.RepoManagerException:
-    #         pass
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testInit(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.init()
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testDestroy(self):
-    #     self.repoManager.destroy()
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.destroy()
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testCheck(self):
-    #     self.repoManager.check()
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testList(self):
-    #     self.repoManager.list()
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testAddDataset(self):
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.addDataset('dataset2')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addDataset('dataset2')
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testRemoveDataset(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeDataset('dataset1')
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.removeDataset('dataset1')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeDataset('dataset1')
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testAddReferenceSet(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addReferenceSet(paths.bamPath, 'link', {})
-    #     self.repoManager.addReferenceSet(
-    #         paths.faPath, 'link', {'description': 'aDescription'})
-    #     self.repoManager.addReferenceSet(
-    #         paths.faPath2, 'copy', {})
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addReferenceSet(paths.faPath, 'link', {})
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testRemoveReferenceSet(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeReferenceSet(paths.referenceSetName)
-    #     self.repoManager.addReferenceSet(paths.faPath, 'link', {})
-    #     self.repoManager.removeReferenceSet(paths.referenceSetName)
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeReferenceSet(paths.referenceSetName)
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testAddReadGroupSet(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addReadGroupSet(
-    #             'dataset1', paths.bamPath, 'link')
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.addDataset('dataset2')
-    #     self.repoManager.addReadGroupSet(
-    #         'dataset1', paths.bamPath, 'link')
-    #     self.repoManager.addReadGroupSet(
-    #         'dataset1', paths.bamPath2, 'link')
-    #     self.repoManager.addReadGroupSet(
-    #         'dataset2', paths.bamPath, 'link')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addReadGroupSet(
-    #             'dataset1', paths.bamPath, 'link')
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testRemoveReadGroupSet(self):
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.addReadGroupSet(
-    #         'dataset1', paths.bamPath, 'link')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeReadGroupSet(
-    #             'dataset2', paths.readGroupSetName)
-    #     self.repoManager.removeReadGroupSet(
-    #         'dataset1', paths.readGroupSetName)
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeReadGroupSet(
-    #             'dataset1', paths.readGroupSetName)
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testAddVariantSet(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addVariantSet(
-    #             'dataset1', paths.vcfDirPath, 'link')
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.addDataset('dataset2')
-    #     self.repoManager.addVariantSet(
-    #         'dataset1', paths.vcfDirPath, 'link')
-    #     self.repoManager.addVariantSet(
-    #         'dataset1', paths.vcfDirPath2, 'link')
-    #     self.repoManager.addVariantSet(
-    #         'dataset2', paths.vcfDirPath, 'link')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addVariantSet(
-    #             'dataset1', paths.vcfDirPath, 'link')
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testRemoveVariantSet(self):
-    #     self.repoManager.addDataset('dataset1')
-    #     self.repoManager.addVariantSet(
-    #         'dataset1', paths.vcfDirPath, 'link')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeVariantSet(
-    #             'dataset2', paths.variantSetName)
-    #     self.repoManager.removeVariantSet(
-    #         'dataset1', paths.variantSetName)
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeVariantSet(
-    #             'dataset1', paths.variantSetName)
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testAddOntologyMap(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addOntologyMap(paths.bamPath, 'link')
-    #     self.repoManager.addOntologyMap(
-    #         paths.ontologyPath, 'link')
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.addOntologyMap(
-    #             paths.ontologyPath, 'link')
-
-    # @unittest.skip("Skip until repo manager completed")
-    # def testRemoveOntologyMap(self):
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeOntologyMap(
-    #             paths.ontologyName)
-    #     self.repoManager.addOntologyMap(
-    #         paths.ontologyPath, 'link')
-    #     self.repoManager.removeOntologyMap(
-    #         paths.ontologyName)
-    #     with self.assertRaises(exceptions.RepoManagerException):
-    #         self.repoManager.removeOntologyMap(
-    #             paths.ontologyName)


### PR DESCRIPTION
This is a PR updating the repo manager. Changes:

1. Changed the SQL schema so that it enforces the integrity of the data model at a schema level using foreign key contraints.
2. Added default name for objects added in the CLI to be derived from the input file.
3. add-readgroupset now supports both local files and remote URLs, along with optionally specifying an index file. The index file is provided via an optional positional argument, so we do ``add-readgroupset repoFile datasetName bam_url index_file``. When a URL is provided, the index is mandatory.
4. Changed the ``check`` command to ``verify``, and reimplemented it. Since the DB schema now guarantees the integrity of the data model, the focus of this command is changed to making sure that the various containers we're pointing at work as they are supposed to.  At the moment it goes through all of the various containers and makes sure that we can actually read some data back from them. This is an essential debug tool I think. The current implementation is crude, but it is still useful. 
5. Changed error handling in the CLI to throw exceptions of the relevant type all the way back to the top level, where they are caught. For example when a ReadGroupSet cannot be found with a specific name, this exception is thrown, and we get a message like "Error: ReadGroupSet with name 'HG000sd' not found". This is printed to stderr and we exit with status 1. In general, we should aim to handle errors in the repo manager CLI like this, where we just follow the nominal case and expect the exception handling to do the right thing.
6. Re-enabled some repo manager unit tests, and added unit tests for the parts of the CLI that have been implemented.

Dataset, ReferenceSet and ReadGroupSet handling is now in quite good shape. Follow up PRs will add VariantSet, VariantAnnotationSet, and FeatureSet.