### PR TITLE
Handle non-ascii characters in compound ids

### DIFF
--- a/ga4gh/datamodel/__init__.py
+++ b/ga4gh/datamodel/__init__.py
@@ -154,7 +154,9 @@ class CompoundId(object):
             localIds = localIds[:differentiatorIndex] + tuple([
                 self.differentiator]) + localIds[differentiatorIndex:]
         for field, localId in zip(self.fields[index:], localIds):
-            encodedLocalId = self.encode(str(localId))
+            if not isinstance(localId, basestring):
+                raise exceptions.BadIdentifierNotStringException(localId)
+            encodedLocalId = self.encode(localId)
             setattr(self, field, encodedLocalId)
         if len(localIds) != len(self.fields) - index:
             raise ValueError(
@@ -255,7 +257,8 @@ class CompoundId(object):
         fashion. This is not intended for security purposes, but rather to
         dissuade users from depending on our internal ID structures.
         """
-        return base64.urlsafe_b64encode(str(idStr)).replace(b'=', b'')
+        return unicode(base64.urlsafe_b64encode(
+            idStr.encode('utf-8')).replace(b'=', b''))
 
     @classmethod
     def deobfuscate(cls, data):
@@ -264,6 +267,9 @@ class CompoundId(object):
         If an identifier arrives without correct base64 padding this
         function will append it to the end.
         """
+        # the str() call is necessary to convert the unicode string
+        # to an ascii string since the urlsafe_b64decode method
+        # sometimes chokes on unicode strings
         return base64.urlsafe_b64decode(str((
             data + b'A=='[(len(data) - 1) % 4:])))
 

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -237,7 +237,7 @@ class AbstractVariantSet(datamodel.DatamodelObject):
         md5 = self.hashVariant(gaVariant)
         compoundId = datamodel.VariantCompoundId(
             self.getCompoundId(), gaVariant.referenceName,
-            gaVariant.start, md5)
+            str(gaVariant.start), md5)
         return str(compoundId)
 
     def getCallSetId(self, sampleName):
@@ -437,7 +437,7 @@ class SimulatedVariantAnnotationSet(AbstractVariantSet):
         md5 = self.hashVariantAnnotation(gaVariant, gaAnnotation)
         compoundId = datamodel.VariantAnnotationCompoundId(
             self.getCompoundId(), gaVariant.referenceName,
-            gaVariant.start, md5)
+            str(gaVariant.start), md5)
         return str(compoundId)
 
     def _addTranscriptEffectLocations(self, effect, ann):
@@ -1131,7 +1131,7 @@ class HtslibVariantAnnotationSet(HtslibVariantSet):
         md5 = self.hashVariantAnnotation(gaVariant, gaAnnotation)
         compoundId = datamodel.VariantAnnotationCompoundId(
             self.getCompoundId(), gaVariant.referenceName,
-            gaVariant.start, md5)
+            str(gaVariant.start), md5)
         return str(compoundId)
 
     def getVariantId(self, gaVariant):
@@ -1144,7 +1144,7 @@ class HtslibVariantAnnotationSet(HtslibVariantSet):
         md5 = self.hashVariant(gaVariant)
         compoundId = datamodel.VariantCompoundId(
             self._variantSetId, gaVariant.referenceName,
-            gaVariant.start, md5)
+            str(gaVariant.start), md5)
         return str(compoundId)
 
     def getAnalysis(self):

--- a/ga4gh/exceptions.py
+++ b/ga4gh/exceptions.py
@@ -133,6 +133,13 @@ class BadIdentifierException(BadRequestException):
             self.message += msg
 
 
+class BadIdentifierNotStringException(BadIdentifierException):
+    def __init__(self, localId):
+        self.message = (
+            "The identifier provided is not a string: '{}'".format(
+                localId))
+
+
 class InvalidJsonException(BadRequestException):
     def __init__(self, jsonString):
         self.message = "Cannot parse JSON: '{}'".format(jsonString)

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -400,7 +400,7 @@ class VariantSetTest(datadriven.DataDrivenTest):
                 md5 = self._hashVariant(variant)
                 compoundId = datamodel.VariantCompoundId(
                     variantSet.getCompoundId(), referenceName,
-                    variant.start, md5)
+                    str(variant.start), md5)
                 gotVariant = variantSet.getVariant(compoundId)
                 self.assertEqual(str(compoundId), gotVariant.id)
 
@@ -408,7 +408,7 @@ class VariantSetTest(datadriven.DataDrivenTest):
                 wrongStart = variant.end
                 compoundId = datamodel.VariantCompoundId(
                     variantSet.getCompoundId(), referenceName,
-                    wrongStart, md5)
+                    str(wrongStart), md5)
                 try:
                     gotVariant = variantSet.getVariant(compoundId)
                     self.assertNotEqual(variant.start, gotVariant.start)
@@ -418,14 +418,14 @@ class VariantSetTest(datadriven.DataDrivenTest):
                 # negative test: change reference name
                 compoundId = datamodel.VariantCompoundId(
                     variantSet.getCompoundId(), "wrong reference name",
-                    variant.start, md5)
+                    str(variant.start), md5)
                 with self.assertRaises(exceptions.ObjectNotFoundException):
                     variantSet.getVariant(compoundId)
 
                 # negative test: change hash
                 compoundId = datamodel.VariantCompoundId(
                     variantSet.getCompoundId(), referenceName,
-                    variant.start, "wrong hash")
+                    str(variant.start), "wrong hash")
                 with self.assertRaises(exceptions.ObjectNotFoundException):
                     variantSet.getVariant(compoundId)
 

--- a/tests/unit/test_compound_ids.py
+++ b/tests/unit/test_compound_ids.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests the compound ids
 """
@@ -25,6 +26,23 @@ class TestCompoundIds(unittest.TestCase):
     """
     Test the compound ids
     """
+    def testUnicode(self):
+        latin1chars = (
+            "¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑ"
+            "ÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ")
+        foo = latin1chars
+        bar = "a unicode string"
+        baz = str("an ascii string")
+        self.assertEqual(type(foo), unicode)
+        self.assertEqual(type(bar), unicode)
+        self.assertEqual(type(baz), str)
+        compoundId = ExampleCompoundId(None, foo, bar, baz)
+        self.assertEqual(type(compoundId.foo), unicode)
+        self.assertEqual(type(compoundId.bar), unicode)
+        self.assertEqual(type(compoundId.baz), unicode)
+        self.assertEqual(type(compoundId.foobar), unicode)
+        self.assertEqual(type(compoundId.foobarbaz), unicode)
+
     def testTopLevelIdsUnique(self):
         datasetId = "a"
         idStr = "b"
@@ -58,10 +76,12 @@ class TestCompoundIds(unittest.TestCase):
             self.assertEqual(idStr, decoded)
 
     def testEncodeRoundTrip(self):
-        splits = ['"a"', 'b', '"c']
+        # tests both double quote escaping and appropriate handling
+        # of non-ascii characters
+        splits = ['"å"', '字', '"c']
         compoundId = ExampleCompoundId(None, *splits)
-        self.assertEqual(compoundId.foo, '\\"a\\"')
-        self.assertEqual(compoundId.bar, 'b')
+        self.assertEqual(compoundId.foo, '\\"å\\"')
+        self.assertEqual(compoundId.bar, '字')
         self.assertEqual(compoundId.baz, '\\"c')
         obfuscated = str(compoundId)
         parsedCompoundId = ExampleCompoundId.parse(obfuscated)

--- a/tests/unit/test_references.py
+++ b/tests/unit/test_references.py
@@ -21,7 +21,7 @@ class TestAbstractReferenceSet(unittest.TestCase):
     def setUp(self):
         self._backend = backend.Backend(datarepo.AbstractDataRepository())
         self._referenceSet = references.AbstractReferenceSet(
-            self._backend)
+            'refSetId')
 
     def testAddOneReference(self):
         self.assertEqual(self._referenceSet.getNumReferences(), 0)
@@ -82,7 +82,7 @@ class TestAbstractReference(unittest.TestCase):
         self._backend = backend.Backend(
             datarepo.AbstractDataRepository())
         self._referenceSet = references.AbstractReferenceSet(
-            self._backend)
+            'refSetId')
         self._reference = references.AbstractReference(
             self._referenceSet, "ref")
 

--- a/tests/unit/test_sequence_annotations.py
+++ b/tests/unit/test_sequence_annotations.py
@@ -22,7 +22,7 @@ class TestAbstractFeatureSet(unittest.TestCase):
     def setUp(self):
         self._featureSetName = "testFeatureSet"
         self._backend = backend.Backend(datarepo.AbstractDataRepository())
-        self._dataset = datasets.AbstractDataset(self._backend)
+        self._dataset = datasets.AbstractDataset("datasetId")
         self._featureSet = features.AbstractFeatureSet(
             self._dataset, self._featureSetName)
 

--- a/tests/unit/test_variant_annotations.py
+++ b/tests/unit/test_variant_annotations.py
@@ -21,7 +21,7 @@ class TestHtslibVariantAnnotationSet(unittest.TestCase):
     def setUp(self):
         self._variantSetName = "testVariantSet"
         self._backend = datarepo.FileSystemDataRepository("tests/data")
-        self._dataset = datasets.AbstractDataset(self._backend)
+        self._dataset = datasets.AbstractDataset("datasetId")
         self._variantSet = variants.AbstractVariantSet(
             self._dataset, self._variantSetName)
         self._variantAnnotationSet = \

--- a/tests/unit/test_variants.py
+++ b/tests/unit/test_variants.py
@@ -83,7 +83,7 @@ class TestAbstractVariantSet(unittest.TestCase):
     def setUp(self):
         self._variantSetName = "testVariantSet"
         self._backend = backend.Backend(datarepo.AbstractDataRepository())
-        self._dataset = datasets.AbstractDataset(self._backend)
+        self._dataset = datasets.AbstractDataset("datasetId")
         self._variantSet = variants.AbstractVariantSet(
             self._dataset, self._variantSetName)
 
@@ -127,8 +127,8 @@ class TestAbstractVariantSet(unittest.TestCase):
                           self._variantSet.getCallSet, 617)
         self.assertRaises(exceptions.CallSetNotFoundException,
                           self._variantSet.getCallSet, None)
-        self.assertRaises(TypeError, self._variantSet.addCallSet,
-                          ['a list of', 2])
+        self.assertRaises(exceptions.BadIdentifierNotStringException,
+                          self._variantSet.addCallSet, ['a list of', 2])
         self.assertRaises(NotImplementedError,
                           self._variantSet.getNumVariants)
 


### PR DESCRIPTION
We now require that localIds must be strings

Issue #1187