### PR TITLE
Fix VA search bug

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -290,15 +290,17 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
 
     def _removeNonMatchingTranscriptEffects(self, ann):
         newTxE = []
+        oldTxE = ann.transcript_effects
         if len(self._effects) == 0:
             return ann
-        for txe in ann.transcript_effects:
+        for txe in oldTxE:
             add = False
             for effect in txe.effects:
                 if self._matchAnyEffects(effect):
                     add = True
             if add:
                 newTxE.append(txe)
+        ann.ClearField('transcript_effects')
         ann.transcript_effects.extend(newTxE)
         return ann
 

--- a/ga4gh/datamodel/variants.py
+++ b/ga4gh/datamodel/variants.py
@@ -968,11 +968,10 @@ class SimulatedVariantAnnotationSet(AbstractVariantAnnotationSet):
         ann.created = datetime.datetime.now().isoformat() + "Z"
         # make a transcript effect for each alternate base element
         # multiplied by a random integer (1,5)
-        for i in range(randomNumberGenerator.randint(1, 5)):
-            for base in variant.alternate_bases:
-                ann.transcript_effects.add().CopyFrom(
-                    self.generateTranscriptEffect(
-                        variant, ann, base, randomNumberGenerator))
+        for base in variant.alternate_bases:
+            ann.transcript_effects.add().CopyFrom(
+                self.generateTranscriptEffect(
+                    variant, ann, base, randomNumberGenerator))
         ann.id = self.getVariantAnnotationId(variant, ann)
         return ann
 
@@ -984,10 +983,6 @@ class SimulatedVariantAnnotationSet(AbstractVariantAnnotationSet):
         effect.protein_location.start = variant.start
         effect.cds_location.start = variant.start
         effect.cdna_location.start = variant.start
-        return effect
-
-    def _addTranscriptEffectId(self, effect):
-        effect.id = str(self.getTranscriptEffectId(effect))
         return effect
 
     def _getRandomOntologyTerm(self, randomNumberGenerator):
@@ -1032,7 +1027,7 @@ class SimulatedVariantAnnotationSet(AbstractVariantAnnotationSet):
             effect, randomNumberGenerator)
         effect = self._addTranscriptEffectOntologyTerm(
             effect, randomNumberGenerator)
-        effect = self._addTranscriptEffectId(effect)
+        effect.id = self.getTranscriptEffectId(effect)
         effect = self._addAnalysisResult(effect, ann, randomNumberGenerator)
         return effect
 

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -722,6 +722,9 @@ class TestSimulatedStack(unittest.TestCase):
                            "There should be some results for a good effect ID")
         for ann in responseData.variant_annotations:
             effectPresent = False
+            txIds = map(lambda t: t.id, ann.transcript_effects)
+            self.assertEqual(len(txIds), len(set(txIds)),
+                             "Transcript effects should be unique")
             for effect in ann.transcript_effects:
                 for featureType in effect.effects:
                     if featureType.id in map(


### PR DESCRIPTION
During the protobuf conversion extend was incorrectly used. This bug caused repeated transcript effect records to appear in results. Fixing this bug revealed that the simulated stack tests for VA were incorrect and generated transcript effect records for the same alternate base repeatedly. This PR removes the uncecessary outer loop.

A test has been added to guard for this. Close #1294