### PR TITLE
Proto perf

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -481,12 +481,12 @@ DEFAULT_PAGE_SIZE
     this value is used.
 
 MAX_RESPONSE_LENGTH
-    The approximate maximum size of a response sent to a client in bytes. This
-    is used to control the amount of memory that the server uses when
-    creating responses. When a client makes a search request with a given
+    The approximate maximum size of the server buffer used when creating
+    responses. This is somewhat smaller than the size of the JSON response
+    returned to the client. When a client makes a search request with a given
     page size, the server will process this query and incrementally build
     a response until (a) the number of values in the page list is equal
-    to the page size; (b) the size of the serialised response in bytes
+    to the page size; (b) the size of the internal buffer in bytes
     is >= MAX_RESPONSE_LENGTH; or (c) there are no more results left in the
     query.
 

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -899,9 +899,8 @@ class SimulatedVariantAnnotationSet(AbstractVariantAnnotationSet):
         ann.variant_id = variant.id
         ann.create_date_time = self._creationTime
         # make a transcript effect for each alternate base element
-        # multiplied by a random integer (0,5)
-
-        for i in xrange(randomNumberGenerator.randint(0, 5)):
+        # multiplied by a random integer (1,5)
+        for i in range(randomNumberGenerator.randint(1, 5)):
             for base in variant.alternate_bases:
                 ann.transcript_effects.add().CopyFrom(
                     self.generateTranscriptEffect(

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -71,17 +71,20 @@ class SearchResponseBuilderTest(unittest.TestCase):
             valueList = getattr(instance, getValueListName(responseClass))
             self.assertEqual(len(valueList), pageSize)
 
-    def testMaxResponseLengthOverridesPageSize(self):
+    def testMaxBufferSizeOverridesPageSize(self):
         responseClass = protocol.SearchVariantsResponse
-        valueClass = protocol.Variant
-        typicalValue = valueClass()
-        typicalValueLength = len(protocol.toJson(typicalValue))
+        typicalValue = protocol.Variant()
+        # We have to put some values in here or it will have zero length.
+        typicalValue.start = 1
+        typicalValue.end = 2
+        typicalValue.reference_bases = "AAAAAAAA"
+        typicalValueLength = typicalValue.ByteSize()
         for numValues in range(1, 10):
-            maxResponseLength = numValues * typicalValueLength
+            maxBufferSize = numValues * typicalValueLength
             builder = protocol.SearchResponseBuilder(
-                responseClass, 1000, maxResponseLength)
+                responseClass, 1000, maxBufferSize)
             self.assertEqual(
-                maxResponseLength, builder.getMaxResponseLength())
+                maxBufferSize, builder.getMaxBufferSize())
             while not builder.isFull():
                 builder.addValue(typicalValue)
             instance = protocol.fromJson(builder.getSerializedResponse(),

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -635,7 +635,6 @@ class TestSimulatedStack(unittest.TestCase):
 
         request.effects.add().id = "ThisIsNotAnEffect"
 
-        # request.effects.extend([{"id": "ThisIsNotAnEffect"}])
         response = self.sendJsonPostRequest(path, protocol.toJson(request))
         responseData = protocol.fromJson(response.data, protocol.
                                          SearchVariantAnnotationsResponse)


### PR DESCRIPTION
Brings server_benchmark up to date, and improves response generation efficiency for protobuf.

Before:
```
jk@holly$ python scripts/server_benchmark.py --profile none WyIxa2ctcDMtc3Vic2V0IiwidnMiLCJtdm5jYWxsIl0
1.929188
```
After:
```
jk@holly$ python scripts/server_benchmark.py --profile none WyIxa2ctcDMtc3Vic2V0IiwidnMiLCJtdm5jYWxsIl0
0.392116
```