### PR TITLE
Makes file path explictly relative during test db build

### DIFF
--- a/scripts/build_test_data.py
+++ b/scripts/build_test_data.py
@@ -18,7 +18,7 @@ def run(*args):
 
 
 def main():
-    prefix = "tests/data"
+    prefix = "./tests/data"
     repoFile = os.path.join(prefix, "repo.db")
     sequenceOntologyName = "so-xp-simple"
     run("init", "-f", repoFile)


### PR DESCRIPTION
I think this should be cross-platform. Using a `./` forces it to be relative. Before `os.path.join` was returning an absolute path on Linux.