### PR TITLE
Add gene symbol and name to features search client

### DIFF
--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -342,8 +342,8 @@ class AbstractClient(object):
             protocol.SearchVariantAnnotationsResponse)
 
     def searchFeatures(
-            self, featureSetId=None, parentId=None, referenceName=None,
-            start=0, end=None, featureTypes=[]):
+            self, featureSetId=None, parentId="", referenceName="",
+            start=0, end=0, featureTypes=[], name="", geneSymbol=""):
         """
         Returns the result of running a searchFeatures method
         on a request with the passed-in parameters.
@@ -355,6 +355,8 @@ class AbstractClient(object):
         :param int start: search start position on reference
         :param int end: end position on reference
         :param featureTypes: array of terms to limit search by (ex: "gene")
+        :param str name: only return features with this name
+        :param str geneSymbol: only return features on this gene
         :return: an iterator over Features as returned in the
             SearchFeaturesResponse object.
         """
@@ -362,10 +364,12 @@ class AbstractClient(object):
         request.feature_set_id = featureSetId
         request.parent_id = parentId
         request.reference_name = referenceName
+        request.name = name
+        request.gene_symbol = geneSymbol
         request.start = start
         request.end = end
         request.feature_types.extend(featureTypes)
-        request.page_size = self._pageSize
+        request.page_size = pb.int(self._pageSize)
         return self._runSearchRequest(
             request, "features",
             protocol.SearchFeaturesResponse)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -41,6 +41,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         self.bioSampleName = "bioSampleName"
         self.individualName = "individualName"
         self.individualId = "individualId"
+        self.geneSymbol = "geneSymbol"
         self.start = 100
         self.end = 101
         self.referenceName = "referenceName"
@@ -132,11 +133,14 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
         request.reference_name = self.referenceName
         request.start = self.start
         request.end = self.end
+        request.name = self.objectName
+        request.gene_symbol = self.geneSymbol
         request.feature_types.append(self.feature)
         self.httpClient.searchFeatures(
             self.featureSetId, parentId=self.parentId,
             referenceName=self.referenceName, start=self.start,
-            end=self.end, featureTypes=[self.feature])
+            end=self.end, featureTypes=[self.feature],
+            name=self.objectName, geneSymbol=self.geneSymbol)
         self.httpClient._runSearchRequest.assert_called_once_with(
             request, "features", protocol.SearchFeaturesResponse)
 


### PR DESCRIPTION
Implements the latest [schema changes](https://github.com/ga4gh/schemas/pull/639) in the client API. Adjusts default values to align with remainder of client API. Adds tests to ensure the fields are set properly.