### PR TITLE
Protobuf 3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
-    - /tmp/proto3.1.0
+    - /tmp/proto3.2.0
 
 install:
   - pip install pip --upgrade
@@ -24,8 +24,8 @@ before_script:
   - python scripts/build_test_data.py 
     
 before_install:
-    - bash tools/travis-install-protoc.sh 3.1.0
-    - export PATH=/tmp/proto3.1.0/bin:$PATH
+    - bash tools/travis-install-protoc.sh 3.2.0
+    - export PATH=/tmp/proto3.2.0/bin:$PATH
 
 # run_tests.py runs everything under the script: tag so only put commands
 # under it that we want to run (and want to be able to run) as local tests

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-#git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
-#git+git://github.com/ga4gh/ga4gh-client.git@master#egg=ga4gh_client
+git+git://github.com/ljdursi/ga4gh-schemas.git@protobuf_3.2.0#egg=ga4gh_schemas
+git+git://github.com/ljdursi/ga4gh-client.git@protobuf_3.2.0#egg=ga4gh_client

--- a/ga4gh/server/backend.py
+++ b/ga4gh/server/backend.py
@@ -205,7 +205,7 @@ class Backend(object):
             if request.name and request.name != obj.getLocalId():
                 include = False
             if request.biosample_id and include:
-                rgsp.ClearField("read_groups")
+                rgsp.ClearField(b"read_groups")
                 for readGroup in obj.getReadGroups():
                     if request.biosample_id == readGroup.getBiosampleId():
                         rgsp.read_groups.extend(

--- a/ga4gh/server/datamodel/reads.py
+++ b/ga4gh/server/datamodel/reads.py
@@ -145,7 +145,7 @@ class AlignmentDataMixin(datamodel.PysamDatamodelMixin):
         ret.aligned_quality.extend(read.query_qualities)
         ret.aligned_sequence = read.query_sequence
         if SamFlags.isFlagSet(read.flag, SamFlags.READ_UNMAPPED):
-            ret.ClearField("alignment")
+            ret.ClearField(b"alignment")
         else:
             ret.alignment.CopyFrom(protocol.LinearAlignment())
             ret.alignment.mapping_quality = read.mapping_quality

--- a/ga4gh/server/paging.py
+++ b/ga4gh/server/paging.py
@@ -297,7 +297,7 @@ class VariantAnnotationsIntervalIterator(IntervalIterator):
                     add = True
             if add:
                 newTxE.append(txe)
-        ann.ClearField('transcript_effects')
+        ann.ClearField(b'transcript_effects')
         ann.transcript_effects.extend(newTxE)
         return ann
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 ga4gh-common==0.0.7
-ga4gh-schemas==0.6.0a10.post1
-ga4gh-client==0.6.0a10
+ga4gh-schemas
+ga4gh-client
 
 Werkzeug==0.11.5
 MarkupSafe==0.23
@@ -46,7 +46,7 @@ peewee==2.8.5
 # prefix due to a setuptools bug.
 Flask-Cors==2.0.1
 Flask==0.10.1
-protobuf==3.1.0.post1
+protobuf==3.2.0
 humanize==0.5.1
 pysam==0.9.0
 requests==2.7.0

--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -11,6 +11,7 @@ import contextlib
 import fnmatch
 import os
 import inspect
+import array
 
 import google.protobuf.json_format as json_format
 
@@ -68,8 +69,17 @@ class TestCase(object):
         Tests if a an b are equal. If not, output an error and raise
         an assertion error.
         """
+        def compare_as_float_32s(a_dbl, b_dbl):
+            a_flt = array.array(b"f", [a_dbl])[0]
+            b_flt = array.array(b"f", [b_dbl])[0]
+            return a_flt == b_flt
+
         if a == b:
             return
+
+        if isinstance(a, float) and isinstance(b, float):
+            if compare_as_float_32s(a, b):
+                return
 
         # Protocol Buffers has default string as "", not None
         if a in TestCase.consideredNone and b in TestCase.consideredNone:

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -691,7 +691,6 @@ class TestSimulatedStack(unittest.TestCase):
         request.effects.add().term_id = "SO:0001627"
         request.effects.add().term_id = "B4DID"
         response = self.sendJsonPostRequest(path, protocol.toJson(request))
-        print(response.data)
         responseData = protocol.fromJson(response.data, protocol.
                                          SearchVariantAnnotationsResponse)
         responseLength = len(responseData.variant_annotations)

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -11,6 +11,7 @@ import unittest
 import logging
 import random
 import json
+import array
 import ga4gh.server.datamodel.reads as reads
 import ga4gh.server.datamodel.references as references
 import ga4gh.server.datamodel.variants as variants
@@ -51,6 +52,12 @@ class TestSimulatedStack(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.app = None
+
+    @classmethod
+    def as_float32(cls, x):
+        x_dbl = float(x)
+        x_flt = array.array(b"f", [x_dbl])[0]
+        return x_flt
 
     def setUp(self):
         self.backend = frontend.app.backend
@@ -217,7 +224,8 @@ class TestSimulatedStack(unittest.TestCase):
             gaReference.source_accessions, reference.getSourceAccessions())
         self.assertEqual(gaReference.is_derived, reference.getIsDerived())
         self.assertEqual(
-            gaReference.source_divergence, reference.getSourceDivergence())
+            TestSimulatedStack.as_float32(gaReference.source_divergence),
+            TestSimulatedStack.as_float32(reference.getSourceDivergence()))
 
     def verifySearchMethod(
             self, request, path, responseClass, objects, objectVerifier):
@@ -683,6 +691,7 @@ class TestSimulatedStack(unittest.TestCase):
         request.effects.add().term_id = "SO:0001627"
         request.effects.add().term_id = "B4DID"
         response = self.sendJsonPostRequest(path, protocol.toJson(request))
+        print(response.data)
         responseData = protocol.fromJson(response.data, protocol.
                                          SearchVariantAnnotationsResponse)
         responseLength = len(responseData.variant_annotations)


### PR DESCRIPTION
Bumps protobuf version to 3.2.0, which means C++ implementation on Linux and so faster/reduced memory usage. Addresses issue ga4gh/ga4gh-server#1623.

The C++ implementation is fussier than the python version - this means that pythonic things like conversion between string types doesn't happen automatically, so that strings passed to protobuf routines have to be byte strings, not unicode strings.  Floating point comparisons are done at float32 precision.