### PR TITLE
explicitly set boolean to True/False

### DIFF
--- a/ga4gh/datamodel/rna_quantification.py
+++ b/ga4gh/datamodel/rna_quantification.py
@@ -70,7 +70,7 @@ class ExpressionLevel(AbstractExpressionLevel):
         self._expression = record["expression"]
         self._quantificationGroupId = record["quantification_group_id"]
         # sqlite stores booleans as int (False = 0, True = 1)
-        self._isNormalized = record["is_normalized"] != 0
+        self._isNormalized = bool(record["is_normalized"])
         self._rawReadCount = record["raw_read_count"]
         self._score = record["score"]
         self._units = record["units"]

--- a/ga4gh/datamodel/rna_quantification.py
+++ b/ga4gh/datamodel/rna_quantification.py
@@ -69,7 +69,8 @@ class ExpressionLevel(AbstractExpressionLevel):
         self._annotationId = record["annotation_id"]
         self._expression = record["expression"]
         self._quantificationGroupId = record["quantification_group_id"]
-        self._isNormalized = record["is_normalized"]
+        # sqlite stores booleans as int (False = 0, True = 1)
+        self._isNormalized = record["is_normalized"] != 0
         self._rawReadCount = record["raw_read_count"]
         self._score = record["score"]
         self._units = record["units"]


### PR DESCRIPTION
sqlite stores booleans as ints (0 or 1).  This explicitly sets boolean value to True/False rather than relying on python's type conversion which work fine internally but was causing the response JSON to contain the int value instead of a boolean value