### PR TITLE
Fixes #715

### DIFF
--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -129,14 +129,15 @@ class TestSimulatedStack(unittest.TestCase):
         self.assertEqual(gaVariantSet.id, variantSet.getId())
         self.assertEqual(gaVariantSet.dataset_id, dataset.getId())
         self.assertEqual(gaVariantSet.name, variantSet.getLocalId())
-        # TODO verify the metadata and other attributes.
+        self.assertItemsEqual(gaVariantSet.metadata, variantSet.getMetadata())
 
     def verifyCallSetsEqual(self, gaCallSet, callSet):
         variantSet = callSet.getParentContainer()
         self.assertEqual(gaCallSet.id, callSet.getId())
         self.assertEqual(gaCallSet.name, callSet.getLocalId())
         self.assertEqual(gaCallSet.variant_set_ids, [variantSet.getId()])
-        # TODO add some simulated info and check
+        for key, value in gaCallSet.info.items():
+            self.assertEqual(value[0], callSet.getInfo()[key])
 
     def verifyReadGroupSetsEqual(self, gaReadGroupSet, readGroupSet):
         dataset = readGroupSet.getParentContainer()


### PR DESCRIPTION
- Adds metadata for simulated VariantSets
- Adds info onto Callset object

It looked like metadata was being added to the VariantSet twice (variants.py:220-222). I removed the later, but I wasn't sure if the intent was exactly the same as in the extend call above. In any case, how it was would fail in testing.

Also, double check if how I'm adding the info dict onto CallSet is how you want to do this. I wasn't really sure what you had in mind, so I just took a stab at it by building out the CallSet class with the field.

