### PR TITLE
Add initial counts to read group set

### DIFF
--- a/ga4gh/datamodel/reads.py
+++ b/ga4gh/datamodel/reads.py
@@ -228,6 +228,8 @@ class AbstractReadGroupSet(datamodel.DatamodelObject):
         self._readGroupIdMap = {}
         self._readGroupIds = []
         self._referenceSet = None
+        self._numAlignedReads = -1
+        self._numUnalignedReads = -1
 
     def setReferenceSet(self, referenceSet):
         """


### PR DESCRIPTION
Note, I'm not sure what the intended behavior is here. It seems like stats are on both the RG and RGS level, but they derive their data from the same place. This PR simply initializes values checked by `getStats` to `-1`.

Closes https://github.com/ga4gh/server/issues/1304