### PR TITLE
Minor docker updates, fix readthedocs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ EXPOSE 80
 # Prepare container for deployment
 # The directory that the user will land in when executing an interactive shell
 WORKDIR /srv/ga4gh/server
-RUN python scripts/prepare_compliance_data.py -o ga4gh_example_data
+RUN python scripts/prepare_compliance_data.py -o ../ga4gh-compliance-data
 
 # Default action: Bring up a webserver instance to run as a daemon
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip install -r requirements.txt
 
 # Install the code
 COPY . /srv/ga4gh/server/
-RUN python setup.py install
+RUN pip install .
 
 # Write new apache config
 COPY deploy/001-ga4gh.conf /etc/apache2/sites-available/001-ga4gh.conf
@@ -48,7 +48,8 @@ COPY deploy/config.py /srv/ga4gh/config.py
 
 # Configure apache to serve GA4GH site
 WORKDIR /etc/apache2/sites-enabled
-RUN rm -f 000-default.conf && ln -s /etc/apache2/sites-available/001-ga4gh.conf 001-ga4gh.conf
+RUN a2dissite 000-default
+RUN a2ensite 001-ga4gh
 
 # Open port 80 for HTTP
 EXPOSE 80
@@ -56,6 +57,7 @@ EXPOSE 80
 # Prepare container for deployment
 # The directory that the user will land in when executing an interactive shell
 WORKDIR /srv/ga4gh/server
+RUN python scripts/prepare_compliance_data.py -o ga4gh_example_data
 
 # Default action: Bring up a webserver instance to run as a daemon
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/README.txt
+++ b/README.txt
@@ -5,6 +5,18 @@
 GA4GH Reference Implementation
 ==============================
 
+.. image:: https://img.shields.io/pypi/v/ga4gh.svg
+   :target: https://pypi.python.org/pypi/ga4gh/
+   :alt: Current PyPi Release
+
+.. image:: https://readthedocs.org/projects/ga4gh-reference-implementation/badge/?version=latest
+   :target: http://ga4gh-reference-implementation.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+   :alt: Join the chat at https://gitter.im/ga4gh/server
+   :target: https://gitter.im/ga4gh/server?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+
 .. image:: https://img.shields.io/travis/ga4gh/server/master.svg
    :alt: Current build status on Travis-CI, click for more
    :target: https://travis-ci.org/ga4gh/server
@@ -12,10 +24,6 @@ GA4GH Reference Implementation
 .. image:: https://img.shields.io/codecov/c/github/ga4gh/server/master.svg
    :alt: Current code coverage of master branch, click for details
    :target: https://codecov.io/github/ga4gh/server
-
-.. image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/ga4gh/server
-   :target: https://gitter.im/ga4gh/server?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 This is the development version of the GA4GH reference implementation.
 If you would like to install the stable version of the server, please

--- a/deploy/001-ga4gh.conf
+++ b/deploy/001-ga4gh.conf
@@ -5,10 +5,11 @@
     CustomLog ${APACHE_LOG_DIR}/access.log combined
     WSGIDaemonProcess ga4gh python-eggs=/var/cache/apache2/python-egg-cache \
         processes=10 threads=1
-    WSGIScriptAlias /ga4gh /srv/ga4gh/application.wsgi
+    WSGIScriptAlias / /srv/ga4gh/application.wsgi
     <Directory /srv/ga4gh>
         WSGIProcessGroup ga4gh
         WSGIApplicationGroup %{GLOBAL}
         Require all granted
     </Directory>
 </VirtualHost>
+

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -1,3 +1,3 @@
 import os
-DATA_SOURCE = os.getenv('GA4GH_DATA_SOURCE', "/data/registry.db")
+DATA_SOURCE = os.getenv('GA4GH_DATA_SOURCE', "/srv/ga4gh/ga4gh-compliance-data/registry.db")
 DEBUG = os.getenv('GA4GH_DEBUG', "")

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -261,34 +261,6 @@ exactly what a force push does.
     uses the ``--ff-only`` flag to merge a remote mainline branch into a
     local mainline branch fails.)
 
-One task that you might be asked to do before your topic branch can be
-merged is "squashing your commits."  We want the git history to be clean
-and informative, and we do that by crafting one and only one commit
-message per logical change.  In the normal course of development (unless
-one is constantly committing with the ``--amend`` flag) many intermediate
-commits can be created that should be squashed down to (usually) one before
-it can be merged.  Do this with (assuming you are in your topic branch):
-
-.. code-block:: bash
-
-    $ git rebase -i `git merge-base master HEAD`
-
-This will launch an editor that will give you control over how you want
-to structure your commits.  Usually you just want to "pick" the first
-commit and "squash" all of the subsequent commits, and then ensure that
-the final commit message is clean (best practice is to give a short
-summary of the change on the first line, a blank line, and then a more
-detailed description of the change following, with the issue number
--- if there is one -- in the detailed description).  More information
-about the interactive rebase process can be found
-`here <https://help.github.com/articles/about-git-rebase/>`__.
-Once the commits are to your liking, you can push the branch to your
-remote repository (which will require a force push if you reordered
-or deleted commits that existed in the remote version of the branch).
-
-(It usually is a good idea to squash commits before rebasing your topic
-branch on top of a mainline branch.  See the elaboration in the :ref:`Git
-Workflow Appendix <git-appendix>` on this topic.)
 
 Once your pull request has been merged into ``master``, you can close
 the pull request and delete the remote branch in the GitHub interface.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -560,13 +560,15 @@ This entails:
    <https://github.com/ga4gh/server/releases>`_ page) with the
    appropriate version number.
 3) Fetch the tag from the upstream repo, and checkout this tag.
-4) Replace git URLs in the `constraints.txt` to point at the schemas and
+4) Replace git URLs in the ``constraints.txt`` to point at the schemas and
    client releases this server release is meant to depend on. 
-5) Create the distribution tarball using ``python setup.py sdist``, and then
+5) Replace git URLs in the ``docs/environment.yml`` using the same versions
+   as (4).
+6) Create the distribution tarball using ``python setup.py sdist``, and then
    upload the resulting tarball to PyPI using 
    ``twine upload dist/ga4gh-MAJOR.MINOR.PATCH.tar.gz`` (using 
    the correct file name).
-6) Verify that the documentation at
+7) Verify that the documentation at
    http://ga4gh-reference-implementation.readthedocs.org/en/stable/
    is for the correct version (it may take a few minutes for this to
    happen after the release has been tagged on GitHub).  The release

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -224,7 +224,7 @@ From the client, the server is accessible at ``http://server/``, and the ``/tmp/
 
 .. code-block:: bash
 
-  #make a development dir and place the example client script in it
+  # make a development dir and place the example client script in it
   $ mkdir /tmp/mydev
   $ curl https://raw.githubusercontent.com/ga4gh/server/master/scripts/demo_example.py > /tmp/mydev/demo_example.py
   $ chmod +x /tmp/mydev/demo_example.py

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -282,22 +282,6 @@ Build the code at server/ and run for production, serving a dataset on local hos
 Build and run the production build from above, with the demo dataset in the container
 (you will need to modify the FROM line in ``/deploy/variants/demo/Dockerfile`` if you want to use your image from above as the base):
 
-.. code-block:: bash
-
- $ cd server/deploy/variants/demo
- $ docker build -t my-repo/my-demo-image .
- $ docker run -itd -p 8000:80 --name ga4gh_demo my-repo/my-demo-image
-
-**Variants**
-
-Other Dockerfile implementations are available in the variants folder which install manually.
-To build one of these images:
-
-.. code-block:: bash
-
- $ cd server/deploy/variants/xxxx
- $ docker build -t my-repo/my-image .
- $ docker run -itd -p 8000:80 --name my_container my-repo/my-image
 
 ++++++++++++++++++++++
 Troubleshooting Docker

--- a/scripts/prepare_compliance_data.py
+++ b/scripts/prepare_compliance_data.py
@@ -122,7 +122,7 @@ class ComplianceDataMunger(object):
         referenceSet = references.HtslibReferenceSet(
             refSetMetadata['assemblyId'])
 
-        referenceSet.populateFromFile(fastaFilePath)
+        referenceSet.populateFromFile(os.path.abspath(fastaFilePath))
         referenceSet.setAssemblyId(refSetMetadata['assemblyId'])
         referenceSet.setDescription(refSetMetadata['description'])
         referenceSet.setNcbiTaxonId(refSetMetadata['ncbiTaxonId'])
@@ -207,7 +207,7 @@ class ComplianceDataMunger(object):
             readSrc.close()
             pysam.index(destFilePath)
             readGroupSet = reads.HtslibReadGroupSet(dataset, name)
-            readGroupSet.populateFromFile(destFilePath, destFilePath + ".bai")
+            readGroupSet.populateFromFile(os.path.abspath(destFilePath), os.abspath(destFilePath + ".bai"))
             readGroupSet.setReferenceSet(referenceSet)
             dataset.addReadGroupSet(readGroupSet)
             bioSamples = [hg00096BioSample, hg00099BioSample, hg00101BioSample]
@@ -225,7 +225,7 @@ class ComplianceDataMunger(object):
         shutil.copy(inputOntologyMap, outputOntologyMap)
 
         sequenceOntology = ontologies.Ontology("so-xp-simple")
-        sequenceOntology.populateFromFile(outputOntologyMap)
+        sequenceOntology.populateFromFile(os.path.abspath(outputOntologyMap))
         sequenceOntology._id = "so-xp-simple"
         self.repo.insertOntology(sequenceOntology)
         self.repo.addOntology(sequenceOntology)
@@ -250,7 +250,7 @@ class ComplianceDataMunger(object):
         dbgen.run()
         gencode = sequence_annotations.Gff3DbFeatureSet(dataset, "gencodev19")
         gencode.setOntology(sequenceOntology)
-        gencode.populateFromFile(seqAnnDest)
+        gencode.populateFromFile(os.path.abspath(seqAnnDest))
         gencode.setReferenceSet(referenceSet)
 
         self.repo.insertFeatureSet(gencode)
@@ -265,10 +265,10 @@ class ComplianceDataMunger(object):
             shutil.copy(filename, outputG2PPath)
 
         featuresetG2P = g2p_featureset.PhenotypeAssociationFeatureSet(
-            dataset, outputG2PPath)
+            dataset, os.path.abspath(outputG2PPath))
         featuresetG2P.setOntology(sequenceOntology)
         featuresetG2P.setReferenceSet(referenceSet)
-        featuresetG2P.populateFromFile(outputG2PPath)
+        featuresetG2P.populateFromFile(os.path.abspath(outputG2PPath))
         self.repo.insertFeatureSet(featuresetG2P)
 
         # add g2p phenotypeAssociationSet
@@ -294,7 +294,7 @@ class ComplianceDataMunger(object):
         rnaQuantificationSet = rna_quantification.SqliteRnaQuantificationSet(
             dataset, "rnaseq")
         rnaQuantificationSet.setReferenceSet(referenceSet)
-        rnaQuantificationSet.populateFromFile(rnaDbName)
+        rnaQuantificationSet.populateFromFile(os.path.abspath(rnaDbName))
         self.repo.insertRnaQuantificationSet(rnaQuantificationSet)
 
         self.repo.commit()
@@ -312,7 +312,7 @@ class ComplianceDataMunger(object):
             dataset, variantFileName.split('_')[1])
         variantSet.setReferenceSet(referenceSet)
         variantSet.populateFromFile(
-            [outputVcf + ".gz"], [outputVcf + ".gz.tbi"])
+            [os.path.abspath(outputVcf + ".gz")], [os.path.abspath(outputVcf + ".gz.tbi")])
         variantSet.checkConsistency()
         for callSet in variantSet.getCallSets():
             for bioSample in bioSamples:

--- a/scripts/prepare_compliance_data.py
+++ b/scripts/prepare_compliance_data.py
@@ -207,7 +207,8 @@ class ComplianceDataMunger(object):
             readSrc.close()
             pysam.index(destFilePath)
             readGroupSet = reads.HtslibReadGroupSet(dataset, name)
-            readGroupSet.populateFromFile(os.path.abspath(destFilePath), os.abspath(destFilePath + ".bai"))
+            readGroupSet.populateFromFile(os.path.abspath(
+                destFilePath), os.path.abspath(destFilePath + ".bai"))
             readGroupSet.setReferenceSet(referenceSet)
             dataset.addReadGroupSet(readGroupSet)
             bioSamples = [hg00096BioSample, hg00099BioSample, hg00101BioSample]
@@ -272,8 +273,9 @@ class ComplianceDataMunger(object):
         self.repo.insertFeatureSet(featuresetG2P)
 
         # add g2p phenotypeAssociationSet
-        phenotypeAssociationSet = g2p_associationset\
-            .RdfPhenotypeAssociationSet(dataset, "cgd", outputG2PPath)
+        phenotypeAssociationSet = \
+            g2p_associationset.RdfPhenotypeAssociationSet(
+                dataset, "cgd", os.path.abspath(outputG2PPath))
         self.repo.insertPhenotypeAssociationSet(phenotypeAssociationSet)
 
         self.repo.commit()
@@ -312,7 +314,8 @@ class ComplianceDataMunger(object):
             dataset, variantFileName.split('_')[1])
         variantSet.setReferenceSet(referenceSet)
         variantSet.populateFromFile(
-            [os.path.abspath(outputVcf + ".gz")], [os.path.abspath(outputVcf + ".gz.tbi")])
+            [os.path.abspath(outputVcf + ".gz")],
+            [os.path.abspath(outputVcf + ".gz.tbi")])
         variantSet.checkConsistency()
         for callSet in variantSet.getCallSets():
             for bioSample in bioSamples:


### PR DESCRIPTION
The existing install pattern using `python setup.py install` does not install the server to the `ga4gh` namespace in the same way `pip` does. This PR adjusts the documentation to reflect proper installation practices in the Dockerfile, and updates the Dockerfile to include the compliance dataset by default.

Also removes some orphaned documentation.

If you have docker installed you can test it out with `docker run -d -p 8000:80 david4096/server-1:1500_docs`. This will start a server at [http://localhost:8000](http://localhost:8000) hosting the compliance dataset.

I noted that there is a problem with how the G2P feature sets are being loaded in that the path is included in the localId. This causes compliance to fail on some brittle tests on the features protocol. 

Close #1500 