### PR TITLE
Ontologies update

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -266,7 +266,8 @@ class FileSystemDataset(Dataset):
                 # Variant annotations sets
                 for vas in variantSet.getVariantAnnotationSets():
                     vas.setSequenceOntologyTermMap(
-                        dataRepository.getOntologyTermMap("sequence_ontology"))
+                        dataRepository.getOntologyTermMapByName(
+                            "sequence_ontology"))
         # Reads
         readGroupSetDir = os.path.join(dataDir, self.readsDirName)
         for filename in os.listdir(readGroupSetDir):
@@ -285,7 +286,7 @@ class FileSystemDataset(Dataset):
             if fnmatch.fnmatch(filename, '*.db'):
                 localId, _ = os.path.splitext(filename)
                 fullPath = os.path.join(featureSetDir, filename)
-                sequenceOntology = dataRepository.getOntologyTermMap(
+                sequenceOntology = dataRepository.getOntologyTermMapByName(
                     "sequence_ontology")
                 featureSet = sequenceAnnotations.Gff3DbFeatureSet(
                     self, localId)

--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -199,7 +199,8 @@ class SimulatedDataset(Dataset):
             numAlignments=1, numFeatureSets=1):
         super(SimulatedDataset, self).__init__(localId)
         self._description = "Simulated dataset {}".format(localId)
-        sequenceOntology = ontologies.Ontology("sequence_ontology")
+        # TODO create a simulated OntologyTermMap
+        sequenceOntology = ontologies.OntologyTermMap("sequence_ontology")
         # TODO add some terms into the simualated sequence ontology
         # Variants
         for i in range(numVariantSets):
@@ -210,7 +211,7 @@ class SimulatedDataset(Dataset):
             self.addVariantSet(variantSet)
             variantAnnotationSet = variants.SimulatedVariantAnnotationSet(
                 variantSet, "simVas{}".format(i), seed)
-            variantAnnotationSet.setSequenceOntology(sequenceOntology)
+            variantAnnotationSet.setSequenceOntologyTermMap(sequenceOntology)
             variantSet.addVariantAnnotationSet(variantAnnotationSet)
         # Reads
         for i in range(numReadGroupSets):
@@ -264,8 +265,8 @@ class FileSystemDataset(Dataset):
                 self.addVariantSet(variantSet)
                 # Variant annotations sets
                 for vas in variantSet.getVariantAnnotationSets():
-                    vas.setSequenceOntology(
-                        dataRepository.getOntology("sequence_ontology"))
+                    vas.setSequenceOntologyTermMap(
+                        dataRepository.getOntologyTermMap("sequence_ontology"))
         # Reads
         readGroupSetDir = os.path.join(dataDir, self.readsDirName)
         for filename in os.listdir(readGroupSetDir):
@@ -284,11 +285,11 @@ class FileSystemDataset(Dataset):
             if fnmatch.fnmatch(filename, '*.db'):
                 localId, _ = os.path.splitext(filename)
                 fullPath = os.path.join(featureSetDir, filename)
-                sequenceOntology = dataRepository.getOntology(
+                sequenceOntology = dataRepository.getOntologyTermMap(
                     "sequence_ontology")
                 featureSet = sequenceAnnotations.Gff3DbFeatureSet(
                     self, localId)
                 featureSet.setReferenceSet(referenceSet)
-                featureSet.setSequenceOntology(sequenceOntology)
+                featureSet.setSequenceOntologyTermMap(sequenceOntology)
                 featureSet.populateFromFile(fullPath)
                 self.addFeatureSet(featureSet)

--- a/ga4gh/datamodel/ontologies.py
+++ b/ga4gh/datamodel/ontologies.py
@@ -18,9 +18,10 @@ class OntologyTermMap(object):
     ontology object.
     """
     def __init__(self, localId):
+        # TODO The instance variables need to be refactored here.
         self._localId = localId
+        self._sourceName = localId
         self._dataUrl = None
-        self._sourceName = None
         self._nameIdMap = dict()
         self._idNameMap = dict()
 
@@ -31,9 +32,6 @@ class OntologyTermMap(object):
         specified file.
         """
         self._dataUrl = dataUrl
-        # TODO shouldn't sourceName be the name of the ontology, (e.g,
-        # sequence_ontology?)
-        self._sourceName = self._dataUrl
         self._readFile()
 
     def populateFromRow(self, row):
@@ -41,12 +39,9 @@ class OntologyTermMap(object):
         Populates this Ontology using values in the specified DB row.
         """
         self._dataUrl = row[b'dataUrl']
-        # TODO shouldn't sourceName be the name of the ontology, (e.g,
-        # sequence_ontology?)
-        self._sourceName = self._dataUrl
         self._readFile()
 
-    def add(self, id_, name):
+    def _add(self, id_, name):
         """
         Adds an ontology term (id, name pair)
 
@@ -84,7 +79,6 @@ class OntologyTermMap(object):
         term = protocol.OntologyTerm()
         term.term = name
         term.id = self.getId(name)
-        # TODO set source name smarter
         term.sourceName = self._sourceName
         # TODO how do we get the right version?
         term.sourceVersion = None
@@ -107,9 +101,8 @@ class OntologyTermMap(object):
         return term
 
     def _readFile(self):
-        self._sourceName = self._dataUrl
         with open(self._dataUrl) as f:
             for line in f:
                 # File format: id \t name
                 fields = line.rstrip().split("\t")
-                self.add(fields[0], fields[1])
+                self._add(fields[0], fields[1])

--- a/ga4gh/datamodel/sequenceAnnotations.py
+++ b/ga4gh/datamodel/sequenceAnnotations.py
@@ -316,16 +316,16 @@ class Gff3DbFeatureSet(AbstractFeatureSet):
     """
     def __init__(self, parentContainer, localId):
         super(Gff3DbFeatureSet, self).__init__(parentContainer, localId)
-        self._sequenceOntology = None
+        self._sequenceOntologyTermMap = None
         self._dbFilePath = None
         self._db = None
 
-    def setSequenceOntology(self, sequenceOntology):
+    def setSequenceOntologyTermMap(self, sequenceOntologyTermMap):
         """
-        Sets the sequence ontology instance used by this FeatureSet to the
+        Sets the OntologyTermMap instance used by this FeatureSet to the
         specified value.
         """
-        self._sequenceOntology = sequenceOntology
+        self._sequenceOntologyTermMap = sequenceOntologyTermMap
 
     def populateFromFile(self, dataUrl):
         """
@@ -391,8 +391,8 @@ class Gff3DbFeatureSet(AbstractFeatureSet):
         gaFeature.childIds = map(
                 self.getCompoundIdForFeatureId,
                 json.loads(feature['child_ids']))
-        gaFeature.featureType = \
-            self._sequenceOntology.getGaTermByName(feature['type'])
+        gaFeature.featureType = self._sequenceOntologyTermMap.getGaTermByName(
+                feature['type'])
         gaFeature.attributes = protocol.Attributes()
         gaFeature.attributes.vals = json.loads(feature['attributes'])
         return gaFeature

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -773,19 +773,20 @@ class AbstractVariantAnnotationSet(datamodel.DatamodelObject):
     def __init__(self, variantSet, localId):
         super(AbstractVariantAnnotationSet, self).__init__(variantSet, localId)
         self._variantSet = variantSet
-        self._sequenceOntology = None
+        self._sequenceOntologyTermMap = None
         self._analysis = None
         # TODO these should be set from the DB, not created on
         # instantiation.
         self._creationTime = datetime.datetime.now().isoformat() + "Z"
         self._updatedTime = datetime.datetime.now().isoformat() + "Z"
 
-    def setSequenceOntology(self, sequenceOntology):
+    def setSequenceOntologyTermMap(self, sequenceOntologyTermMap):
         """
-        Sets the sequence ontology object used in this VariantAnnotationSet
-        to the specified value.
+        Sets the OntologyTermMap used in this VariantAnnotationSet to
+        translate sequence ontology term names into IDs to the
+        specified value.
         """
-        self._sequenceOntology = sequenceOntology
+        self._sequenceOntologyTermMap = sequenceOntologyTermMap
 
     def getAnalysis(self):
         """
@@ -1304,7 +1305,7 @@ class HtslibVariantAnnotationSet(AbstractVariantAnnotationSet):
         for soName in seqOntTerms:
             so = self._createGaOntologyTermSo()
             so.term = soName
-            so.id = self._sequenceOntology.getId(soName, "")
+            so.id = self._sequenceOntologyTermMap.getId(soName, "")
             soTerms.append(so)
         return soTerms
 

--- a/ga4gh/datarepo.py
+++ b/ga4gh/datarepo.py
@@ -55,12 +55,12 @@ class AbstractDataRepository(object):
         self._referenceSetNameMap[referenceSet.getLocalId()] = referenceSet
         self._referenceSetIds.append(id_)
 
-    def addOntology(self, ontology):
+    def addOntologyTermMap(self, ontologyTermMap):
         """
-        Add an ontology map to this data repository.
+        Add an ontologyTermMap map to this data repository.
         """
-        name = ontology.getLocalId()
-        self._ontologyNameMap[name] = ontology
+        name = ontologyTermMap.getLocalId()
+        self._ontologyNameMap[name] = ontologyTermMap
         self._ontologyNames.append(name)
 
     def getDatasets(self):
@@ -110,15 +110,15 @@ class AbstractDataRepository(object):
         """
         return len(self._referenceSetIds)
 
-    def getOntology(self, name):
+    def getOntologyTermMap(self, name):
         """
-        Returns an ontology map by name
+        Returns an ontologyTermMap by name
         """
-        return self._ontologyNameMap.get(name, None)
+        return self._ontologyNameMap[name]
 
-    def getOntologys(self):
+    def getOntologyTermMaps(self):
         """
-        Returns all ontology maps in the repo
+        Returns all ontologyTermMaps in the repo
         """
         return [self._ontologyNameMap[name] for name in self._ontologyNames]
 
@@ -400,33 +400,38 @@ class SqlDataRepository(AbstractDataRepository):
         self._creationTimeStamp = config["creationTimeStamp"]
 
     def _createOntologyTable(self, cursor):
+        # Right now we support a crude ontology term name-ID bidirectional
+        # map. However, in the future we will want to have better ontology
+        # support. Therefore we're not making the SQL schema too specific
+        # so that we can make this transition without needing backwards
+        # incompatible schema changes.
         sql = """
-            CREATE TABLE Ontology (
+            CREATE TABLE Ontology(
                 name TEXT NOT NULL PRIMARY KEY,
                 dataUrl TEXT NOT NULL
             );
         """
         cursor.execute(sql)
 
-    def insertOntology(self, ontology):
+    def insertOntologyTermMap(self, ontologyTermMap):
         """
-        Inserts the specified ontology into this repository.
+        Inserts the specified ontologyTermMap into this repository.
         """
         sql = """
-            INSERT INTO Ontology (name, dataUrl)
+            INSERT INTO Ontology(name, dataUrl)
             VALUES (?, ?);
         """
         cursor = self._dbConnection.cursor()
         cursor.execute(sql, (
-            ontology.getLocalId(), ontology.getDataUrl()))
+            ontologyTermMap.getLocalId(), ontologyTermMap.getDataUrl()))
 
-    def _readOntologyTable(self, cursor):
+    def _readOntologyTermMapTable(self, cursor):
         cursor.row_factory = sqlite3.Row
         cursor.execute("SELECT * FROM Ontology;")
         for row in cursor:
-            ontology = ontologies.Ontology(row[b'name'])
-            ontology.populateFromRow(row)
-            self.addOntology(ontology)
+            ontologyTermMap = ontologies.OntologyTermMap(row[b'name'])
+            ontologyTermMap.populateFromRow(row)
+            self.addOntologyTermMap(ontologyTermMap)
 
     def _createReferenceTable(self, cursor):
         sql = """
@@ -899,8 +904,8 @@ class SqlDataRepository(AbstractDataRepository):
             featureSet = sequenceAnnotations.Gff3DbFeatureSet(
                 dataset, row[b'name'])
             featureSet.setReferenceSet(referenceSet)
-            featureSet.setSequenceOntology(
-                self.getOntology('sequence_ontology'))
+            featureSet.setSequenceOntologyTermMap(
+                self.getOntologyTermMap('sequence_ontology'))
             featureSet.populateFromRow(row)
             assert featureSet.getId() == row[b'id']
             dataset.addFeatureSet(featureSet)
@@ -947,7 +952,7 @@ class SqlDataRepository(AbstractDataRepository):
         with sqlite3.connect(self._dbFilename) as db:
             cursor = db.cursor()
             self._readSystemTable(cursor)
-            self._readOntologyTable(cursor)
+            self._readOntologyTermMapTable(cursor)
             self._readReferenceSetTable(cursor)
             self._readReferenceTable(cursor)
             self._readDatasetTable(cursor)
@@ -994,10 +999,10 @@ class FileSystemDataRepository(AbstractDataRepository):
                 for filename in os.listdir(relativePath):
                     if filename.endswith(".txt"):
                         name = filename.split(".")[0]
-                        ontology = ontologies.Ontology(name)
-                        ontology.populateFromFile(
+                        ontologyTermMap = ontologies.OntologyTermMap(name)
+                        ontologyTermMap.populateFromFile(
                             os.path.join(relativePath, filename))
-                        self.addOntology(ontology)
+                        self.addOntologyTermMap(ontologyTermMap)
 
         sourceDir = os.path.join(self._dataDir, self.datasetsDirName)
         for setName in os.listdir(sourceDir):

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -338,6 +338,15 @@ class DatasetNameNotFoundException(NotFoundException):
         self.message = "Dataset with name '{0}' not found".format(name)
 
 
+class OntologyNameNotFoundException(NotFoundException):
+    """
+    Indicates a request was made for an Ontology with a name that
+    does not exist.
+    """
+    def __init__(self, name):
+        self.message = "Ontology with name '{0}' not found".format(name)
+
+
 class FeatureSetNotFoundException(NotFoundException):
     def __init__(self, featureSetId):
         self.message = (

--- a/tests/datadriven/test_sequenceAnnotations.py
+++ b/tests/datadriven/test_sequenceAnnotations.py
@@ -111,7 +111,7 @@ class FeatureSetTests(datadriven.DataDrivenTest):
         """
         self._dataset = datasets.Dataset(_datasetName)
         self._repo = datarepo.FileSystemDataRepository("tests/data")
-        self._sequenceOntologyTermMap = self._repo.getOntologyTermMap(
+        self._sequenceOntologyTermMap = self._repo.getOntologyTermMapByName(
             "sequence_ontology")
         self._referenceSet = references.AbstractReferenceSet("test_rs")
         featureSetLocalName = featureSetLocalName[:-3]  # remove '.db'

--- a/tests/datadriven/test_sequenceAnnotations.py
+++ b/tests/datadriven/test_sequenceAnnotations.py
@@ -111,7 +111,8 @@ class FeatureSetTests(datadriven.DataDrivenTest):
         """
         self._dataset = datasets.Dataset(_datasetName)
         self._repo = datarepo.FileSystemDataRepository("tests/data")
-        self._sequenceOntology = self._repo.getOntology("sequence_ontology")
+        self._sequenceOntologyTermMap = self._repo.getOntologyTermMap(
+            "sequence_ontology")
         self._referenceSet = references.AbstractReferenceSet("test_rs")
         featureSetLocalName = featureSetLocalName[:-3]  # remove '.db'
         self._testData = _testDataForFeatureSetName[featureSetLocalName]
@@ -123,7 +124,7 @@ class FeatureSetTests(datadriven.DataDrivenTest):
     def getDataModelInstance(self, localId, dataPath):
         featureSet = sequenceAnnotations.Gff3DbFeatureSet(
             self._dataset, localId)
-        featureSet.setSequenceOntology(self._sequenceOntology)
+        featureSet.setSequenceOntologyTermMap(self._sequenceOntologyTermMap)
         featureSet.setReferenceSet(self._referenceSet)
         featureSet.populateFromFile(dataPath)
         return featureSet

--- a/tests/datadriven/test_variant_annotations.py
+++ b/tests/datadriven/test_variant_annotations.py
@@ -116,9 +116,10 @@ class VariantAnnotationSetTest(datadriven.DataDrivenTest):
         referenceSet = references.AbstractReferenceSet("rs")
         variantSet.setReferenceSet(referenceSet)
         if variantSet.isAnnotated():
-            sequenceOntology = ontologies.Ontology("sequence_ontology")
+            sequenceOntology = ontologies.OntologyTermMap(
+                "sequence_ontology")
             annotationSet = variantSet.getVariantAnnotationSets()[0]
-            annotationSet.setSequenceOntology(sequenceOntology)
+            annotationSet.setSequenceOntologyTermMap(sequenceOntology)
             return annotationSet
         else:
             return variantSet

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -378,22 +378,21 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEquals(args.runner, "removeVariantSet")
         self.assertEquals(args.force, False)
 
-    def testAddOntologyMap(self):
-        cliInput = "add-ontologymap {} {}".format(
+    def testAddOntology(self):
+        cliInput = "add-ontology {} {}".format(
             self.repoPath, self.filePath)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.filePath, self.filePath)
-        self.assertEquals(args.runner, "addOntologyMap")
+        self.assertEquals(args.runner, "addOntology")
 
-    def testRemoveOntologyMap(self):
-        ontologyMapName = "ontologyMap"
-        cliInput = "remove-ontologymap {} {}".format(
-            self.repoPath, ontologyMapName)
+    def testRemoveOntology(self):
+        ontologyName = "the_ontology_name"
+        cliInput = "remove-ontology {} {}".format(self.repoPath, ontologyName)
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
-        self.assertEquals(args.ontologyMapName, ontologyMapName)
-        self.assertEquals(args.runner, "removeOntologyMap")
+        self.assertEquals(args.ontologyName, ontologyName)
+        self.assertEquals(args.runner, "removeOntology")
         self.assertEquals(args.force, False)
 
 

--- a/tests/unit/test_variant_annotations.py
+++ b/tests/unit/test_variant_annotations.py
@@ -31,8 +31,8 @@ class TestHtslibVariantAnnotationSet(unittest.TestCase):
         self._variantSet.populateFromDirectory(vcfDir)
         self._variantAnnotationSet = variants.HtslibVariantAnnotationSet(
             self._variantSet, "testVAs")
-        self._variantAnnotationSet.setSequenceOntology(
-            self._repo.getOntology("sequence_ontology"))
+        self._variantAnnotationSet.setSequenceOntologyTermMap(
+            self._repo.getOntologyTermMap("sequence_ontology"))
 
     def setUp(self):
         vcfDir = "tests/data/datasets/dataset1/variants/WASH7P_annotation"

--- a/tests/unit/test_variant_annotations.py
+++ b/tests/unit/test_variant_annotations.py
@@ -32,7 +32,7 @@ class TestHtslibVariantAnnotationSet(unittest.TestCase):
         self._variantAnnotationSet = variants.HtslibVariantAnnotationSet(
             self._variantSet, "testVAs")
         self._variantAnnotationSet.setSequenceOntologyTermMap(
-            self._repo.getOntologyTermMap("sequence_ontology"))
+            self._repo.getOntologyTermMapByName("sequence_ontology"))
 
     def setUp(self):
         vcfDir = "tests/data/datasets/dataset1/variants/WASH7P_annotation"


### PR DESCRIPTION
Depends on #1104.

Makes two changes:

1. Change the Ontology/OntologyMap object to  OntologyTermMap internally. This is supposed to model what it's doing a bit better. The current setup is rather brittle and will need to be improved, but this at least makes it a bit clearer what's going on (I hope).
2. Ported the CLI support for ontologies to the SQL repo.  The SQL schema and CLI used the term Ontology rather than OntologyTermMap because it seems that the current approach is quite
limited and will need to be changed. This seems more forward compatible, since we don't want to affect uses by making them change CLI syntax or make backwards incompatible changes to the schema.

I would imagine that we would want to update the CLI ``add-ontology`` command to download the map from some authoritative source, and store the terms in the DB. Asking the repo administrator to create a text file mapping the term names to IDs is pretty user-unfriendly. I don't think we should tackle this now, I'm just giving my reasoning for not fully pushing the OntologyTermMap nomenclature into the repo mangement UI.

Issue #1111.