### PR TITLE
Dependency management - relaxing requirements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -25,5 +25,5 @@
 # ga4gh-schemas==0.6.0a9post2
 #
 git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
+git+git://github.com/david4096/schemas.git@reqts#egg=ga4gh_schemas
 git+git://github.com/david4096/ga4gh-client.git@reqts#egg=ga4gh_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -26,4 +26,4 @@
 #
 git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
-git+git://github.com/ga4gh/ga4gh-client.git@master#egg=ga4gh_client
+git+git://github.com/david4096/ga4gh-client.git@reqts#egg=ga4gh_client

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,6 +29,7 @@ snakefood==1.4
 lxml==3.4.4
 Sphinx==1.4.6
 sphinx_rtd_theme
+sphinx-argparse==0.1.15
 
 # Requirements for OIDC provider
 pyaml==15.03.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -26,6 +26,7 @@ PyVCF==0.6.7
 freezegun==0.3.6
 guppy==0.1.10
 snakefood==1.4
+lxml==3.4.4
 Sphinx==1.4.6
 sphinx_rtd_theme
 

--- a/ga4gh/server/frontend.py
+++ b/ga4gh/server/frontend.py
@@ -15,7 +15,6 @@ import functools
 
 import flask
 import flask.ext.cors as cors
-import humanize
 import werkzeug
 import oic
 import oic.oauth2
@@ -109,12 +108,6 @@ class ServerStatus(object):
         except:
             html = flask.render_template("landing_message.html")
         return html
-
-    def getNaturalUptime(self):
-        """
-        Returns the uptime in a human-readable format.
-        """
-        return humanize.naturaltime(self.startupTime)
 
     def getProtocolVersion(self):
         """

--- a/ga4gh/server/templates/index.html
+++ b/ga4gh/server/templates/index.html
@@ -36,7 +36,7 @@
         </div>
         <div>
             <h3>Uptime</h3>
-            Running since {{ info.getNaturalUptime()}} ({{ info.getPreciseUptime()}})
+            Running since {{ info.getPreciseUptime() }}
         </div>
         <div>
             <h3>Configuration</h3>

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ ga4gh-client
 Flask-Cors==2.0.1
 Flask==0.10.1
 protobuf>=3.1.0.post1
-humanize==0.5.1
 pysam>=0.10.0
 requests>=2.7.0
 oic==0.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ Flask-Cors==2.0.1
 Flask==0.10.1
 protobuf==3.1.0.post1
 humanize==0.5.1
-pysam==0.9.0
+pysam==0.10.0
 requests==2.7.0
 oic==0.7.6
 pyOpenSSL==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,9 +34,7 @@ cffi==1.5.2
 pycparser==2.14
 Jinja2==2.7.3
 future==0.15.2
-pyjwkest==1.0.1
-PyJWT==1.4.2
-peewee==2.8.5
+
 
 ### This section is for the actual libraries ###
 # these libraries are imported in code that can be reached via
@@ -46,13 +44,15 @@ peewee==2.8.5
 # prefix due to a setuptools bug.
 Flask-Cors==2.0.1
 Flask==0.10.1
-protobuf==3.1.0.post1
+protobuf>=3.1.0.post1
 humanize==0.5.1
-pysam==0.10.0
-requests==2.7.0
+pysam>=0.10.0
+requests>=2.7.0
 oic==0.7.6
 pyOpenSSL==0.15.1
-lxml==3.4.4
+pyjwkest==1.0.1
+PyJWT==1.4.2
+peewee>=2.8.5
 
 # We need sphinx-argparse to build on readthedocs.
 sphinx-argparse==0.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,6 @@
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
 
-### This section is for dependencies of the libraries ###
-# these libraries are the set listed by pipdeptree -f -w
-# that are dependencies of libraries listed in the next section
-
 # Adding the constraints.txt allows you to choose a specific 
 # way to resolve our internal dependencies. During development,
 # the constraints file will point at the current master branch 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,25 +16,6 @@ ga4gh-common
 ga4gh-schemas
 ga4gh-client
 
-Werkzeug==0.11.5
-MarkupSafe==0.23
-itsdangerous==0.24
-six==1.10.0
-pycrypto==2.6.1
-Mako==1.0.4
-Beaker==1.8.0
-funcsigs==0.4
-alabaster==0.7.7
-cryptography==1.3.1
-idna==2.1
-pyasn1==0.1.9
-enum34==1.1.2
-ipaddress==1.0.16
-cffi==1.5.2
-pycparser==2.14
-Jinja2==2.7.3
-future==0.15.2
-
 
 ### This section is for the actual libraries ###
 # these libraries are imported in code that can be reached via
@@ -54,8 +35,6 @@ pyjwkest==1.0.1
 PyJWT==1.4.2
 peewee>=2.8.5
 
-# We need sphinx-argparse to build on readthedocs.
-sphinx-argparse==0.1.15
 
 # G2P uses a ttl backend
 RDFLib==4.2.1

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -386,8 +386,10 @@ class VariantSetTest(datadriven.DataDrivenTest):
                         keyMap[key].type, content[contentKey].type)
                     self.assertEqual(keyMap[key].number, convertPyvcfNumber(
                         content[contentKey].num))
+                    # pysam introduces opinionated stripping
                     self.assertEqual(
-                        keyMap[key].description, content[contentKey].desc)
+                        keyMap[key].description,
+                        content[contentKey].desc.rstrip())
         testMetaLength = (
             1 + len(self._formats) + len(self._infos) - gtCounter)
         self.assertEqual(len(keyMap), testMetaLength)


### PR DESCRIPTION
* Relax some version requirements (`==` becomes `>=`)

* I haven't seen many projects use the `pipedeptree` approach to defining dependencies. I understand that these packages should be able to maintain their own dependency tree, and we don't need to (and shouldn't) try to manage their dependencies for them.

* Remove the `humanize` dependency, which was used for one line on the landing page (server uptime nicely printed).

* The lxml requirement is only needed for testing https://github.com/ga4gh/server/blob/73e496bc2995a4066ca35411c6e4ac1c7097ea77/tests/end_to_end/test_oidc.py .

* sphinx-argparse is needed in RTD, but not for basic server usage.

Note: I did not relax the requirements for Flask as there appear to be some problems with how we are using the flask configuration for logging. A future PR will update our dependencies for Flask and Flask_cors.

Note, this will keep our software better up to date as CI will be able to find when one of our dependencies triggers a breaking upgrade. During release, it is possible to once again fix the requirements to a known working version of a module.