### PR TITLE
Fix VariantFormatterMixin

### DIFF
--- a/ga4gh/cli.py
+++ b/ga4gh/cli.py
@@ -515,7 +515,8 @@ class VariantFormatterMixin(object):
                 variant.reference_bases, variant.alternate_bases,
                 sep="\t", end="\t")
             for key, value in variant.info.items():
-                print(key, value, sep="=", end=";")
+                val = value.values[0].string_value
+                print(key, val, sep="=", end=";")
             print("\t", end="")
             for c in variant.calls:
                 print(


### PR DESCRIPTION
Issue #1264 

Now looks like:
```
$ python client_dev.py variants-search http://localhost:8000 -s 99718 -e 100000
WyIxa2ctcDMtc3Vic2V0IiwidnMiLCJtdm5jYWxsIiwiMSIsIjk5NzE4IiwiNjhkMTU1ZjQ0Mjg2NzQ4YWI2Njg4ZWQzOTNkZmY2MzQiXQ	WyIxa2ctcDMtc3Vic2V0IiwidnMiLCJtdm5jYWxsIl0	[u'rs183898652']	1	99718	99719	C	[u'T']	EUR_AF=0.00989999994636;SAS_AF=0.00609999988228;AC=0;AA=.|||;AF=0.00898561999202;AFR_AF=0.0143999997526;AMR_AF=0.0143999997526;AN=6;VT=SNP;EAS_AF=0.0;NS=2504;DP=17114;
```