### PR TITLE
Removes needless conversion.

### DIFF
--- a/ga4gh/datamodel/references.py
+++ b/ga4gh/datamodel/references.py
@@ -184,10 +184,7 @@ class AbstractReferenceSet(datamodel.DatamodelObject):
         which do not belong to the modeled species, e.g.  EBV in a
         human reference genome.
         """
-        if self._ncbiTaxonId is not None:
-            return int(self._ncbiTaxonId)
-        else:
-            return None
+        return self._ncbiTaxonId
 
     def toProtocolElement(self):
         """
@@ -308,10 +305,7 @@ class AbstractReference(datamodel.DatamodelObject):
         which do not belong to the modeled species, e.g.  EBV in a
         human reference genome.
         """
-        if self._ncbiTaxonId is not None:
-            return int(self._ncbiTaxonId)
-        else:
-            return None
+        return self._ncbiTaxonId
 
     def getMd5Checksum(self):
         """
@@ -460,7 +454,7 @@ class HtslibReferenceSet(datamodel.PysamDatamodelMixin, AbstractReferenceSet):
         self._assemblyId = row[b'assemblyId']
         self._isDerived = bool(row[b'isDerived'])
         self._md5checksum = row[b'md5checksum']
-        self.setNcbiTaxonId(row[b'ncbiTaxonId'])
+        self._ncbiTaxonId = row[b'ncbiTaxonId']
         self._sourceAccessions = json.loads(row[b'sourceAccessions'])
         self._sourceUri = row[b'sourceUri']
 


### PR DESCRIPTION
Removes no-op type checks from the ncbiTaxonId code path. The type of the value in the DB is integer, so the value within python must be either an integer or None. Also removes the call to `setNcbiTaxonId` as none of the other attributes did this, and there is no real difference between between ``_ncbiTaxonId`` and the rest.  Calling setters is good practise, but this should be done uniformly within the method on all attributes,  not piecemeal on one.