### PR TITLE
Fix a bug in loading RNA feature IDs for prepare compliance data

### DIFF
--- a/scripts/rnaseq2ga.py
+++ b/scripts/rnaseq2ga.py
@@ -144,7 +144,8 @@ class AbstractWriter(object):
             featureSet = dataset.getFeatureSets()[0]
             featureId = ""
             for feature in featureSet.getFeatures(name=featureName):
-                featureId = feature[0].id
+                featureId = feature.id
+                break
             datafields = (expressionId, rnaQuantificationId, name, featureId,
                           expressionLevel, isNormalized,
                           rawCount, score, units, confidenceLow, confidenceHi)


### PR DESCRIPTION
A bug was causing the prepare compliance data script to fail for me. Added a break to avoid unnecessary resetting of the feature.