### PR TITLE
Add biosampleID to RNA quantification

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -386,28 +386,61 @@ Initializes a rnaquantification set.
 
 Initializes the RNA Quantification Set with the filename rnaseq.db.
 
++++++++++++++++++++++++++
+init-rnaquantificationset
++++++++++++++++++++++++++
+
+Initializes a rnaquantification set.
+
+.. argparse::
+   :module: ga4gh.cli.repomanager
+   :func: getRepoManagerParser
+   :prog: ga4gh_repo
+   :path: init-rnaquantificationset
+   :nodefault:
+
+**Examples:**
+
+.. code-block:: bash
+
+    $ ga4gh_repo init-rnaquantificationset repo.db rnaseq.db
+
+Initializes the RNA Quantification Set with the filename rnaseq.db.
+
++++++++++++++++++++++
+add-rnaquantification
++++++++++++++++++++++
+
+Adds a rnaquantification to a RNA quantification set.
+
+RNA quantification formats supported are currently kallisto and RSEM.
+
+.. argparse::
+   :module: ga4gh.cli.repomanager
+   :func: getRepoManagerParser
+   :prog: ga4gh_repo
+   :path: add-rnaquantification
+   :nodefault:
+
+**Examples:**
+
+.. code-block:: bash
+
+    $ ga4gh_repo add-rnaquantification rnaseq.db data.tsv \
+             kallisto ga4gh-example-data/registry.db brca1 \
+            --bioSampleName HG00096 --featureSetNames gencodev19
+            --readGroupSetName HG00096rna --transcript
+
+Adds the data.tsv in kallisto format to the `rnaseq.db` quantification set with
+optional fields for associating a quantification with a Feature Set, Read Group
+Set, and BioSample.
+
 ++++++++++++++++++++++++
 add-rnaquantificationset
 ++++++++++++++++++++++++
 
-Adds a rnaquantification set to a named dataset in a repository.
-Rnaquantification sets are currently derived from a single sqlite database,
-which is stored locally.
-
-Each rnaquantification set must be associated with the reference set that it is
-aligned to.  The sqlite database contains the rnaquantifications which are
-members of the rnaquantification set as well as the feature quantifications for
-each of those rnaquantifications.
-
-.. todo:: Database schema diagram.
-
-A helper script ``scripts/rnaseq2ga.py`` is included to create the
-rnaquantification database. Quantifications are specified in a tab delimited
-control file with columns:
-rna_quant_name    filename    type    feature_set_name    read_group_set_name    description    programs
-
-Each line corresponds to one rnaquantification in the set.  The script supports
-the following quantification types: Cufflinks, kallisto and RSEM.
+When the desired RNA quantification have been added to the set, use this command
+to add them to the registry.
 
 .. argparse::
    :module: ga4gh.cli.repomanager
@@ -420,12 +453,12 @@ the following quantification types: Cufflinks, kallisto and RSEM.
 
 .. code-block:: bash
 
-    $ ga4gh_repo add-rnaquantificationset registry.db 1kg \
-        path/to/expression_values_database.db -R GRCh37-subset
+    $ ga4gh_repo add-rnaquantificationset registry.db brca1 rnaseq.db \
+        -R hg37 -n rnaseq
 
-Adds a new rnaquantification set for a feature expression database stored on
-the local file system. The name of the rnaquantification set is automatically
-derived from the file name.
+Adds the RNA quantification set `rnaseq.db` to the registry under the `brca1`
+dataset. The flags set the reference genome to be hg37 and the name of the
+set to `rnaseq`.
 
 +++++++++++++++++++++++++++
 add-phenotypeassociationset

--- a/ga4gh/backend.py
+++ b/ga4gh/backend.py
@@ -495,9 +495,15 @@ class Backend(object):
                 compoundId.dataset_id)
             rnaQuantSet = dataset.getRnaQuantificationSet(
                 compoundId.rna_quantification_set_id)
-            return self._topLevelObjectGenerator(
-                request, rnaQuantSet.getNumRnaQuantifications(),
-                rnaQuantSet.getRnaQuantificationByIndex)
+        results = []
+        for obj in rnaQuantSet.getRnaQuantifications():
+            include = True
+            if request.bio_sample_id:
+                if request.bio_sample_id != obj.getBioSampleId():
+                    include = False
+            if include:
+                results.append(obj)
+        return self._objectListGenerator(request, results)
 
     def expressionLevelsGenerator(self, request):
         """

--- a/ga4gh/cli/repomanager.py
+++ b/ga4gh/cli/repomanager.py
@@ -484,6 +484,10 @@ class RepoManager(object):
         """
         self._openRepo()
         dataset = self._repo.getDatasetByName(self._args.datasetName)
+        bioSampleId = ""
+        if self._args.bioSampleName:
+            bioSample = dataset.getBioSampleByName(self._args.bioSampleName)
+            bioSampleId = bioSample.getId()
         if self._args.name is None:
             name = getNameFromPath(self._args.filePath)
         else:
@@ -497,8 +501,9 @@ class RepoManager(object):
             self._args.quantificationFilePath, self._args.filePath, name,
             self._args.format, dataset=dataset, featureType=featureType,
             description=self._args.description, programs=programs,
-            featureSetNames=self._args.featureSetName,
-            readGroupSetNames=self._args.readGroupSetName)
+            featureSetNames=self._args.featureSetNames,
+            readGroupSetNames=self._args.readGroupSetName,
+            bioSampleId=bioSampleId)
 
     def initRnaQuantificationSet(self):
         """
@@ -951,8 +956,12 @@ class RepoManager(object):
         cls.addRnaFormatArgument(addRnaQuantificationParser)
         cls.addRepoArgument(addRnaQuantificationParser)
         cls.addDatasetNameArgument(addRnaQuantificationParser)
-        cls.addFeatureSetNameArgument(addRnaQuantificationParser)
-        cls.addReadGroupSetNameArgument(addRnaQuantificationParser)
+        addRnaQuantificationParser.add_argument(
+            "--bioSampleName", default=None, help="BioSample Name")
+        addRnaQuantificationParser.add_argument(
+            "--readGroupSetName", default=None, help="Read Group Set Name")
+        addRnaQuantificationParser.add_argument(
+            "--featureSetNames", default=None, help="Comma separated list")
         cls.addNameOption(addRnaQuantificationParser, "rna quantification")
         cls.addDescriptionOption(addRnaQuantificationParser, objectType)
         cls.addRnaFeatureTypeOption(addRnaQuantificationParser)

--- a/ga4gh/client.py
+++ b/ga4gh/client.py
@@ -709,7 +709,8 @@ class AbstractClient(object):
             request, "rnaquantificationsets",
             protocol.SearchRnaQuantificationSetsResponse)
 
-    def search_rna_quantifications(self, rna_quantification_set_id=""):
+    def search_rna_quantifications(
+            self, rna_quantification_set_id="", bio_sample_id=""):
         """
         Returns an iterator over the RnaQuantification objects from the server
 
@@ -718,6 +719,8 @@ class AbstractClient(object):
         """
         request = protocol.SearchRnaQuantificationsRequest()
         request.rna_quantification_set_id = rna_quantification_set_id
+        if bio_sample_id:
+            request.bio_sample_id = bio_sample_id
         request.page_size = pb.int(self._page_size)
         return self._run_search_request(
             request, "rnaquantifications",

--- a/ga4gh/datamodel/rna_quantification.py
+++ b/ga4gh/datamodel/rna_quantification.py
@@ -213,6 +213,7 @@ class AbstractRnaQuantification(datamodel.DatamodelObject):
         self._readGroupIds = []
         self._referenceSet = None
         self._programs = []
+        self._bioSampleId = ""
 
     def toProtocolElement(self):
         """
@@ -224,6 +225,7 @@ class AbstractRnaQuantification(datamodel.DatamodelObject):
         protocolElement.description = self._description
         protocolElement.read_group_ids.extend(self._readGroupIds)
         protocolElement.programs.extend(self._programs)
+        protocolElement.bio_sample_id = self._bioSampleId
         protocolElement.feature_set_ids.extend(self._featureSetIds)
         protocolElement.rna_quantification_set_id = \
             self._parentContainer.getId()
@@ -238,6 +240,7 @@ class AbstractRnaQuantification(datamodel.DatamodelObject):
         self._featureSetIds = fields["feature_set_ids"].split(',')
         self._description = fields["description"]
         self._name = fields["name"]
+        self._bioSampleId = fields.get("bio_sample_id", "")
         if fields["read_group_ids"] == "":
             self._readGroupIds = []
         else:
@@ -261,6 +264,15 @@ class AbstractRnaQuantification(datamodel.DatamodelObject):
         specified value.
         """
         self._referenceSet = referenceSet
+
+    def setBioSampleId(self, bioSampleId):
+        """
+        Associates this quantification with a sample.
+        """
+        self._bioSampleId = bioSampleId
+
+    def getBioSampleId(self):
+        return self._bioSampleId
 
 
 class SqliteRnaQuantification(AbstractRnaQuantification):

--- a/ga4gh/rna_quantification_pb2.py
+++ b/ga4gh/rna_quantification_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/rna_quantification.proto',
   package='ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n\x1ega4gh/rna_quantification.proto\x12\x05ga4gh\x1a\x14ga4gh/metadata.proto\"D\n\x14RnaQuantificationSet\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\ndataset_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\"\xb8\x01\n\x11RnaQuantification\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x16\n\x0eread_group_ids\x18\x04 \x03(\t\x12 \n\x08programs\x18\x05 \x03(\x0b\x32\x0e.ga4gh.Program\x12\x17\n\x0f\x66\x65\x61ture_set_ids\x18\x06 \x03(\t\x12!\n\x19rna_quantification_set_id\x18\x07 \x01(\t\"\x8d\x02\n\x0f\x45xpressionLevel\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x12\n\nfeature_id\x18\x03 \x01(\t\x12\x1d\n\x15rna_quantification_id\x18\x04 \x01(\t\x12\x16\n\x0eraw_read_count\x18\x05 \x01(\x02\x12\x12\n\nexpression\x18\x06 \x01(\x02\x12\x15\n\ris_normalized\x18\x07 \x01(\x08\x12$\n\x05units\x18\x08 \x01(\x0e\x32\x15.ga4gh.ExpressionUnit\x12\r\n\x05score\x18\t \x01(\x02\x12\x19\n\x11\x63onf_interval_low\x18\n \x01(\x02\x12\x1a\n\x12\x63onf_interval_high\x18\x0b \x01(\x02*D\n\x0e\x45xpressionUnit\x12\x1f\n\x1b\x45XPRESSION_UNIT_UNSPECIFIED\x10\x00\x12\x08\n\x04\x46PKM\x10\x01\x12\x07\n\x03TPM\x10\x02\x62\x06proto3')
+  serialized_pb=_b('\n\x1ega4gh/rna_quantification.proto\x12\x05ga4gh\x1a\x14ga4gh/metadata.proto\"D\n\x14RnaQuantificationSet\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\ndataset_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\"\xcf\x01\n\x11RnaQuantification\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x15\n\rbio_sample_id\x18\x08 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x16\n\x0eread_group_ids\x18\x04 \x03(\t\x12 \n\x08programs\x18\x05 \x03(\x0b\x32\x0e.ga4gh.Program\x12\x17\n\x0f\x66\x65\x61ture_set_ids\x18\x06 \x03(\t\x12!\n\x19rna_quantification_set_id\x18\x07 \x01(\t\"\x8d\x02\n\x0f\x45xpressionLevel\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x12\n\nfeature_id\x18\x03 \x01(\t\x12\x1d\n\x15rna_quantification_id\x18\x04 \x01(\t\x12\x16\n\x0eraw_read_count\x18\x05 \x01(\x02\x12\x12\n\nexpression\x18\x06 \x01(\x02\x12\x15\n\ris_normalized\x18\x07 \x01(\x08\x12$\n\x05units\x18\x08 \x01(\x0e\x32\x15.ga4gh.ExpressionUnit\x12\r\n\x05score\x18\t \x01(\x02\x12\x19\n\x11\x63onf_interval_low\x18\n \x01(\x02\x12\x1a\n\x12\x63onf_interval_high\x18\x0b \x01(\x02*D\n\x0e\x45xpressionUnit\x12\x1f\n\x1b\x45XPRESSION_UNIT_UNSPECIFIED\x10\x00\x12\x08\n\x04\x46PKM\x10\x01\x12\x07\n\x03TPM\x10\x02\x62\x06proto3')
   ,
   dependencies=[ga4gh_dot_metadata__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -47,8 +47,8 @@ _EXPRESSIONUNIT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=592,
-  serialized_end=660,
+  serialized_start=615,
+  serialized_end=683,
 )
 _sym_db.RegisterEnumDescriptor(_EXPRESSIONUNIT)
 
@@ -126,35 +126,42 @@ _RNAQUANTIFICATION = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='description', full_name='ga4gh.RnaQuantification.description', index=2,
+      name='bio_sample_id', full_name='ga4gh.RnaQuantification.bio_sample_id', index=2,
+      number=8, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='description', full_name='ga4gh.RnaQuantification.description', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='read_group_ids', full_name='ga4gh.RnaQuantification.read_group_ids', index=3,
+      name='read_group_ids', full_name='ga4gh.RnaQuantification.read_group_ids', index=4,
       number=4, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='programs', full_name='ga4gh.RnaQuantification.programs', index=4,
+      name='programs', full_name='ga4gh.RnaQuantification.programs', index=5,
       number=5, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='feature_set_ids', full_name='ga4gh.RnaQuantification.feature_set_ids', index=5,
+      name='feature_set_ids', full_name='ga4gh.RnaQuantification.feature_set_ids', index=6,
       number=6, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='rna_quantification_set_id', full_name='ga4gh.RnaQuantification.rna_quantification_set_id', index=6,
+      name='rna_quantification_set_id', full_name='ga4gh.RnaQuantification.rna_quantification_set_id', index=7,
       number=7, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -173,7 +180,7 @@ _RNAQUANTIFICATION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=134,
-  serialized_end=318,
+  serialized_end=341,
 )
 
 
@@ -215,14 +222,14 @@ _EXPRESSIONLEVEL = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='raw_read_count', full_name='ga4gh.ExpressionLevel.raw_read_count', index=4,
       number=5, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='expression', full_name='ga4gh.ExpressionLevel.expression', index=5,
       number=6, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -243,21 +250,21 @@ _EXPRESSIONLEVEL = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='score', full_name='ga4gh.ExpressionLevel.score', index=8,
       number=9, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='conf_interval_low', full_name='ga4gh.ExpressionLevel.conf_interval_low', index=9,
       number=10, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='conf_interval_high', full_name='ga4gh.ExpressionLevel.conf_interval_high', index=10,
       number=11, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -273,8 +280,8 @@ _EXPRESSIONLEVEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=321,
-  serialized_end=590,
+  serialized_start=344,
+  serialized_end=613,
 )
 
 _RNAQUANTIFICATION.fields_by_name['programs'].message_type = ga4gh_dot_metadata__pb2._PROGRAM

--- a/ga4gh/rna_quantification_service_pb2.py
+++ b/ga4gh/rna_quantification_service_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/rna_quantification_service.proto',
   package='ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n&ga4gh/rna_quantification_service.proto\x12\x05ga4gh\x1a\x1ega4gh/rna_quantification.proto\"_\n\"SearchRnaQuantificationSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"|\n#SearchRnaQuantificationSetsResponse\x12<\n\x17rna_quantification_sets\x18\x01 \x03(\x0b\x32\x1b.ga4gh.RnaQuantificationSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"C\n\x1eGetRnaQuantificationSetRequest\x12!\n\x19rna_quantification_set_id\x18\x01 \x01(\t\"k\n\x1fSearchRnaQuantificationsRequest\x12!\n\x19rna_quantification_set_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"r\n SearchRnaQuantificationsResponse\x12\x35\n\x13rna_quantifications\x18\x01 \x03(\x0b\x32\x18.ga4gh.RnaQuantification\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"<\n\x1bGetRnaQuantificationRequest\x12\x1d\n\x15rna_quantification_id\x18\x01 \x01(\t\"\x8d\x01\n\x1dSearchExpressionLevelsRequest\x12\x1d\n\x15rna_quantification_id\x18\x01 \x01(\t\x12\x13\n\x0b\x66\x65\x61ture_ids\x18\x02 \x03(\t\x12\x11\n\tthreshold\x18\x03 \x01(\x02\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"l\n\x1eSearchExpressionLevelsResponse\x12\x31\n\x11\x65xpression_levels\x18\x01 \x03(\x0b\x32\x16.ga4gh.ExpressionLevel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"8\n\x19GetExpressionLevelRequest\x12\x1b\n\x13\x65xpression_level_id\x18\x01 \x01(\t2\xe9\x04\n\x18RnaQuantificationService\x12t\n\x1bSearchRnaQuantificationSets\x12).ga4gh.SearchRnaQuantificationSetsRequest\x1a*.ga4gh.SearchRnaQuantificationSetsResponse\x12]\n\x17GetRnaQuantificationSet\x12%.ga4gh.GetRnaQuantificationSetRequest\x1a\x1b.ga4gh.RnaQuantificationSet\x12k\n\x18SearchRnaQuantifications\x12&.ga4gh.SearchRnaQuantificationsRequest\x1a\'.ga4gh.SearchRnaQuantificationsResponse\x12T\n\x14GetRnaQuantification\x12\".ga4gh.GetRnaQuantificationRequest\x1a\x18.ga4gh.RnaQuantification\x12\x65\n\x16SearchExpressionLevels\x12$.ga4gh.SearchExpressionLevelsRequest\x1a%.ga4gh.SearchExpressionLevelsResponse\x12N\n\x12GetExpressionLevel\x12 .ga4gh.GetExpressionLevelRequest\x1a\x16.ga4gh.ExpressionLevelb\x06proto3')
+  serialized_pb=_b('\n&ga4gh/rna_quantification_service.proto\x12\x05ga4gh\x1a\x1ega4gh/rna_quantification.proto\"_\n\"SearchRnaQuantificationSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"|\n#SearchRnaQuantificationSetsResponse\x12<\n\x17rna_quantification_sets\x18\x01 \x03(\x0b\x32\x1b.ga4gh.RnaQuantificationSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"C\n\x1eGetRnaQuantificationSetRequest\x12!\n\x19rna_quantification_set_id\x18\x01 \x01(\t\"\x82\x01\n\x1fSearchRnaQuantificationsRequest\x12!\n\x19rna_quantification_set_id\x18\x01 \x01(\t\x12\x15\n\rbio_sample_id\x18\x04 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"r\n SearchRnaQuantificationsResponse\x12\x35\n\x13rna_quantifications\x18\x01 \x03(\x0b\x32\x18.ga4gh.RnaQuantification\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"<\n\x1bGetRnaQuantificationRequest\x12\x1d\n\x15rna_quantification_id\x18\x01 \x01(\t\"\x8d\x01\n\x1dSearchExpressionLevelsRequest\x12\x1d\n\x15rna_quantification_id\x18\x01 \x01(\t\x12\x13\n\x0b\x66\x65\x61ture_ids\x18\x02 \x03(\t\x12\x11\n\tthreshold\x18\x03 \x01(\x02\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"l\n\x1eSearchExpressionLevelsResponse\x12\x31\n\x11\x65xpression_levels\x18\x01 \x03(\x0b\x32\x16.ga4gh.ExpressionLevel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"8\n\x19GetExpressionLevelRequest\x12\x1b\n\x13\x65xpression_level_id\x18\x01 \x01(\t2\xe9\x04\n\x18RnaQuantificationService\x12t\n\x1bSearchRnaQuantificationSets\x12).ga4gh.SearchRnaQuantificationSetsRequest\x1a*.ga4gh.SearchRnaQuantificationSetsResponse\x12]\n\x17GetRnaQuantificationSet\x12%.ga4gh.GetRnaQuantificationSetRequest\x1a\x1b.ga4gh.RnaQuantificationSet\x12k\n\x18SearchRnaQuantifications\x12&.ga4gh.SearchRnaQuantificationsRequest\x1a\'.ga4gh.SearchRnaQuantificationsResponse\x12T\n\x14GetRnaQuantification\x12\".ga4gh.GetRnaQuantificationRequest\x1a\x18.ga4gh.RnaQuantification\x12\x65\n\x16SearchExpressionLevels\x12$.ga4gh.SearchExpressionLevelsRequest\x1a%.ga4gh.SearchExpressionLevelsResponse\x12N\n\x12GetExpressionLevel\x12 .ga4gh.GetExpressionLevelRequest\x1a\x16.ga4gh.ExpressionLevelb\x06proto3')
   ,
   dependencies=[ga4gh_dot_rna__quantification__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -157,14 +157,21 @@ _SEARCHRNAQUANTIFICATIONSREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='page_size', full_name='ga4gh.SearchRnaQuantificationsRequest.page_size', index=1,
+      name='bio_sample_id', full_name='ga4gh.SearchRnaQuantificationsRequest.bio_sample_id', index=1,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='page_size', full_name='ga4gh.SearchRnaQuantificationsRequest.page_size', index=2,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='page_token', full_name='ga4gh.SearchRnaQuantificationsRequest.page_token', index=2,
+      name='page_token', full_name='ga4gh.SearchRnaQuantificationsRequest.page_token', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -182,8 +189,8 @@ _SEARCHRNAQUANTIFICATIONSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=373,
-  serialized_end=480,
+  serialized_start=374,
+  serialized_end=504,
 )
 
 
@@ -220,8 +227,8 @@ _SEARCHRNAQUANTIFICATIONSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=482,
-  serialized_end=596,
+  serialized_start=506,
+  serialized_end=620,
 )
 
 
@@ -251,8 +258,8 @@ _GETRNAQUANTIFICATIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=598,
-  serialized_end=658,
+  serialized_start=622,
+  serialized_end=682,
 )
 
 
@@ -280,7 +287,7 @@ _SEARCHEXPRESSIONLEVELSREQUEST = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='threshold', full_name='ga4gh.SearchExpressionLevelsRequest.threshold', index=2,
       number=3, type=2, cpp_type=6, label=1,
-      has_default_value=False, default_value=float(0),
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -310,8 +317,8 @@ _SEARCHEXPRESSIONLEVELSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=661,
-  serialized_end=802,
+  serialized_start=685,
+  serialized_end=826,
 )
 
 
@@ -348,8 +355,8 @@ _SEARCHEXPRESSIONLEVELSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=804,
-  serialized_end=912,
+  serialized_start=828,
+  serialized_end=936,
 )
 
 
@@ -379,8 +386,8 @@ _GETEXPRESSIONLEVELREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=914,
-  serialized_end=970,
+  serialized_start=938,
+  serialized_end=994,
 )
 
 _SEARCHRNAQUANTIFICATIONSETSRESPONSE.fields_by_name['rna_quantification_sets'].message_type = ga4gh_dot_rna__quantification__pb2._RNAQUANTIFICATIONSET

--- a/scripts/prepare_compliance_data.py
+++ b/scripts/prepare_compliance_data.py
@@ -283,8 +283,10 @@ class ComplianceDataMunger(object):
             self.inputDirectory + "/rna_brca1.tsv",
             rnaDbName, "rna_brca1.tsv", "rsem",
             featureType="transcript",
-            readGroupSetNames="HG00096", featureSetNames="gencodev19",
-            dataset=dataset)
+            readGroupSetNames="HG00096",
+            dataset=dataset,
+            featureSetNames="gencodev19",
+            bioSampleId=hg00096BioSample.getId())
         rnaQuantificationSet = rna_quantification.SqliteRnaQuantificationSet(
             dataset, "rnaseq")
         rnaQuantificationSet.setReferenceSet(referenceSet)


### PR DESCRIPTION
same changes as ga4gh/server#1418
real author is @david4096

This PR allows RNA quantifications to be tagged and queried by biosample
identifiers. It adds an option to use the CLI to tag quantifications
using BioSample names. The test data has not been updated.

Prepare compliance has been updated to tag the rna quantification with
HG00096's biosample ID.

ga4gh/schemas#705