### PR TITLE
Search features by gene symbol and name

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -690,7 +690,7 @@ class Backend(object):
         return featureSet.getFeatures(
             request.reference_name, request.start, request.end,
             request.page_token, request.page_size,
-            request.feature_types, parentId)
+            request.feature_types, parentId, request.name, request.gene_symbol)
 
     def callSetsGenerator(self, request):
         """

--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -687,8 +687,14 @@ class Backend(object):
         dataset = self.getDataRepository().getDataset(
             compoundId.dataset_id)
         featureSet = dataset.getFeatureSet(compoundId.feature_set_id)
+        if request.start == request.end and request.start == 0:
+            start = None
+            end = None
+        else:
+            start = request.start
+            end = request.end
         return featureSet.getFeatures(
-            request.reference_name, request.start, request.end,
+            request.reference_name, start, end,
             request.page_token, request.page_size,
             request.feature_types, parentId, request.name, request.gene_symbol)
 

--- a/ga4gh/datamodel/sequenceAnnotations.py
+++ b/ga4gh/datamodel/sequenceAnnotations.py
@@ -77,7 +77,8 @@ class Gff3DbBackend(sqliteBackend.SqliteBackedDataSource):
 
     def countFeaturesSearchInDb(
             self, referenceName=None, start=0, end=0,
-            parentId=None, featureTypes=None):
+            parentId=None, featureTypes=None,
+            name=None, geneSymbol=None):
         """
         Same parameters as searchFeaturesInDb,
         except without the pagetoken/size.
@@ -104,7 +105,8 @@ class Gff3DbBackend(sqliteBackend.SqliteBackedDataSource):
     def searchFeaturesInDb(
             self, pageToken=0, pageSize=None,
             referenceName=None, start=0, end=0,
-            parentId=None, featureTypes=None):
+            parentId=None, featureTypes=None,
+            name=None, geneSymbol=None):
         """
         Perform a full features query in database.
 
@@ -412,7 +414,8 @@ class Gff3DbFeatureSet(AbstractFeatureSet):
 
     def getFeatures(self, referenceName, start, end,
                     pageToken, pageSize,
-                    featureTypes=None, parentId=None):
+                    featureTypes=None, parentId=None,
+                    name=None, geneSymbol=None):
         """
         method passed to runSearchRequest to fulfill the request
         :param str referenceName: name of reference (ex: "chr1")
@@ -422,6 +425,8 @@ class Gff3DbFeatureSet(AbstractFeatureSet):
         :param pageSize: none or castable to int
         :param featureTypes: array of str
         :param parentId: none or featureID of parent
+        :param name: the name of the feature
+        :param geneSymbol: the symbol for the gene the features are on
         :return: yields a protocol.Feature at a time, together with
             the corresponding nextPageToken (which is null for the last
             feature served out).
@@ -437,12 +442,14 @@ class Gff3DbFeatureSet(AbstractFeatureSet):
             featuresCount = dataSource.countFeaturesSearchInDb(
                 referenceName=referenceName,
                 start=start, end=end,
-                parentId=parentId, featureTypes=featureTypes)
+                parentId=parentId, featureTypes=featureTypes,
+                name=name, geneSymbol=geneSymbol)
             featuresReturned = dataSource.searchFeaturesInDb(
                 pageToken, pageSize,
                 referenceName=referenceName,
                 start=start, end=end,
-                parentId=parentId, featureTypes=featureTypes)
+                parentId=parentId, featureTypes=featureTypes,
+                name=name, geneSymbol=geneSymbol)
 
         # pagination logic: None if last feature was returned,
         # else 1 + row number being returned (starting at row 0).

--- a/ga4gh/datamodel/sequenceAnnotations.py
+++ b/ga4gh/datamodel/sequenceAnnotations.py
@@ -127,6 +127,7 @@ class Gff3DbBackend(sqliteBackend.SqliteBackedDataSource):
             sql += ") "
             sql_args += tuple(kwargs.get('featureTypes'))
         sql_rows += sql
+        sql_rows += "ORDER BY reference_name, start, end ASC "
         sql_count += sql
         return sql_rows, sql_count, sql_args
 

--- a/ga4gh/sequence_annotation_service_pb2.py
+++ b/ga4gh/sequence_annotation_service_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/sequence_annotation_service.proto',
   package='ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n\'ga4gh/sequence_annotation_service.proto\x12\x05ga4gh\x1a ga4gh/sequence_annotations.proto\"U\n\x18SearchFeatureSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"]\n\x19SearchFeatureSetsResponse\x12\'\n\x0c\x66\x65\x61ture_sets\x18\x01 \x03(\x0b\x32\x11.ga4gh.FeatureSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\".\n\x14GetFeatureSetRequest\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x01 \x01(\t\"\xb4\x01\n\x15SearchFeaturesRequest\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x01 \x01(\t\x12\x11\n\tparent_id\x18\x02 \x01(\t\x12\x16\n\x0ereference_name\x18\x03 \x01(\t\x12\r\n\x05start\x18\x04 \x01(\x03\x12\x0b\n\x03\x65nd\x18\x05 \x01(\x03\x12\x15\n\rfeature_types\x18\x06 \x03(\t\x12\x11\n\tpage_size\x18\x07 \x01(\x05\x12\x12\n\npage_token\x18\x08 \x01(\t\"S\n\x16SearchFeaturesResponse\x12 \n\x08\x66\x65\x61tures\x18\x01 \x03(\x0b\x32\x0e.ga4gh.Feature\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\'\n\x11GetFeatureRequest\x12\x12\n\nfeature_id\x18\x01 \x01(\t2\xbb\x02\n\x19SequenceAnnotationService\x12V\n\x11SearchFeatureSets\x12\x1f.ga4gh.SearchFeatureSetsRequest\x1a .ga4gh.SearchFeatureSetsResponse\x12?\n\rGetFeatureSet\x12\x1b.ga4gh.GetFeatureSetRequest\x1a\x11.ga4gh.FeatureSet\x12M\n\x0eSearchFeatures\x12\x1c.ga4gh.SearchFeaturesRequest\x1a\x1d.ga4gh.SearchFeaturesResponse\x12\x36\n\nGetFeature\x12\x18.ga4gh.GetFeatureRequest\x1a\x0e.ga4gh.Featureb\x06proto3')
+  serialized_pb=_b('\n\'ga4gh/sequence_annotation_service.proto\x12\x05ga4gh\x1a ga4gh/sequence_annotations.proto\"U\n\x18SearchFeatureSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"]\n\x19SearchFeatureSetsResponse\x12\'\n\x0c\x66\x65\x61ture_sets\x18\x01 \x03(\x0b\x32\x11.ga4gh.FeatureSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\".\n\x14GetFeatureSetRequest\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x01 \x01(\t\"\xd7\x01\n\x15SearchFeaturesRequest\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0bgene_symbol\x18\x03 \x01(\t\x12\x11\n\tparent_id\x18\x04 \x01(\t\x12\x16\n\x0ereference_name\x18\x05 \x01(\t\x12\r\n\x05start\x18\x06 \x01(\x03\x12\x0b\n\x03\x65nd\x18\x07 \x01(\x03\x12\x15\n\rfeature_types\x18\x08 \x03(\t\x12\x11\n\tpage_size\x18\t \x01(\x05\x12\x12\n\npage_token\x18\n \x01(\t\"S\n\x16SearchFeaturesResponse\x12 \n\x08\x66\x65\x61tures\x18\x01 \x03(\x0b\x32\x0e.ga4gh.Feature\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\'\n\x11GetFeatureRequest\x12\x12\n\nfeature_id\x18\x01 \x01(\t2\xbb\x02\n\x19SequenceAnnotationService\x12V\n\x11SearchFeatureSets\x12\x1f.ga4gh.SearchFeatureSetsRequest\x1a .ga4gh.SearchFeatureSetsResponse\x12?\n\rGetFeatureSet\x12\x1b.ga4gh.GetFeatureSetRequest\x1a\x11.ga4gh.FeatureSet\x12M\n\x0eSearchFeatures\x12\x1c.ga4gh.SearchFeaturesRequest\x1a\x1d.ga4gh.SearchFeaturesResponse\x12\x36\n\nGetFeature\x12\x18.ga4gh.GetFeatureRequest\x1a\x0e.ga4gh.Featureb\x06proto3')
   ,
   dependencies=[ga4gh_dot_sequence__annotations__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -157,50 +157,64 @@ _SEARCHFEATURESREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parent_id', full_name='ga4gh.SearchFeaturesRequest.parent_id', index=1,
+      name='name', full_name='ga4gh.SearchFeaturesRequest.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='reference_name', full_name='ga4gh.SearchFeaturesRequest.reference_name', index=2,
+      name='gene_symbol', full_name='ga4gh.SearchFeaturesRequest.gene_symbol', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='start', full_name='ga4gh.SearchFeaturesRequest.start', index=3,
-      number=4, type=3, cpp_type=2, label=1,
+      name='parent_id', full_name='ga4gh.SearchFeaturesRequest.parent_id', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='reference_name', full_name='ga4gh.SearchFeaturesRequest.reference_name', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='start', full_name='ga4gh.SearchFeaturesRequest.start', index=5,
+      number=6, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='end', full_name='ga4gh.SearchFeaturesRequest.end', index=4,
-      number=5, type=3, cpp_type=2, label=1,
+      name='end', full_name='ga4gh.SearchFeaturesRequest.end', index=6,
+      number=7, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='feature_types', full_name='ga4gh.SearchFeaturesRequest.feature_types', index=5,
-      number=6, type=9, cpp_type=9, label=3,
+      name='feature_types', full_name='ga4gh.SearchFeaturesRequest.feature_types', index=7,
+      number=8, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='page_size', full_name='ga4gh.SearchFeaturesRequest.page_size', index=6,
-      number=7, type=5, cpp_type=1, label=1,
+      name='page_size', full_name='ga4gh.SearchFeaturesRequest.page_size', index=8,
+      number=9, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='page_token', full_name='ga4gh.SearchFeaturesRequest.page_token', index=7,
-      number=8, type=9, cpp_type=9, label=1,
+      name='page_token', full_name='ga4gh.SearchFeaturesRequest.page_token', index=9,
+      number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -218,7 +232,7 @@ _SEARCHFEATURESREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=315,
-  serialized_end=495,
+  serialized_end=530,
 )
 
 
@@ -255,8 +269,8 @@ _SEARCHFEATURESRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=497,
-  serialized_end=580,
+  serialized_start=532,
+  serialized_end=615,
 )
 
 
@@ -286,8 +300,8 @@ _GETFEATUREREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=582,
-  serialized_end=621,
+  serialized_start=617,
+  serialized_end=656,
 )
 
 _SEARCHFEATURESETSRESPONSE.fields_by_name['feature_sets'].message_type = ga4gh_dot_sequence__annotations__pb2._FEATURESET

--- a/ga4gh/sequence_annotations_pb2.py
+++ b/ga4gh/sequence_annotations_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/sequence_annotations.proto',
   package='ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n ga4gh/sequence_annotations.proto\x12\x05ga4gh\x1a\x12ga4gh/common.proto\x1a\x14ga4gh/metadata.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xee\x02\n\nAttributes\x12)\n\x04vals\x18\x01 \x03(\x0b\x32\x1b.ga4gh.Attributes.ValsEntry\x1a\x99\x01\n\x0e\x41ttributeValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12\x38\n\x13\x65xternal_identifier\x18\x02 \x01(\x0b\x32\x19.ga4gh.ExternalIdentifierH\x00\x12,\n\rontology_term\x18\x03 \x01(\x0b\x32\x13.ga4gh.OntologyTermH\x00\x42\x07\n\x05value\x1a\x46\n\x12\x41ttributeValueList\x12\x30\n\x06values\x18\x01 \x03(\x0b\x32 .ga4gh.Attributes.AttributeValue\x1aQ\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32$.ga4gh.Attributes.AttributeValueList:\x02\x38\x01\"\xf8\x01\n\x07\x46\x65\x61ture\x12\n\n\x02id\x18\x01 \x01(\t\x12\x11\n\tparent_id\x18\x02 \x01(\t\x12\x11\n\tchild_ids\x18\x03 \x03(\t\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x04 \x01(\t\x12\x16\n\x0ereference_name\x18\x05 \x01(\t\x12\r\n\x05start\x18\x06 \x01(\x03\x12\x0b\n\x03\x65nd\x18\x07 \x01(\x03\x12\x1d\n\x06strand\x18\x08 \x01(\x0e\x32\r.ga4gh.Strand\x12)\n\x0c\x66\x65\x61ture_type\x18\t \x01(\x0b\x32\x13.ga4gh.OntologyTerm\x12%\n\nattributes\x18\n \x01(\x0b\x32\x11.ga4gh.Attributes\"\xdc\x01\n\nFeatureSet\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\ndataset_id\x18\x02 \x01(\t\x12\x18\n\x10reference_set_id\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x12\n\nsource_uri\x18\x05 \x01(\t\x12)\n\x04info\x18\x06 \x03(\x0b\x32\x1b.ga4gh.FeatureSet.InfoEntry\x1aG\n\tInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.ListValue:\x02\x38\x01\x62\x06proto3')
+  serialized_pb=_b('\n ga4gh/sequence_annotations.proto\x12\x05ga4gh\x1a\x12ga4gh/common.proto\x1a\x14ga4gh/metadata.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xee\x02\n\nAttributes\x12)\n\x04vals\x18\x01 \x03(\x0b\x32\x1b.ga4gh.Attributes.ValsEntry\x1a\x99\x01\n\x0e\x41ttributeValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12\x38\n\x13\x65xternal_identifier\x18\x02 \x01(\x0b\x32\x19.ga4gh.ExternalIdentifierH\x00\x12,\n\rontology_term\x18\x03 \x01(\x0b\x32\x13.ga4gh.OntologyTermH\x00\x42\x07\n\x05value\x1a\x46\n\x12\x41ttributeValueList\x12\x30\n\x06values\x18\x01 \x03(\x0b\x32 .ga4gh.Attributes.AttributeValue\x1aQ\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32$.ga4gh.Attributes.AttributeValueList:\x02\x38\x01\"\x9b\x02\n\x07\x46\x65\x61ture\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0bgene_symbol\x18\x03 \x01(\t\x12\x11\n\tparent_id\x18\x04 \x01(\t\x12\x11\n\tchild_ids\x18\x05 \x03(\t\x12\x16\n\x0e\x66\x65\x61ture_set_id\x18\x06 \x01(\t\x12\x16\n\x0ereference_name\x18\x07 \x01(\t\x12\r\n\x05start\x18\x08 \x01(\x03\x12\x0b\n\x03\x65nd\x18\t \x01(\x03\x12\x1d\n\x06strand\x18\n \x01(\x0e\x32\r.ga4gh.Strand\x12)\n\x0c\x66\x65\x61ture_type\x18\x0b \x01(\x0b\x32\x13.ga4gh.OntologyTerm\x12%\n\nattributes\x18\x0c \x01(\x0b\x32\x11.ga4gh.Attributes\"\xdc\x01\n\nFeatureSet\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\ndataset_id\x18\x02 \x01(\t\x12\x18\n\x10reference_set_id\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x12\n\nsource_uri\x18\x05 \x01(\t\x12)\n\x04info\x18\x06 \x03(\x0b\x32\x1b.ga4gh.FeatureSet.InfoEntry\x1aG\n\tInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.ListValue:\x02\x38\x01\x62\x06proto3')
   ,
   dependencies=[ga4gh_dot_common__pb2.DESCRIPTOR,ga4gh_dot_metadata__pb2.DESCRIPTOR,google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -190,64 +190,78 @@ _FEATURE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parent_id', full_name='ga4gh.Feature.parent_id', index=1,
+      name='name', full_name='ga4gh.Feature.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='child_ids', full_name='ga4gh.Feature.child_ids', index=2,
-      number=3, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
+      name='gene_symbol', full_name='ga4gh.Feature.gene_symbol', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='feature_set_id', full_name='ga4gh.Feature.feature_set_id', index=3,
+      name='parent_id', full_name='ga4gh.Feature.parent_id', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='reference_name', full_name='ga4gh.Feature.reference_name', index=4,
-      number=5, type=9, cpp_type=9, label=1,
+      name='child_ids', full_name='ga4gh.Feature.child_ids', index=4,
+      number=5, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='feature_set_id', full_name='ga4gh.Feature.feature_set_id', index=5,
+      number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='start', full_name='ga4gh.Feature.start', index=5,
-      number=6, type=3, cpp_type=2, label=1,
+      name='reference_name', full_name='ga4gh.Feature.reference_name', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='start', full_name='ga4gh.Feature.start', index=7,
+      number=8, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='end', full_name='ga4gh.Feature.end', index=6,
-      number=7, type=3, cpp_type=2, label=1,
+      name='end', full_name='ga4gh.Feature.end', index=8,
+      number=9, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='strand', full_name='ga4gh.Feature.strand', index=7,
-      number=8, type=14, cpp_type=8, label=1,
+      name='strand', full_name='ga4gh.Feature.strand', index=9,
+      number=10, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='feature_type', full_name='ga4gh.Feature.feature_type', index=8,
-      number=9, type=11, cpp_type=10, label=1,
+      name='feature_type', full_name='ga4gh.Feature.feature_type', index=10,
+      number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='attributes', full_name='ga4gh.Feature.attributes', index=9,
-      number=10, type=11, cpp_type=10, label=1,
+      name='attributes', full_name='ga4gh.Feature.attributes', index=11,
+      number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -265,7 +279,7 @@ _FEATURE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=485,
-  serialized_end=733,
+  serialized_end=768,
 )
 
 
@@ -302,8 +316,8 @@ _FEATURESET_INFOENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=885,
-  serialized_end=956,
+  serialized_start=920,
+  serialized_end=991,
 )
 
 _FEATURESET = _descriptor.Descriptor(
@@ -367,8 +381,8 @@ _FEATURESET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=736,
-  serialized_end=956,
+  serialized_start=771,
+  serialized_end=991,
 )
 
 _ATTRIBUTES_ATTRIBUTEVALUE.fields_by_name['external_identifier'].message_type = ga4gh_dot_common__pb2._EXTERNALIDENTIFIER

--- a/tests/datadriven/test_sequenceAnnotations.py
+++ b/tests/datadriven/test_sequenceAnnotations.py
@@ -55,7 +55,7 @@ _sacCerTestTestData = {
     "sampleStart": 337,
     "sampleEnd": 801,
     "sampleStrand": protocol.NEG_STRAND,
-    "sampleSiblings": 20,
+    "sampleSiblings": 33,
     "region": [0, 2**32],
     "ontologyRestriction": ["gene", ],
     "featuresWithOntology": 11
@@ -70,7 +70,7 @@ _specialCasesTestTestData = {
     "sampleStart": 22229583,
     "sampleEnd": 22229699,
     "sampleStrand": protocol.NEG_STRAND,
-    "sampleSiblings": 2,
+    "sampleSiblings": 4,
     "region": [0, 2**32],
     "ontologyRestriction": ["gene", ],
     "featuresWithOntology": 0

--- a/tests/end_to_end/test_sequenceAnnotations.py
+++ b/tests/end_to_end/test_sequenceAnnotations.py
@@ -72,7 +72,9 @@ class TestSequenceAnnotations(unittest.TestCase):
             responseData = self.sendSearchRequest(
                 path, request, protocol.SearchFeaturesResponse)
             self.assertEqual(0, len(responseData.features))
-            request.name = "ENSG00000012048.15"
+            request.name = "exon:ENSTR0000507418.3:5"
+            responseData = self.sendSearchRequest(
+                path, request, protocol.SearchFeaturesResponse)
             for feature in responseData.features:
                 ran = True
                 self.assertEqual(feature.name, request.name)
@@ -85,17 +87,16 @@ class TestSequenceAnnotations(unittest.TestCase):
             path = "features/search"
             request = protocol.SearchFeaturesRequest()
             request.feature_set_id = featureSet.id
-            request.gene_symbol = "BRCA1"
+            request.gene_symbol = "BAD GENE SYMBOL"
             responseData = self.sendSearchRequest(
                 path, request, protocol.SearchFeaturesResponse)
             self.assertEqual(0, len(responseData.features))
-            request.name = "ENSG00000012048.15"
-            while responseData.next_page_token:
-                innerResponseData = self.sendSearchRequest(
-                    path, request, protocol.SearchFeaturesResponse)
-                for feature in innerResponseData.features:
-                    ran = True
-                    self.assertEqual(feature.gene, request.name)
+            request.gene_symbol = "DDX11L16"
+            responseData = self.sendSearchRequest(
+                path, request, protocol.SearchFeaturesResponse)
+            for feature in responseData.features:
+                ran = True
+                self.assertEqual(feature.gene_symbol, request.gene_symbol)
         self.assertTrue(ran)
 
     def testSearchFeatures(self):
@@ -130,7 +131,6 @@ class TestSequenceAnnotations(unittest.TestCase):
                 path, request, protocol.SearchFeaturesResponse)
             for feature in responseData.features:
                 self.assertIn(feature.feature_type.term, request.feature_types)
-
             request = protocol.SearchFeaturesRequest()
             request.feature_set_id = featureSet.id
             request.start = 0

--- a/tests/end_to_end/test_sequenceAnnotations.py
+++ b/tests/end_to_end/test_sequenceAnnotations.py
@@ -61,6 +61,43 @@ class TestSequenceAnnotations(unittest.TestCase):
             path, request, protocol.SearchFeatureSetsResponse)
         return responseData.feature_sets
 
+    def testSearchFeaturesByName(self):
+        ran = False
+        featureSets = self.getAllFeatureSets()
+        for featureSet in featureSets:
+            path = "features/search"
+            request = protocol.SearchFeaturesRequest()
+            request.feature_set_id = featureSet.id
+            request.name = "BAD NAME"
+            responseData = self.sendSearchRequest(
+                path, request, protocol.SearchFeaturesResponse)
+            self.assertEqual(0, len(responseData.features))
+            request.name = "ENSG00000012048.15"
+            for feature in responseData.features:
+                ran = True
+                self.assertEqual(feature.name, request.name)
+        self.assertTrue(ran)
+
+    def testSearchFeaturesByGeneSymbol(self):
+        ran = False
+        featureSets = self.getAllFeatureSets()
+        for featureSet in featureSets:
+            path = "features/search"
+            request = protocol.SearchFeaturesRequest()
+            request.feature_set_id = featureSet.id
+            request.gene_symbol = "BRCA1"
+            responseData = self.sendSearchRequest(
+                path, request, protocol.SearchFeaturesResponse)
+            self.assertEqual(0, len(responseData.features))
+            request.name = "ENSG00000012048.15"
+            while responseData.next_page_token:
+                innerResponseData = self.sendSearchRequest(
+                    path, request, protocol.SearchFeaturesResponse)
+                for feature in innerResponseData.features:
+                    ran = True
+                    self.assertEqual(feature.gene, request.name)
+        self.assertTrue(ran)
+
     def testSearchFeatures(self):
         featureSets = self.getAllFeatureSets()
         for featureSet in featureSets:


### PR DESCRIPTION
Accompanies https://github.com/ga4gh/schemas/pull/639 and https://github.com/ga4gh/compliance/pull/196

In order to allow for some common access patterns to features data, it has been proposed to allow matching on gene name and gene symbol. This PR demonstrates that functionality within the reference server. 

The handling of requests has been improved for missing values and completed a TODO for generalizing query construction. This does not include a CLI interface, or modifications to the client.