### PR TITLE
Point at path for landing message in templates dir

### DIFF
--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -100,12 +100,9 @@ class ServerStatus(object):
         try:
             htmlFile = open(filePath, 'r')
             html = htmlFile.read()
-        except:
-            filePath = "ga4gh/templates/landing_message.html"
-            htmlFile = open(filePath, 'r')
-            html = htmlFile.read()
-        finally:
             htmlFile.close()
+        except:
+            html = flask.render_template("landing_message.html")
         return html
 
     def getNaturalUptime(self):


### PR DESCRIPTION
While testing deployment @macieksmuga found that the running server wouldn't necessarily be able to reach the directory containing the default landing message. This caused an internal server error.

This PR fixes that case by using flask's render_template to guarantee we are looking at the proper path.