### PR TITLE
Updated documentation for SQL repo.

### DIFF
--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -59,8 +59,8 @@ Now we can download some example data, which we'll use for our demo:
 
 .. code-block:: bash
 
-    (ga4gh-env) $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar
-    (ga4gh-env) $ tar -xvf ga4gh-example-data-v3.0.tar
+    (ga4gh-env) $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v4.0.tar
+    (ga4gh-env) $ tar -xvf ga4gh-example-data-v4.0.tar
 
 After extracting the data, we can then run the ``ga4gh_server`` application:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,8 +62,8 @@ Download and unpack the example data:
 
 .. code-block:: bash
 
-  $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v3.2.tar
-  $ tar -xf ga4gh-example-data-v3.2.tar
+  $ wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data-v4.0.tar
+  $ tar -xf ga4gh-example-data-v4.0.tar
 
 Create the WSGI file at ``/srv/ga4gh/application.wsgi`` and write the following
 contents:
@@ -108,7 +108,7 @@ Restart Apache:
   $ sudo service apache2 restart
 
 We will now test to see the server started properly by requesting the
-landing page. 
+landing page.
 
 .. code-block:: bash
 
@@ -117,7 +117,7 @@ landing page.
     #    <h2>GA4GH reference server 0.2.3.dev4+nge0b07f3</h2>
     # Welcome to the GA4GH reference server landing page! This page describes
 
-We can also test the server by running some API commands. Please refer to 
+We can also test the server by running some API commands. Please refer to
 the instructions in the :ref:`demo` for how to access data made available
 by this server.
 


### PR DESCRIPTION
- Removed inaccurate information about file hierarchy
- Updated links to ga4gh-example-data.

We'll want to make a much better job of documenting the repo manager soon (with a nice tutorial on how to set up a repo). This change basically means the information is not inaccurate, although it is quite incomplete.