### PR TITLE
Patch bug for list printing

### DIFF
--- a/ga4gh/server/datarepo.py
+++ b/ga4gh/server/datarepo.py
@@ -254,8 +254,8 @@ class AbstractDataRepository(object):
                         print(
                             "\t\t", quant.getLocalId(),
                             quant._description,
-                            quant._readGroupIds[0],
-                            quant._featureSetIds[0], sep="\t")
+                            ",".join(quant._readGroupIds),
+                            ",".join(quant._featureSetIds), sep="\t")
 
     def allReferences(self):
         """


### PR DESCRIPTION
The readgroupIds were being iterated into directly when at times there are no read group IDs associated with an RNA quantification.

Close #1472 