### PR TITLE
fix for failing testVariantSetMetadata test

### DIFF
--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -385,7 +385,8 @@ class VariantSetTest(datadriven.DataDrivenTest):
                     self.assertEqual(keyMap[key].number, convertPyvcfNumber(
                         content[contentKey].num))
                     self.assertEqual(
-                        keyMap[key].description, content[contentKey].desc)
+                        keyMap[key].description,
+                        content[contentKey].desc.strip())
         testMetaLength = (
             1 + len(self._formats) + len(self._infos) - gtCounter)
         self.assertEqual(len(keyMap), testMetaLength)


### PR DESCRIPTION
when the `vcf` module read the header info it included a hidden character at the end of the `ANN` field (presumably a new line)