### PR TITLE
catches malformed regex and throws a new type of exception

### DIFF
--- a/ga4gh/server/datamodel/genotype_phenotype_featureset.py
+++ b/ga4gh/server/datamodel/genotype_phenotype_featureset.py
@@ -6,10 +6,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import re
 import bisect
 import rdflib
 from rdflib import RDF
 
+import ga4gh.server.exceptions as exceptions
 import ga4gh.server.protocol as protocol
 import ga4gh.server.datamodel.sequence_annotations as sequence_annotations
 import ga4gh.server.datamodel.genotype_phenotype as g2p
@@ -143,8 +145,11 @@ class PhenotypeAssociationFeatureSet(
             referenceName, geneSymbol, name, start, end)
         featuresResults = self._rdfGraph.query(query)
         featureIds = set()
-        for row in featuresResults.bindings:
-            featureIds.add(row['feature'].toPython())
+        try:
+            for row in featuresResults.bindings:
+                featureIds.add(row['feature'].toPython())
+        except re.error:
+            raise exceptions.BadFeatureSetSearchRequestRegularExpression()
 
         if startIndex:
             startPosition = int(startIndex)

--- a/ga4gh/server/exceptions.py
+++ b/ga4gh/server/exceptions.py
@@ -176,6 +176,10 @@ class RequestValidationFailureException(BadRequestException):
         )
 
 
+class BadFeatureSetSearchRequestRegularExpression(BadRequestException):
+    message = "Malformed regular expression"
+    httpStatus = 400
+
 class BadReadsSearchRequestBothRefs(BadRequestException):
     message = "only one of referenceId and referenceName can be specified"
 

--- a/ga4gh/server/exceptions.py
+++ b/ga4gh/server/exceptions.py
@@ -180,6 +180,7 @@ class BadFeatureSetSearchRequestRegularExpression(BadRequestException):
     message = "Malformed regular expression"
     httpStatus = 400
 
+
 class BadReadsSearchRequestBothRefs(BadRequestException):
     message = "only one of referenceId and referenceName can be specified"
 

--- a/tests/end_to_end/test_g2p.py
+++ b/tests/end_to_end/test_g2p.py
@@ -524,3 +524,17 @@ class TestG2P(unittest.TestCase):
             self.assertNotEqual(previous_id, response.features[0].id)
             pageCount += 1
         self.assertEqual(3, pageCount)
+
+    def testGenotypesSearchByNameError(self):
+        """
+        Search for feature by name with a malformed regular expression.
+        """
+        # setup phenotype query
+        request = protocol.SearchFeaturesRequest()
+        datasetName, featureSet = self.getCGDDataSetFeatureSet()
+        request.feature_set_id = featureSet.id
+        request.name = "*"  # invalid regular expression
+
+        postUrl = "features/search"
+        response = self.sendJsonPostRequest(postUrl, protocol.toJson(request))
+        self.assertEqual(400, response.status_code)


### PR DESCRIPTION
For a features search, if a search field contains a malformed regular expression, a server error was produced. This fix catches the regular expression error and throws a new exception that returns a "400 BAD REQUEST" with the message "Malformed regular expression"

Close #1379 