### PR TITLE
Align RNA data with existing repository

### DIFF
--- a/ga4gh/datamodel/rna_quantification.py
+++ b/ga4gh/datamodel/rna_quantification.py
@@ -69,7 +69,7 @@ class SqliteExpressionLevel(AbstractExpressionLevel):
         super(SqliteExpressionLevel, self).__init__(
             parentContainer, record["id"])
         self._expression = record["expression"]
-        self._featureId = record["id"]
+        self._featureId = record["feature_id"]
         # sqlite stores booleans as int (False = 0, True = 1)
         self._isNormalized = bool(record["is_normalized"])
         self._rawReadCount = record["raw_read_count"]

--- a/scripts/prepare_compliance_data.py
+++ b/scripts/prepare_compliance_data.py
@@ -46,7 +46,8 @@ class ComplianceDataMunger(object):
         """
         self.inputDirectory = inputDirectory
         self.outputDirectory = outputDirectory
-        self.repoPath = os.path.join(outputDirectory, "repo.db")
+        self.repoPath = os.path.abspath(
+            os.path.join(outputDirectory, "repo.db"))
         self.tempdir = None
 
         if os.path.exists(self.outputDirectory):
@@ -233,11 +234,13 @@ class ComplianceDataMunger(object):
         gencode.setReferenceSet(referenceSet)
 
         self.repo.insertFeatureSet(gencode)
+        self.repo.commit()
 
         # RNA Quantification
         rnaDbName = os.path.join(self.outputDirectory, "rnaseq.db")
         rnaseq2ga.rnaseq2ga(
-            self.inputDirectory, rnaDbName, featureType="transcript")
+            self.inputDirectory, rnaDbName, self.repoPath,
+            featureType="transcript")
         rnaQuantificationSet = rna_quantification.SqliteRnaQuantificationSet(
             dataset, "rnaseq")
         rnaQuantificationSet.setReferenceSet(referenceSet)


### PR DESCRIPTION
In order to make feature IDs in the RNA expression levels point to features within an existing repository three changes were made. The rnaseq2ga script now accepts a repository path.

First, when writing expression levels to the database features are searched within the first feature set in the first dataset found. Features are matched based on name and the resulting feature ID is written to the database.

Second, the signature of the usage of this script in prepare compliance data was changed.

And third, the rna data model needed to be modified to read from the feature ID column. It was reporting the 'id' for both name and featureId.

@saupchurch @dcolligan