### PR TITLE
Reference list bases post request

### DIFF
--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -923,7 +923,7 @@ class Backend(object):
         self.endProfile()
         return responseString
 
-    def runListReferenceBases(self, id_, requestJson):
+    def runListReferenceBases(self, requestJson):
         """
         Runs a listReferenceBases request for the specified ID and
         request arguments.
@@ -939,7 +939,6 @@ class Backend(object):
                     protocol.ListReferenceBasesRequest)
             except protocol.json_format.ParseError:
                 raise exceptions.InvalidJsonException(requestJson)
-        request.reference_id = id_
         compoundId = datamodel.ReferenceCompoundId.parse(request.reference_id)
         referenceSet = self.getDataRepository().getReferenceSet(
             compoundId.reference_set_id)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -80,14 +80,13 @@ class AbstractClient(object):
         request = protocol.ListReferenceBasesRequest()
         request.start = pb.int(start)
         request.end = pb.int(end)
+        request.reference_id = id_
         not_done = True
         # TODO We should probably use a StringIO here to make string buffering
         # a bit more efficient.
         bases_list = []
         while not_done:
-            request.reference_id = id_
-            response = self._run_list_reference_bases_page_request(
-                id_, request)
+            response = self._run_list_reference_bases_page_request(request)
             bases_list.append(response.sequence)
             not_done = bool(response.next_page_token)
             request.page_token = response.next_page_token
@@ -820,8 +819,8 @@ class HttpClient(AbstractClient):
         return self._deserialize_response(
             response.text, protocol_response_class)
 
-    def _run_list_reference_bases_page_request(self, id_, request):
-        url_suffix = "references/{}/bases".format(id_)
+    def _run_list_reference_bases_page_request(self, request):
+        url_suffix = "listreferencebases"
         url = posixpath.join(self._url_prefix, url_suffix)
         response = self._session.post(
             url, params=self._get_http_parameters(),
@@ -893,8 +892,8 @@ class LocalClient(AbstractClient):
         return self._deserialize_response(
             response_json, protocol_response_class)
 
-    def _run_list_reference_bases_page_request(self, id_, request):
+    def _run_list_reference_bases_page_request(self, request):
         response_json = self._backend.runListReferenceBases(
-            id_, protocol.toJson(request))
+            protocol.toJson(request))
         return self._deserialize_response(
             response_json, protocol.ListReferenceBasesResponse)

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -340,11 +340,11 @@ def handleHttpPost(request, endpoint):
     return getFlaskResponse(responseStr)
 
 
-def handleList(id_, endpoint, request):
+def handleList(endpoint, request):
     """
     Handles the specified HTTP GET request, mapping to a list request
     """
-    responseStr = endpoint(id_, request.get_data())
+    responseStr = endpoint(request.get_data())
     return getFlaskResponse(responseStr)
 
 
@@ -450,7 +450,7 @@ def handleFlaskListRequest(id_, flaskRequest, endpoint):
     Invokes the specified endpoint to generate a response.
     """
 
-    return handleList(id_, endpoint, flaskRequest)
+    return handleList(endpoint, flaskRequest)
 
 
 def handleFlaskPostRequest(flaskRequest, endpoint):
@@ -521,8 +521,8 @@ def getReferenceSet(id):
         id, flask.request, app.backend.runGetReferenceSet)
 
 
-@DisplayedRoute('/references/<id>/bases', postMethod=True)
-def listReferenceBases(id):
+@DisplayedRoute('/listreferencebases', postMethod=True)
+def listReferenceBases():
     return handleFlaskListRequest(
         id, flask.request, app.backend.runListReferenceBases)
 

--- a/ga4gh/frontend.py
+++ b/ga4gh/frontend.py
@@ -344,7 +344,7 @@ def handleList(id_, endpoint, request):
     """
     Handles the specified HTTP GET request, mapping to a list request
     """
-    responseStr = endpoint(id_, request.args)
+    responseStr = endpoint(id_, request.get_data())
     return getFlaskResponse(responseStr)
 
 
@@ -449,10 +449,8 @@ def handleFlaskListRequest(id_, flaskRequest, endpoint):
     Handles the specified flask list request for one of the GET URLs.
     Invokes the specified endpoint to generate a response.
     """
-    if flaskRequest.method == "GET":
-        return handleList(id_, endpoint, flaskRequest)
-    else:
-        raise exceptions.MethodNotAllowedException()
+
+    return handleList(id_, endpoint, flaskRequest)
 
 
 def handleFlaskPostRequest(flaskRequest, endpoint):
@@ -523,7 +521,7 @@ def getReferenceSet(id):
         id, flask.request, app.backend.runGetReferenceSet)
 
 
-@DisplayedRoute('/references/<id>/bases')
+@DisplayedRoute('/references/<id>/bases', postMethod=True)
 def listReferenceBases(id):
     return handleFlaskListRequest(
         id, flask.request, app.backend.runListReferenceBases)

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -116,8 +116,7 @@ class TestSimulatedStack(unittest.TestCase):
         ListReferenceBasesResponse.
         """
         path = '/references/{}/bases'.format(id_)
-        response = self.app.get(
-            path, query_string=protocol.toJsonDict(request))
+        response = self.sendJsonPostRequest(path, protocol.toJson(request))
         self.assertEqual(response.status_code, 200)
         obj = protocol.fromJson(
             response.data, protocol.ListReferenceBasesResponse)
@@ -849,13 +848,14 @@ class TestSimulatedStack(unittest.TestCase):
 
     def testListReferenceBasesErrors(self):
         referenceSet = self.dataRepo.getReferenceSets()[0]
+        args = protocol.ListReferenceBasesRequest()
         for badId in self.getBadIds():
             path = '/references/{}/bases'.format(badId)
-            response = self.app.get(path)
+            response = self.sendJsonPostRequest(path, protocol.toJson(args))
             self.assertEqual(response.status_code, 404)
             reference = references.AbstractReference(referenceSet, badId)
             path = '/references/{}/bases'.format(reference.getId())
-            response = self.app.get(path)
+            response = self.sendJsonPostRequest(path, protocol.toJson(args))
             self.assertEqual(response.status_code, 404)
         path = '/references/{}/bases'.format(self.reference.getId())
         length = self.reference.getLength()
@@ -863,8 +863,7 @@ class TestSimulatedStack(unittest.TestCase):
         for start, end in badRanges:
             args = protocol.ListReferenceBasesRequest()
             args.start, args.end = start, end
-            response = self.app.get(
-                path, query_string=protocol.toJsonDict(args))
+            response = self.sendJsonPostRequest(path, protocol.toJson(args))
             self.assertEqual(response.status_code, 416)
 
     def testListReferenceBasesPaging(self):
@@ -881,7 +880,7 @@ class TestSimulatedStack(unittest.TestCase):
                 self.assertEqual(response.sequence, sequence[:pageSize])
                 self.assertEqual(response.offset, start)
                 sequenceFragments = [response.sequence]
-                while response.next_page_token is not "":
+                while response.next_page_token:
                     args = protocol.ListReferenceBasesRequest()
                     args.page_token = response.next_page_token
                     args.start, args.end = start, end

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -254,7 +254,7 @@ class TestFrontend(unittest.TestCase):
             'Origin': self.exampleUrl,
         }
         data = protocol.toJsonDict(request)
-        response = self.app.get(path, data=data, headers=headers)
+        response = self.app.post(path, data=data, headers=headers)
         return response
 
     def sendReferenceBasesList(self, id_=None):
@@ -330,15 +330,17 @@ class TestFrontend(unittest.TestCase):
 
     def testRouteReferences(self):
         referenceId = self.referenceId
-        paths = ['/references/{}', '/references/{}/bases']
-        for path in paths:
-            path = path.format(referenceId)
-            self.assertEqual(200, self.app.get(path).status_code)
+        path = '/references/{}'
+        path = path.format(referenceId)
+        self.assertEqual(200, self.app.get(path).status_code)
+        path = 'references/{}/bases'
+        path = path.format(referenceId)
+        self.assertEqual(200, self.app.post(path).status_code)
         referenceSetId = self.referenceSetId
-        paths = ['/referencesets/{}']
-        for path in paths:
-            path = path.format(referenceSetId)
-            self.assertEqual(200, self.app.get(path).status_code)
+        path = '/referencesets/{}'
+        path = path.format(referenceSetId)
+        self.assertEqual(200, self.app.get(path).status_code)
+        path = 'references/{}'
         self.verifySearchRouting('/referencesets/search', True)
         self.verifySearchRouting('/references/search', True)
 

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -333,9 +333,8 @@ class TestFrontend(unittest.TestCase):
         path = '/references/{}'
         path = path.format(referenceId)
         self.assertEqual(200, self.app.get(path).status_code)
-        path = 'references/{}/bases'
-        path = path.format(referenceId)
-        self.assertEqual(200, self.app.post(path).status_code)
+        path = '/listreferencebases'
+        self.assertEqual(404, self.app.post(path).status_code)
         referenceSetId = self.referenceSetId
         path = '/referencesets/{}'
         path = path.format(referenceSetId)


### PR DESCRIPTION
In an effort to make the API consistent this PR implements the list reference bases endpoint as a POST request (https://github.com/ga4gh/schemas/pull/647), as opposed to a get request with query parameters. This helps to make the API more consistent by making POST requests used for anything that requires paging.

`GET /reference/abcd123/bases?start=0&end=100&pageToken=3`
  becomes 
`POST /reference/abcd123/bases {start: 0, end: 100, pageToken: "3"}`

A couple of bits of code that were noted for removal have been cleared out with this. Namely, as suggested in the TODO, we can pass around request objects without hand editing a parameter dictionary.

- Change tests to use post endpoint
- Simplify testing code path
- Change routes for list ref bases
- Add to client