### PR TITLE
Sql repo variants

### DIFF
--- a/ga4gh/datamodel/datasets.py
+++ b/ga4gh/datamodel/datasets.py
@@ -28,6 +28,7 @@ class Dataset(datamodel.DatamodelObject):
         self._description = None
         self._variantSetIds = []
         self._variantSetIdMap = {}
+        self._variantSetNameMap = {}
         self._featureSetIds = []
         self._featureSetIdMap = {}
         self._featureSetNameMap = {}
@@ -54,6 +55,7 @@ class Dataset(datamodel.DatamodelObject):
         """
         id_ = variantSet.getId()
         self._variantSetIdMap[id_] = variantSet
+        self._variantSetNameMap[variantSet.getLocalId()] = variantSet
         self._variantSetIds.append(id_)
 
     def addFeatureSet(self, featureSet):
@@ -108,6 +110,15 @@ class Dataset(datamodel.DatamodelObject):
         Returns the variant set at the specified index in this dataset.
         """
         return self._variantSetIdMap[self._variantSetIds[index]]
+
+    def getVariantSetByName(self, name):
+        """
+        Returns a VariantSet with the specified name, or raises a
+        VariantSetNameNotFoundException if it does not exist.
+        """
+        if name not in self._variantSetNameMap:
+            raise exceptions.VariantSetNameNotFoundException(name)
+        return self._variantSetNameMap[name]
 
     def getFeatureSets(self):
         """

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -410,6 +410,12 @@ class HtslibVariantSet(datamodel.PysamDatamodelMixin, AbstractVariantSet):
         """
         return self._chromFileMap
 
+    def getDataUrlIndexPairs(self):
+        """
+        Returns the set of (dataUrl, indexFile) pairs.
+        """
+        return set(self._chromFileMap.values())
+
     def populateFromRow(self, row):
         """
         Populates this VariantSet from the specified DB row.
@@ -452,6 +458,13 @@ class HtslibVariantSet(datamodel.PysamDatamodelMixin, AbstractVariantSet):
             dataFiles.append(vcfFile)
             indexFiles.append(vcfFile + ".tbi")
         self.populateFromFile(dataFiles, indexFiles)
+
+    def getVcfHeaderReferenceSetName(self):
+        """
+        Returns the name of the reference set from the VCF header.
+        """
+        # TODO implemenent
+        return None
 
     def checkConsistency(self):
         """

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -302,6 +302,15 @@ class CallSetNameNotFoundException(NotFoundException):
         self.message = "CallSet with name '{0}' not found".format(name)
 
 
+class VariantSetNameNotFoundException(NotFoundException):
+    """
+    Indicates a request was made for a VariantSet with a name that
+    does not exist.
+    """
+    def __init__(self, name):
+        self.message = "VariantSet with name '{0}' not found".format(name)
+
+
 class ReadGroupSetNameNotFoundException(NotFoundException):
     """
     Indicates a request was made for a ReadGroupSet with a name that

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -337,7 +337,7 @@ class TestRepoManagerCli(unittest.TestCase):
 
     def testAddReadGroupSetWithIndexFile(self):
         indexPath = self.filePath + ".bai"
-        cliInput = "add-readgroupset {} {} {} {}".format(
+        cliInput = "add-readgroupset {} {} {} -I {}".format(
             self.repoPath, self.datasetName, self.filePath,
             indexPath)
         args = self.parser.parse_args(cliInput.split())
@@ -364,7 +364,23 @@ class TestRepoManagerCli(unittest.TestCase):
         args = self.parser.parse_args(cliInput.split())
         self.assertEquals(args.repoPath, self.repoPath)
         self.assertEquals(args.datasetName, self.datasetName)
-        self.assertEquals(args.filePath, self.filePath)
+        self.assertEquals(args.dataFiles, [self.filePath])
+        self.assertEquals(args.indexFiles, None)
+        self.assertEquals(args.runner, "addVariantSet")
+
+    def testAddVariantSetWithIndexFiles(self):
+        file1 = "file1"
+        file2 = "file2"
+        indexFile1 = file1 + ".tbi"
+        indexFile2 = file2 + ".tbi"
+        cliInput = "add-variantset {} {} {} {} -I {} {}".format(
+            self.repoPath, self.datasetName, file1, file2,
+            indexFile1, indexFile2)
+        args = self.parser.parse_args(cliInput.split())
+        self.assertEquals(args.repoPath, self.repoPath)
+        self.assertEquals(args.datasetName, self.datasetName)
+        self.assertEquals(args.dataFiles, [file1, file2])
+        self.assertEquals(args.indexFiles, [indexFile1, indexFile2])
         self.assertEquals(args.runner, "addVariantSet")
 
     def testRemoveVariantSet(self):


### PR DESCRIPTION
Depends on #1117 (and #1104 ...). Just look at the last commit for the changes for this PR.

Adds support for variants to the SQL repo and repo manager. The CLI should be quite flexible now, and there's room for it to become more useful. Here's the CLI help:
```
usage: repo_dev.py add-variantset [-h] [-I indexFiles [indexFiles ...]]
                                  [-n NAME] [-R REFERENCESETNAME]
                                  repoPath datasetName dataFiles
                                  [dataFiles ...]

Add a variant set to the data repo based on one or more VCF files.

positional arguments:
  repoPath              the file path of the data repository
  datasetName           the name of the dataset
  dataFiles             The VCF/BCF files representing the new VariantSet.
                        These may be specified either one or more paths to
                        local files or remote URLS, or as a path to a local
                        directory containing VCF files. Either a single
                        directory argument may be passed or a list of file
                        paths/URLS, but not a mixture of directories and
                        paths.

optional arguments:
  -h, --help            show this help message and exit
  -I indexFiles [indexFiles ...], --indexFiles indexFiles [indexFiles ...]
                        The index files for the VCF/BCF files provided in the
                        dataFiles argument. These must be provided in the same
                        order as the data files.
  -n NAME, --name NAME  The name of the VariantSet
  -R REFERENCESETNAME, --referenceSetName REFERENCESETNAME
                        the name of the reference set to associate with this
                        VariantSet
```

The idea is that the manager should just do the right thing, depending on what you give it. The basic functionality has been tested, but there's a fair number of gaps to fill in in terms of the common user errors.

The major issue that's popping up now is, how do we deal with the explicit dependency on the ``sequence_ontology`` OntologyTermMap? This is an important usability consideration that we need to make nice and simple. We should probably do this after merging into master, as it's already quite a lot better than the current state of affairs.