### PR TITLE
Add default pagesize to client

### DIFF
--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -20,7 +20,7 @@ class AbstractClient(object):
     """
 
     def __init__(self, log_level=0):
-        self._page_size = None
+        self._page_size = 10
         self._log_level = log_level
         self._protocol_bytes_received = 0
         logging.basicConfig()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -59,7 +59,7 @@ class TestSearchMethodsCallRunRequest(unittest.TestCase):
     def testSetPageSize(self):
         testClient = client.AbstractClient()
         # pageSize is None by default
-        self.assertIsNone(testClient.get_page_size())
+        self.assertEqual(testClient.get_page_size(), 10)
         for pageSize in [1, 10, 100]:
             testClient.set_page_size(pageSize)
             self.assertEqual(testClient.get_page_size(), pageSize)


### PR DESCRIPTION
Set the default page size to 10. The client was sending a pagesize of 0 by default. Close #1362 